### PR TITLE
Allow DB Feeds to skip Metadata retrieval

### DIFF
--- a/zeeguu/core/feed_handler/feed_handler.py
+++ b/zeeguu/core/feed_handler/feed_handler.py
@@ -3,15 +3,12 @@ from zeeguu.core.util.time import normalize_to_server_time
 
 
 class FeedHandler:
-    def __init__(self, url: str, feed_type: int, is_stored_db: bool = False):
+    def __init__(self, url: str, feed_type: int):
         self.url = url
         self.feed_type = feed_type
         self.title = ""
         self.description = ""
         self.image_url_string = ""
-        if not is_stored_db:
-            print("Extracting Feed Metadata.")
-            self.extract_feed_metadata()
 
     def get_server_time(self, article_date) -> datetime:
         if type(article_date) is datetime:

--- a/zeeguu/core/feed_handler/feed_handler.py
+++ b/zeeguu/core/feed_handler/feed_handler.py
@@ -3,13 +3,15 @@ from zeeguu.core.util.time import normalize_to_server_time
 
 
 class FeedHandler:
-    def __init__(self, url: str, feed_type: int):
+    def __init__(self, url: str, feed_type: int, is_stored_db: bool = False):
         self.url = url
         self.feed_type = feed_type
         self.title = ""
         self.description = ""
         self.image_url_string = ""
-        self.extract_feed_metadata()
+        if not is_stored_db:
+            print("Extracting Feed Metadata.")
+            self.extract_feed_metadata()
 
     def get_server_time(self, article_date) -> datetime:
         if type(article_date) is datetime:
@@ -18,8 +20,8 @@ class FeedHandler:
 
     def extract_feed_metadata() -> None:
         """
-            Performs the logic to fill the properties of the 
-            object. These are accessed from the other classes.
+        Performs the logic to fill the properties of the
+        object. These are accessed from the other classes.
         """
         NotImplementedError
 

--- a/zeeguu/core/feed_handler/newspaperfeed.py
+++ b/zeeguu/core/feed_handler/newspaperfeed.py
@@ -13,10 +13,11 @@ class NewspaperFeed(FeedHandler):
         is_stored_db: bool = False,
     ):
         self.use_cache = use_cache
-        super().__init__(url, feed_type, is_stored_db)
-        logp(f"Created Newspaper Source ({self.url})")
+        super().__init__(url, feed_type)
+        logp(f"Using Newspaper Handler ({self.url})")
 
     def extract_feed_metadata(self) -> None:
+        print("Extracting Feed Metadata.")
         data = newspaper.Source(self.url)
         self.title = data.brand
         self.description = data.description

--- a/zeeguu/core/feed_handler/newspaperfeed.py
+++ b/zeeguu/core/feed_handler/newspaperfeed.py
@@ -5,9 +5,15 @@ from zeeguu.logging import log, logp
 
 
 class NewspaperFeed(FeedHandler):
-    def __init__(self, url: str, feed_type: int, use_cache: bool = True):
+    def __init__(
+        self,
+        url: str,
+        feed_type: int,
+        use_cache: bool = True,
+        is_stored_db: bool = False,
+    ):
         self.use_cache = use_cache
-        super().__init__(url, feed_type)
+        super().__init__(url, feed_type, is_stored_db)
         logp(f"Created Newspaper Source ({self.url})")
 
     def extract_feed_metadata(self) -> None:

--- a/zeeguu/core/feed_handler/rssfeed.py
+++ b/zeeguu/core/feed_handler/rssfeed.py
@@ -6,8 +6,9 @@ from zeeguu.logging import log, logp
 
 
 class RSSFeed(FeedHandler):
-    def __init__(self, url: str, feed_type: int):
-        super().__init__(url, feed_type)
+    def __init__(self, url: str, feed_type: int, is_stored_db: bool = False):
+        super().__init__(url, feed_type, is_stored_db)
+        logp(f"Created RSS Source ({self.url})")
 
     def extract_feed_metadata(self) -> None:
         data = feedparser.parse(self.url)
@@ -47,7 +48,11 @@ class RSSFeed(FeedHandler):
 
         feed_items = []
         try:
-            response = requests.get(self.url, headers=headers, timeout=(connect_timeout_seconds, read_timeout_seconds))
+            response = requests.get(
+                self.url,
+                headers=headers,
+                timeout=(connect_timeout_seconds, read_timeout_seconds),
+            )
             feed_data = feedparser.parse(response.text)
 
             log(f"** Articles in feed: {len(feed_data.entries)}")
