### PR TITLE
Updating to sqlalchemy >= 2.0 

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -14,7 +14,6 @@ from zeeguu.api.app import create_app
 
 application = create_app()
 
-
 application.logger.debug(application.instance_path)
 
 logging.getLogger("elasticsearch").setLevel(logging.CRITICAL)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ feedparser
 flask==2.3.2
 Flask-Assets
 flask_cors
-flask_sqlalchemy
+flask_sqlalchemy>=3.0
 git+https://github.com/zeeguu-ecosystem/apimux.git@master#egg=apimux
 git+https://github.com/zeeguu-ecosystem/Python-Translators.git@master#egg=python_translators
 jieba3k
@@ -26,7 +26,7 @@ requests
 requests_mock
 sentry-sdk[flask]
 sortedcontainers
-SQLAlchemy==1.3.20
+SQLAlchemy>=2.0
 git+https://github.com/zeeguu-ecosystem/Python-Wordstats.git@master#egg=wordstats
 google-cloud-texttospeech==2.3.0
 timeago
@@ -47,3 +47,4 @@ scipy==1.10.1
 git+https://github.com/zeeguu/confusionwords.git@main#egg=confusionwords
 readabilipy
 scikit-learn==1.4.0
+flask_monitoringdashboard

--- a/zeeguu/api/app.py
+++ b/zeeguu/api/app.py
@@ -68,7 +68,8 @@ def create_app(testing=False):
     # Creating the DB tables if needed
     # Note that this must be called after all the model classes are loaded
     # And they are loaded above, in the import db... which implicitly loads the model package
-    db.create_all(app=app)
+    with app.app_context():
+        db.create_all()
 
     from .endpoints import api
 

--- a/zeeguu/api/endpoints/teacher_dashboard/cohorts.py
+++ b/zeeguu/api/endpoints/teacher_dashboard/cohorts.py
@@ -219,7 +219,6 @@ def wrapper_to_json_class(id):
 @with_session
 @only_teachers
 def add_colleague_to_cohort():
-
     cohort_id = request.form.get("cohort_id")
     colleague_email = request.form.get("colleague_email")
 
@@ -243,7 +242,6 @@ def add_colleague_to_cohort():
 @with_session
 @only_teachers
 def remove_user_from_cohort(user_id):
-
     check_permission_for_user(user_id)
 
     u = User.find_by_id(user_id)

--- a/zeeguu/core/sql/query_building.py
+++ b/zeeguu/core/sql/query_building.py
@@ -1,4 +1,4 @@
-import zeeguu.core
+from sqlalchemy import text
 
 from zeeguu.core.model import db
 
@@ -12,9 +12,9 @@ def datetime_format(date_object):
 
 
 def list_of_dicts_from_query(query, values):
-    rows = db.session.execute(query, values)
+    rows = db.session.execute(text(query), values)
 
     result = []
     for row in rows:
-        result.append(dict(row))
+        result.append(dict(row._mapping))
     return result

--- a/zeeguu/core/user_statistics/activity.py
+++ b/zeeguu/core/user_statistics/activity.py
@@ -1,5 +1,7 @@
 import json
 
+from sqlalchemy import text
+
 import zeeguu.core
 from zeeguu.core.constants import SIMPLE_DATE_FORMAT
 
@@ -22,8 +24,8 @@ def activity_duration_by_day(user):
 def convert_to_date_seconds(result_raw):
     result_array = [
         {
-            "date": (each["date"]).strftime(SIMPLE_DATE_FORMAT),
-            "seconds": (int(each["duration"])),
+            "date": (each._mapping["date"]).strftime(SIMPLE_DATE_FORMAT),
+            "seconds": (int(each._mapping["duration"])),
         }
         for each in result_raw
     ]
@@ -39,7 +41,7 @@ def _time_by_day(user, table_name, date_field, duration_field):
             + " WHERE user_id = :uid GROUP BY date;"
     )
     result_raw = zeeguu.core.model.db.session.execute(
-        query,
+        text(query),
         {"uid": user.id, "table_name": table_name},
     )
 

