### PR TITLE
Updates to nlp components

### DIFF
--- a/zeeguu/api/api/nlp.py
+++ b/zeeguu/api/api/nlp.py
@@ -74,13 +74,20 @@ def get_sentences_for_wo():
     
     nlp_pipe = SpacyWrappers[language]
     sentences = nlp_pipe.get_sent_list(article_text)
-    filtered_sentences = [sent for sent in sentences if len(nlp_pipe.tokenize_sentence(sent)) <= 15]
+    short_sentences_in_article = [sent for sent in sentences if len(nlp_pipe.tokenize_sentence(sent)) <= 15]
     
-    context_doc = nlp_pipe.spacy_pipe(bookmark_context)
+    context_doc = nlp_pipe.get_doc(bookmark_context)
     heap = []
-    for f_sent in filtered_sentences:
-        sent_doc = nlp_pipe.spacy_pipe(f_sent)
-        heapq.heappush(heap, (-context_doc.similarity(sent_doc), f_sent))
+    for f_sent in short_sentences_in_article:
+        sent_doc = nlp_pipe.get_doc(f_sent)
+        heapq.heappush(heap, (context_doc.similarity(sent_doc), f_sent))
 
-    _, most_similar_sent = heap.pop()
-    return json_result(heap)
+    most_similar_sent = heapq.nlargest(1, heap)[0][1]
+    top_10_results = heapq.nlargest(10, heap)
+
+    result_json = {
+        "top_1_sent": most_similar_sent,
+        "top_10_sents_w_sim": top_10_results
+    }
+
+    return json_result(result_json)

--- a/zeeguu/core/nlp_pipeline/automatic_gec_tagging.py
+++ b/zeeguu/core/nlp_pipeline/automatic_gec_tagging.py
@@ -332,14 +332,14 @@ class AutoGECTagging():
             op_list = op.split(":")
             # Allow for feedback dict to be prepared.
             while len(op_list) < 3: op_list.append("")
-
             pos_feedback = UD_TO_WORD_CLASS.get(op_list[1],"")
             morph_feedback = UD_TO_WORD_CLASS.get(op_list[2],"")
             
             pos_is_correct = op_list[1] == err_pos
             related_words_feedback = "" if related_words is None else f" It might relate to '{','.join(related_words)}'."
-
-            article = "a" if err_pos[0].lower() not in "aeiou" else "an"
+            article = "a"
+            if len(pos_feedback) > 0:
+                article = "an" if pos_feedback[0] in "aeiou" else "a"
 
             FEEDBACK_DICT = {
                 "U":[f"'{word}' is not necessary in this context.", 

--- a/zeeguu/core/nlp_pipeline/confusion_generator.py
+++ b/zeeguu/core/nlp_pipeline/confusion_generator.py
@@ -137,7 +137,7 @@ class NoiseGenerator():
         result = {
             "confusion_words": list(confusion_set),
             "pos_picked" : pos_pick,
-            "word_position" : str(t_confusion)
+            "word_used" : str(t_confusion)
         }
         return result
     

--- a/zeeguu/core/nlp_pipeline/spacy_wrapper.py
+++ b/zeeguu/core/nlp_pipeline/spacy_wrapper.py
@@ -81,3 +81,6 @@ class SpacyWrapper:
     def get_sent_list(self, lines):
         # Get tokenized sentences from spaCy.
         return [str(sent).strip() for sent in self.spacy_pipe(lines).sents]
+    
+    def get_sent_similarity(self, sentence_a, sentence_b):
+        return self.spacy_pipe(sentence_a).similarity(self.spacy_pipe(sentence_b))

--- a/zeeguu/core/nlp_pipeline/spacy_wrapper.py
+++ b/zeeguu/core/nlp_pipeline/spacy_wrapper.py
@@ -78,6 +78,9 @@ class SpacyWrapper:
         # Get tokens from spaCy.
         return [str(token) for token in self.spacy_pipe(sentence)]
 
+    def get_doc(self, sentence):
+        return self.spacy_pipe(sentence)
+
     def get_sent_list(self, lines):
         # Get tokenized sentences from spaCy.
         return [str(sent).strip() for sent in self.spacy_pipe(lines).sents]


### PR DESCRIPTION
# These changes are made to help support the logging activity.

## nlp
- create_confusion_words: Instead of just providing the confusion words the dictionary is returned, and the frontend can use all the properties. This was done to support the user_activity
- added a new endpoint get_sentences_for_wo, which should implement the logic to find sentences when WO has a very long sentence. Currently, the highest similarity sentence with a limit of 15 tokens is used.

## automatic_gec_tagging
- Fixed the article, it was checking the wrong parameter to select the article used.

## confusion_generator
- Changed the names in the dictionary to make more sense.

## spacy_wrapper
- Added a method to get similarity of two sentences.