@@ -64,6 +69,7 @@ class RSSFeed(FeedHandler):
         except requests.exceptions.ConnectTimeout as e:
             msg = f"Connection timeout when trying to connect to {self.url}"
             from sentry_sdk import capture_message
+
             print(msg)
             capture_message(msg)
 

--- a/zeeguu/core/feed_handler/rssfeed.py
+++ b/zeeguu/core/feed_handler/rssfeed.py
@@ -6,11 +6,12 @@ from zeeguu.logging import log, logp
 
 
 class RSSFeed(FeedHandler):
-    def __init__(self, url: str, feed_type: int, is_stored_db: bool = False):
-        super().__init__(url, feed_type, is_stored_db)
-        logp(f"Created RSS Source ({self.url})")
+    def __init__(self, url: str, feed_type: int):
+        super().__init__(url, feed_type)
+        logp(f"Using RSS Handler ({self.url})")
 
     def extract_feed_metadata(self) -> None:
+        print("Extracting Feed Metadata.")
         data = feedparser.parse(self.url)
         try:
             title = data.feed.title

--- a/zeeguu/core/model/feed.py
+++ b/zeeguu/core/model/feed.py
@@ -44,15 +44,15 @@ class Feed(db.Model):
     feed_handler = None
 
     def __init__(
-            self,
-            url,
-            title,
-            description,
-            image_url=None,
-            icon_name=None,
-            language=None,
-            feed_type=0,
-            feed_handler=None,
+        self,
+        url,
+        title,
+        description,
+        image_url=None,
+        icon_name=None,
+        language=None,
+        feed_type=0,
+        feed_handler=None,
     ):
         self.url = url
         self.image_url = image_url
@@ -93,7 +93,9 @@ class Feed(db.Model):
 
     def initializeFeedHandler(self):
         if self.feed_handler is None:
-            self.feed_handler = FEED_TYPE_TO_FEED_HANDLER[self.feed_type](str(self.url), self.feed_type)
+            self.feed_handler = FEED_TYPE_TO_FEED_HANDLER[self.feed_type](
+                str(self.url), self.feed_type, is_stored_db=True
+            )
 
     def as_dictionary(self):
         language = "unknown_lang"
@@ -175,6 +177,7 @@ class Feed(db.Model):
             return result
         except Exception as e:
             import traceback
+
             traceback.print_exc()
             from sentry_sdk import capture_exception
 
@@ -191,14 +194,14 @@ class Feed(db.Model):
 
     @classmethod
     def find_or_create(
-            cls,
-            session,
-            url,
-            title,
-            description,
-            icon_name,
-            language: Language,
-            feed_type,
+        cls,
+        session,
+        url,
+        title,
+        description,
+        icon_name,
+        language: Language,
+        feed_type,
     ):
         try:
             result = (
@@ -231,7 +234,7 @@ class Feed(db.Model):
         return cls.query.filter(cls.language == language).all()
 
     def get_articles(
-            self, limit=None, after_date=None, most_recent_first=False, easiest_first=False
+        self, limit=None, after_date=None, most_recent_first=False, easiest_first=False
     ):
         """
 

--- a/zeeguu/core/model/feed.py
+++ b/zeeguu/core/model/feed.py
@@ -79,6 +79,7 @@ class Feed(db.Model):
     def from_url(cls, url: str, feed_type: int):
         try:
             feed_handler = FEED_TYPE_TO_FEED_HANDLER[feed_type](url, feed_type)
+            feed_handler.extract_feed_metadata()
             feed_url = Url(feed_handler.url, feed_handler.title)
         except KeyError as e:
             log(f"Feed Handler not defined for type '{feed_type}'.")
@@ -94,7 +95,7 @@ class Feed(db.Model):
     def initializeFeedHandler(self):
         if self.feed_handler is None:
             self.feed_handler = FEED_TYPE_TO_FEED_HANDLER[self.feed_type](
-                str(self.url), self.feed_type, is_stored_db=True
+                str(self.url), self.feed_type
             )
 
     def as_dictionary(self):


### PR DESCRIPTION
Added a flag to the FeedHandler super class that allows skipping the extracting metadata call. This should only be called when the  feed is created, which at this point is done in feed.py line 81 `feed_handler = FEED_TYPE_TO_FEED_HANDLER[feed_type](url, feed_type)`. 

When crawling the websites to extract the data, this information is stored in the DB and therefor we do not need to re-acquire it. This is done during `initializeFeedHandler` where now the keyed argument **is_stored_db** is passed to skip the call to `extract_feed_metadata`.

+ Automatic formatting.

### Tests performed:

- Add a new feed and ensure the fields are updated. 
- Crawled the websites and checked the metadata wasn't retrieved. 