### PR TITLE
Match Workflow python version with deployed version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.9]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
From the docker deployment file:

`FROM python:3.9.2-buster`

Shouldn't we ensure the version is the same on the server? We could also upgrade python in the docker to the latest version? 

https://devguide.python.org/versions/ Seems like 3.9 ends in 2025, and since no errors are seen for 3.11 maybe we could just upgrade it? 