### PR TITLE
shows all exercises for test cohort no matter the language

### DIFF
--- a/tools/migrations/24-05-06--update_cohort_language_to_null_for_testing.sql
+++ b/tools/migrations/24-05-06--update_cohort_language_to_null_for_testing.sql
@@ -1,0 +1,4 @@
+/* 
+ Sets language id for learning cycle test cohort to null, so we can see all exercise despite the language.
+ */
+UPDATE cohort SET language_id = NULL WHERE name IN ('Merle', 'MerleITU');

--- a/zeeguu/core/sql/learner/exercises_history.py
+++ b/zeeguu/core/sql/learner/exercises_history.py
@@ -34,7 +34,7 @@ def exercises_in_session(session_id: int):
 
 
 def exercise_history(user_id: int, language_id: int, from_date: str, to_date: str):
-    query = """
+    query = f"""
         select e.id as exercise_id,
                 b.user_id,
                 es.source,
@@ -57,11 +57,10 @@ def exercise_history(user_id: int, language_id: int, from_date: str, to_date: st
             e.time > '2021-05-24' -- before this date data is saved in a different format... 
             and e.time > :from_date -- '2021-04-13'
             and e.time <= :to_date -- '2021-05-23'
-            and o_uw.language_id = :language_id -- 3
+            {"and o_uw.language_id = :language_id -- 3" if language_id else ""}
             and b.user_id = :user_id
         order by e.time
         """
-
     return list_of_dicts_from_query(
         query,
         {


### PR DESCRIPTION
This pr allows the cohort language to be null, so teachers can see all exercises, regardless of the student's chosen language. It also includes a sql query to update the language of the cohort testing the learning cycle implementation to null.