### PR TITLE
Retrieve past article_difficulty_feedback for user.

### DIFF
--- a/zeeguu/core/model/article_difficulty_feedback.py
+++ b/zeeguu/core/model/article_difficulty_feedback.py
@@ -48,7 +48,7 @@ class ArticleDifficultyFeedback(db.Model):
     @classmethod
     def find(cls, user: User, article: Article):
         try:
-            return cls.query.filter_by(user=user, article=article).one()
+            return cls.query.filter_by(user=user, article=article).order_by(cls.date.desc()).first()        
         except NoResultFound:
             return None
 

--- a/zeeguu/core/model/user_article.py
+++ b/zeeguu/core/model/user_article.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.orm.exc import NoResultFound
 
 from zeeguu.core.model import Article, User
+from zeeguu.core.model.article_difficulty_feedback import ArticleDifficultyFeedback
 from zeeguu.core.model.personal_copy import PersonalCopy
 from zeeguu.core.util.encoding import datetime_to_json
 
@@ -248,6 +249,9 @@ class UserArticle(db.Model):
 
         user_article_info = UserArticle.find(user, article)
 
+        user_diff_feedback = ArticleDifficultyFeedback.find(user, article)
+
+
         if not user_article_info:
             returned_info["starred"] = False
             returned_info["opened"] = False
@@ -263,9 +267,8 @@ class UserArticle(db.Model):
                     user_article_info.starred
                 )
 
-            returned_info["relative_difficulty"] = random.choice(
-                ["easy", "moderate'", "hard"]
-            )
+            if user_diff_feedback is not None:
+                returned_info["relative_difficulty"] = user_diff_feedback.difficulty_feedback
 
             if with_translations:
                 translations = Bookmark.find_all_for_user_and_article(user, article)

--- a/zeeguu/core/model/user_article.py
+++ b/zeeguu/core/model/user_article.py
@@ -132,7 +132,7 @@ class UserArticle(db.Model):
         user: User,
         article: Article,
         opened=None,
-        liked=False,
+        liked=None,
         starred=None,
     ):
         """

--- a/zeeguu/core/user_activity_hooks/article_interaction_hooks.py
+++ b/zeeguu/core/user_activity_hooks/article_interaction_hooks.py
@@ -31,7 +31,7 @@ def distill_article_interactions(session, user, data):
     elif EVENT_USER_FEEDBACK in event:
         article_feedback(session, article_id, user, value)
     """ elif EVENT_LIKE_ARTICLE in event:
-        article_liked(session, article_id, user, True) """
+        article_liked(session, article_id, user, value == "true") """
 
 
 def article_feedback(session, article_id, user, event_value):

--- a/zeeguu/core/user_activity_hooks/article_interaction_hooks.py
+++ b/zeeguu/core/user_activity_hooks/article_interaction_hooks.py
@@ -28,10 +28,10 @@ def distill_article_interactions(session, user, data):
 
     if EVENT_OPEN_ARTICLE in event:
         article_opened(session, article_id, user)
-    elif EVENT_LIKE_ARTICLE in event:
-        article_liked(session, article_id, user, True)
     elif EVENT_USER_FEEDBACK in event:
         article_feedback(session, article_id, user, value)
+    """ elif EVENT_LIKE_ARTICLE in event:
+        article_liked(session, article_id, user, True) """
 
 
 def article_feedback(session, article_id, user, event_value):


### PR DESCRIPTION
We have changed the *find* function for ArticleDifficultyFeedback. This was done because we can see that feedback for the same article, by the same user, is stored multiple times in the database. Therefore, we are only interested in the newest feedback given by the user.