--- a/zeeguu/core/user_statistics/exercise_corectness.py
+++ b/zeeguu/core/user_statistics/exercise_corectness.py
@@ -73,7 +73,7 @@ def number_of_words_translated_but_not_studied(
     """
 
     rows = db.session.execute(
-        query,
+        text(query),
         {
             "userid": user_id,
             "startDate": start_date,
@@ -108,7 +108,7 @@ def number_of_distinct_words_in_exercises(user_id, cohort_id, start_date, end_da
     """
 
     rows = db.session.execute(
-        query,
+        text(query),
         {
             "userid": user_id,
             "startDate": start_date,
@@ -135,7 +135,7 @@ def number_of_learned_words(user_id, cohort_id, start_date, end_date):
     """
 
     rows = db.session.execute(
-        query,
+        text(query),
         {
             "userid": user_id,
             "startDate": start_date,

--- a/zeeguu/core/user_statistics/exercise_corectness.py
+++ b/zeeguu/core/user_statistics/exercise_corectness.py
@@ -1,3 +1,5 @@
+from sqlalchemy import text
+
 import zeeguu.core
 
 from zeeguu.core.model import db
@@ -21,7 +23,7 @@ def exercise_count_and_correctness_percentage(user_id, cohort_id, start_date, en
 
 
 def number_of_words_translated_but_not_studied(
-    user_id, cohort_id, start_date, end_date
+        user_id, cohort_id, start_date, end_date
 ):
     query = """
 
@@ -146,7 +148,6 @@ def number_of_learned_words(user_id, cohort_id, start_date, end_date):
 
 
 def exercise_outcome_stats(user_id, cohort_id, start_date: str, end_date: str):
-
     query = """
         select o.outcome, count(o.outcome)
             
@@ -170,7 +171,7 @@ def exercise_outcome_stats(user_id, cohort_id, start_date: str, end_date: str):
     """
 
     rows = db.session.execute(
-        query,
+        text(query),
         {
             "userid": user_id,
             "startDate": start_date,

--- a/zeeguu/core/user_statistics/exercise_sessions.py
+++ b/zeeguu/core/user_statistics/exercise_sessions.py
@@ -1,3 +1,5 @@
+from sqlalchemy import text
+
 import zeeguu.core
 
 from zeeguu.core.model import db
@@ -18,7 +20,7 @@ def total_time_in_exercise_sessions(user_id, cohort_id, start_time, end_time):
     """
 
     rows = db.session.execute(
-        query,
+        text(query),
         {
             "user_id": user_id,
             "start_time": start_time,

--- a/zeeguu/core/user_statistics/reading_sessions.py
+++ b/zeeguu/core/user_statistics/reading_sessions.py
@@ -141,7 +141,7 @@ def translations_in_interval(start_time, end_time, user_id):
     """
 
     rows = db.session.execute(
-        query,
+        text(query),
         {"start_time": start_time, "end_time": end_time, "user_id": user_id},
     )
 

--- a/zeeguu/core/user_statistics/reading_sessions.py
+++ b/zeeguu/core/user_statistics/reading_sessions.py
@@ -1,5 +1,7 @@
 from statistics import mean
 
+from sqlalchemy import text
+
 import zeeguu.core
 
 from zeeguu.core.model import db
@@ -49,7 +51,6 @@ def summarize_reading_activity(user_id, cohort_id, start_date, end_date):
 
 
 def reading_sessions(user_id, cohort_id, from_date: str, to_date: str):
-
     query = """
             select  u.id as session_id, 
                 user_id, 
@@ -80,7 +81,7 @@ def reading_sessions(user_id, cohort_id, from_date: str, to_date: str):
     """
 
     rows = db.session.execute(
-        query,
+        text(query),
         {
             "userId": user_id,
             "startDate": from_date,
@@ -111,7 +112,6 @@ def reading_sessions(user_id, cohort_id, from_date: str, to_date: str):
 
 
 def translations_in_interval(start_time, end_time, user_id):
-
     query = """
         select 
             b.id, 


### PR DESCRIPTION
We were quite behind with the dependency pinned to 1.3. The FMD was not compatible anymore. 

The changes are quite minor. 

Tagging you @tfnribeiro more to ask if you could test to see that it works for you and to attract your attention to the change in `db.session.execute` which now needs to take a `text()` around a query. 