### PR TITLE
Fix overriding schedule

### DIFF
--- a/zeeguu/core/model/bookmark.py
+++ b/zeeguu/core/model/bookmark.py
@@ -215,8 +215,11 @@ class Bookmark(db.Model):
                 BasicSRSchedule.bookmark_id == self.id
             ).one()
             cooling_interval = basic_sr_schedule.cooling_interval // ONE_DAY
+            next_practice_time = basic_sr_schedule.next_practice_time
+            can_update_schedule = (next_practice_time < datetime.now(),)
         except sqlalchemy.exc.NoResultFound:
             cooling_interval = None
+            can_update_schedule = None
 
         bookmark_title = ""
         if with_title:
@@ -246,6 +249,7 @@ class Bookmark(db.Model):
             learning_cycle=self.learning_cycle,
             cooling_interval=cooling_interval,
             is_last_in_cycle=cooling_interval == MAX_INTERVAL_8_DAY // ONE_DAY,
+            can_update_schedule=can_update_schedule,
         )
 
         if self.text.article:

--- a/zeeguu/core/model/bookmark.py
+++ b/zeeguu/core/model/bookmark.py
@@ -216,7 +216,7 @@ class Bookmark(db.Model):
             ).one()
             cooling_interval = basic_sr_schedule.cooling_interval // ONE_DAY
             next_practice_time = basic_sr_schedule.next_practice_time
-            can_update_schedule = (next_practice_time < datetime.now(),)
+            can_update_schedule = next_practice_time <= BasicSRSchedule.get_end_of_today()
         except sqlalchemy.exc.NoResultFound:
             cooling_interval = None
             can_update_schedule = None

--- a/zeeguu/core/word_scheduling/basicSR/basicSR.py
+++ b/zeeguu/core/word_scheduling/basicSR/basicSR.py
@@ -137,6 +137,12 @@ class BasicSRSchedule(db.Model):
         )
 
         schedule = cls.find_or_create(db_session, bookmark)
+        if schedule.next_practice_time > datetime.now():
+            # The user is doing the word before it was scheduled.
+            # We do not update the schedule if that's the case.
+            # This can happen when they practice words from the
+            # Article.
+            return
         schedule.update_schedule(db_session, correctness)
 
     @classmethod

--- a/zeeguu/core/word_scheduling/basicSR/basicSR.py
+++ b/zeeguu/core/word_scheduling/basicSR/basicSR.py
@@ -135,9 +135,9 @@ class BasicSRSchedule(db.Model):
             ]  # allow for a few translations before hitting the correct; they work like hints
             or outcome == "HC"  # if it's correct after hint it should still be fine
         )
-
+        current_time = datetime.now()
         schedule = cls.find_or_create(db_session, bookmark)
-        if schedule.next_practice_time > datetime.now():
+        if schedule.next_practice_time > current_time:
             # The user is doing the word before it was scheduled.
             # We do not update the schedule if that's the case.
             # This can happen when they practice words from the


### PR DESCRIPTION
+ Now whenever we perform a scheduler update, we check if the next_practice_time is above the current_time. If this is true, it means the word is being practiced before schedule. 
This would happen if a user kept doing in the Review Words screen for an article - overriding the scheduler.
+ Added a property, can_update_schedule, which allows the frontend to add logic around if the scheduler can update the word or not.