### PR TITLE
Adding end-point to remove saved articles

### DIFF
--- a/zeeguu/api/endpoints/article.py
+++ b/zeeguu/api/endpoints/article.py
@@ -67,6 +67,7 @@ def make_personal_copy():
 
     return "OK" if PersonalCopy.exists_for(user, article) else "Something went wrong!"
 
+
 # ---------------------------------------------------------------------------
 @api.route("/remove_personal_copy", methods=("POST",))
 # ---------------------------------------------------------------------------
@@ -78,7 +79,12 @@ def remove_personal_copy():
     article = Article.find_by_id(article_id)
     user = flask.g.user
 
-    return "OK" if PersonalCopy.remove_for(user, article, db_session) else "Something went wrong!"
+    if PersonalCopy.exists_for(user, article):
+        PersonalCopy.remove_for(user, article, db_session)
+
+    return (
+        "OK" if not PersonalCopy.exists_for(user, article) else "Something went wrong!"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/zeeguu/api/endpoints/article.py
+++ b/zeeguu/api/endpoints/article.py
@@ -67,6 +67,19 @@ def make_personal_copy():
 
     return "OK" if PersonalCopy.exists_for(user, article) else "Something went wrong!"
 
+# ---------------------------------------------------------------------------
+@api.route("/remove_personal_copy", methods=("POST",))
+# ---------------------------------------------------------------------------
+@cross_domain
+@with_session
+def remove_personal_copy():
+
+    article_id = request.form.get("article_id", "")
+    article = Article.find_by_id(article_id)
+    user = flask.g.user
+
+    return "OK" if PersonalCopy.remove_for(user, article, db_session) else "Something went wrong!"
+
 
 # ---------------------------------------------------------------------------
 @api.route("/is_article_language_supported", methods=("POST",))

--- a/zeeguu/core/model/personal_copy.py
+++ b/zeeguu/core/model/personal_copy.py
@@ -40,6 +40,12 @@ class PersonalCopy(db.Model):
         )
 
     @classmethod
+    def remove_for(cls, user, article, session):
+        article_copy = PersonalCopy.find(user_id=user.id, article_id=article.id)
+        session.delete(article_copy)
+        session.commit()
+
+    @classmethod
     def make_for(cls, user, article, session):
         new_personal_copy = PersonalCopy(user, article)
         session.add(new_personal_copy)

--- a/zeeguu/core/model/personal_copy.py
+++ b/zeeguu/core/model/personal_copy.py
@@ -41,7 +41,11 @@ class PersonalCopy(db.Model):
 
     @classmethod
     def remove_for(cls, user, article, session):
-        article_copy = PersonalCopy.find(user_id=user.id, article_id=article.id)
+        article_copy = (
+            cls.query.filter(PersonalCopy.user_id == user.id)
+            .filter(PersonalCopy.article_id == article.id)
+            .one()
+        )
         session.delete(article_copy)
         session.commit()
 


### PR DESCRIPTION
Added an end-point similar to `make_personal_copy` called `remove_personal_copy` to delete saved articles. 

This end-point can be called from the Web to remove the saved articles. 