### PR TITLE
Changes to the ES filtering on difficulty

### DIFF
--- a/zeeguu/api/endpoints/search.py
+++ b/zeeguu/api/endpoints/search.py
@@ -196,7 +196,7 @@ def get_filtered_searches():
 # ---------------------------------------------------------------------------
 @cross_domain
 @requires_session
-def search_for_search_terms(search_terms):
+def search_for_search_terms(search_terms, page: int = 0):
     """
     This endpoint is used for the standard search.
     It passes the search terms to the mysql_recommender function
@@ -208,7 +208,7 @@ def search_for_search_terms(search_terms):
     """
 
     user = User.find_by_id(flask.g.user_id)
-    articles = article_search_for_user(flask.g.user, 20, search_terms, page=page)
-    article_infos = [UserArticle.user_article_info(flask.g.user, a) for a in articles]
+    articles = article_search_for_user(user, 20, search_terms, page=page)
+    article_infos = [UserArticle.user_article_info(user, a) for a in articles]
 
     return json_result(article_infos)

--- a/zeeguu/api/endpoints/search.py
+++ b/zeeguu/api/endpoints/search.py
@@ -191,7 +191,7 @@ def get_filtered_searches():
 
 
 # ---------------------------------------------------------------------------
-@api.route(f"/{SEARCH}/<search_terms>/", methods=("GET",))
+@api.route(f"/{SEARCH}/<search_terms>", methods=("GET",))
 @api.route(f"/{SEARCH}/<search_terms>/<int:page>", methods=("GET",))
 # ---------------------------------------------------------------------------
 @cross_domain

--- a/zeeguu/api/endpoints/search.py
+++ b/zeeguu/api/endpoints/search.py
@@ -187,11 +187,12 @@ def get_filtered_searches():
 
 
 # ---------------------------------------------------------------------------
-@api.route(f"/{SEARCH}/<search_terms>", methods=("GET",))
+@api.route(f"/{SEARCH}/<search_terms>/", methods=("GET",))
+@api.route(f"/{SEARCH}/<search_terms>/<int:page>", methods=("GET",))
 # ---------------------------------------------------------------------------
 @cross_domain
 @with_session
-def search_for_search_terms(search_terms):
+def search_for_search_terms(search_terms, page: int = 0):
     """
     This endpoint is used for the standard search.
     It passes the search terms to the mysql_recommender function
@@ -202,7 +203,7 @@ def search_for_search_terms(search_terms):
 
     """
 
-    articles = article_search_for_user(flask.g.user, 20, search_terms)
+    articles = article_search_for_user(flask.g.user, 20, search_terms, page=page)
     article_infos = [UserArticle.user_article_info(flask.g.user, a) for a in articles]
 
     return json_result(article_infos)

--- a/zeeguu/core/content_recommender/elastic_recommender.py
+++ b/zeeguu/core/content_recommender/elastic_recommender.py
@@ -83,6 +83,7 @@ def _prepare_user_constraints(user):
 def article_recommendations_for_user(
     user,
     count,
+    page=0,
     es_scale="30d",
     es_offset="1d",
     es_decay=0.6,
@@ -125,6 +126,7 @@ def article_recommendations_for_user(
         es_offset,
         es_decay,
         es_weight,
+        page=page,
     )
 
     es = Elasticsearch(ES_CONN_STRING)
@@ -169,6 +171,7 @@ def article_search_for_user(
     es_scale="3d",
     es_decay=0.8,
     es_weight=4.2,
+    page=0,
 ):
     final_article_mix = []
 
@@ -196,6 +199,7 @@ def article_search_for_user(
         es_scale,
         es_decay,
         es_weight,
+        page=page,
     )
 
     es = Elasticsearch(ES_CONN_STRING)
@@ -220,6 +224,7 @@ def article_search_for_user(
             es_decay,
             es_weight,
             second_try=True,
+            page=page,
         )
         res = es.search(index=ES_ZINDEX, body=query_body)
 

--- a/zeeguu/core/content_recommender/elastic_recommender.py
+++ b/zeeguu/core/content_recommender/elastic_recommender.py
@@ -135,27 +135,6 @@ def article_recommendations_for_user(
     hit_list = res["hits"].get("hits")
     final_article_mix.extend(_to_articles_from_ES_hits(hit_list))
 
-    if len(final_article_mix) == 0:
-        # build the query using elastic_query_builder
-        query_body = build_elastic_recommender_query(
-            count,
-            topics_to_include,
-            topics_to_exclude,
-            wanted_user_topics,
-            unwanted_user_topics,
-            language,
-            upper_bounds,
-            lower_bounds,
-            es_scale,
-            es_decay,
-            es_weight,
-            second_try=True,
-        )
-        res = es.search(index=ES_ZINDEX, body=query_body)
-
-    hit_list = res["hits"].get("hits")
-    final_article_mix.extend(_to_articles_from_ES_hits(hit_list))
-
     articles = [a for a in final_article_mix if a is not None and not a.broken]
 
     sorted_articles = sorted(articles, key=lambda x: x.published_time, reverse=True)
@@ -207,29 +186,6 @@ def article_search_for_user(
 
     hit_list = res["hits"].get("hits")
     final_article_mix.extend(_to_articles_from_ES_hits(hit_list))
-
-    if len(final_article_mix) == 0:
-        # build the query using elastic_query_builder
-        query_body = build_elastic_search_query(
-            count,
-            search_terms,
-            topics_to_include,
-            topics_to_exclude,
-            wanted_user_topics,
-            unwanted_user_topics,
-            language,
-            upper_bounds,
-            lower_bounds,
-            es_scale,
-            es_decay,
-            es_weight,
-            second_try=True,
-            page=page,
-        )
-        res = es.search(index=ES_ZINDEX, body=query_body)
-
-        hit_list = res["hits"].get("hits")
-        final_article_mix.extend(_to_articles_from_ES_hits(hit_list))
 
     return [a for a in final_article_mix if a is not None and not a.broken]
 

--- a/zeeguu/core/content_recommender/elastic_recommender.py
+++ b/zeeguu/core/content_recommender/elastic_recommender.py
@@ -6,6 +6,7 @@
    - topics, language and user subscriptions.
 
 """
+
 from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search, Q, SF
 
@@ -22,10 +23,11 @@ from zeeguu.core.model import (
 from zeeguu.core.elastic.elastic_query_builder import (
     build_elastic_recommender_query,
     build_elastic_search_query,
-    build_elastic_more_like_this_query
+    build_elastic_more_like_this_query,
 )
 from zeeguu.core.util.timer_logging_decorator import time_this
 from zeeguu.core.elastic.settings import ES_CONN_STRING, ES_ZINDEX
+
 
 def _prepare_user_constraints(user):
     language = user.learned_language
@@ -79,12 +81,12 @@ def _prepare_user_constraints(user):
 
 
 def article_recommendations_for_user(
-        user,
-        count,
-        es_scale="30d",
-        es_offset="1d",
-        es_decay=0.6,
-        es_weight=4.2,
+    user,
+    count,
+    es_scale="30d",
+    es_offset="1d",
+    es_decay=0.6,
+    es_weight=4.2,
 ):
     """
 
@@ -161,12 +163,12 @@ def article_recommendations_for_user(
 
 @time_this
 def article_search_for_user(
-        user,
-        count,
-        search_terms,
-        es_scale="3d",
-        es_decay=0.8,
-        es_weight=4.2,
+    user,
+    count,
+    search_terms,
+    es_scale="3d",
+    es_decay=0.8,
+    es_weight=4.2,
 ):
     final_article_mix = []
 
@@ -227,14 +229,16 @@ def article_search_for_user(
     return [a for a in final_article_mix if a is not None and not a.broken]
 
 
-def topic_filter_for_user(user,
-                          count,
-                          newer_than,
-                          media_type,
-                          max_duration,
-                          min_duration,
-                          difficulty_level,
-                          topic):
+def topic_filter_for_user(
+    user,
+    count,
+    newer_than,
+    media_type,
+    max_duration,
+    min_duration,
+    difficulty_level,
+    topic,
+):
     es = Elasticsearch(ES_CONN_STRING)
 
     s = Search().query(Q("term", language=user.learned_language.code()))
@@ -245,10 +249,14 @@ def topic_filter_for_user(user,
     AVERAGE_WORDS_PER_MINUTE = 70
 
     if max_duration:
-        s = s.filter("range", word_count={"lte": int(max_duration) * AVERAGE_WORDS_PER_MINUTE})
+        s = s.filter(
+            "range", word_count={"lte": int(max_duration) * AVERAGE_WORDS_PER_MINUTE}
+        )
 
     if min_duration:
-        s = s.filter("range", word_count={"gte": int(min_duration) * AVERAGE_WORDS_PER_MINUTE})
+        s = s.filter(
+            "range", word_count={"gte": int(min_duration) * AVERAGE_WORDS_PER_MINUTE}
+        )
 
     if media_type:
         if media_type == "video":
@@ -261,14 +269,15 @@ def topic_filter_for_user(user,
 
     if difficulty_level:
         lower_bounds, upper_bounds = _difficuty_level_bounds()
-        s = s.filter("range", fk_difficulty={"gte": lower_bounds,
-                                             "lte": upper_bounds})
+        s = s.filter("range", fk_difficulty={"gte": lower_bounds, "lte": upper_bounds})
 
     query = s.query
 
-    query_with_size = {"size": count,
-                       "query": query.to_dict(),
-                       "sort": [{"published_time": "desc"}]}
+    query_with_size = {
+        "size": count,
+        "query": query.to_dict(),
+        "sort": [{"published_time": "desc"}],
+    }
 
     res = es.search(index=ES_ZINDEX, body=query_with_size)
 
@@ -304,19 +313,24 @@ def _difficuty_level_bounds(level):
     return lower_bounds, upper_bounds
 
 
-def __find_articles_like(recommended_articles_ids: 'list[int]', limit: int, article_age: int, language_id: int) -> 'list[Article]':
+def __find_articles_like(
+    recommended_articles_ids: "list[int]",
+    limit: int,
+    article_age: int,
+    language_id: int,
+) -> "list[Article]":
     es = Elasticsearch(ES_CONN_STRING)
     fields = ["content", "title"]
     language = Language.find_by_id(language_id)
     like_documents = [
-        {"_index": ES_ZINDEX, "_id": str(doc_id) } for doc_id in recommended_articles_ids
+        {"_index": ES_ZINDEX, "_id": str(doc_id)} for doc_id in recommended_articles_ids
     ]
-    
+
     mlt_query = build_elastic_more_like_this_query(
         language=language,
         like_documents=like_documents,
         similar_to=fields,
-        cutoff_days=article_age
+        cutoff_days=article_age,
     )
 
     res = es.search(index=ES_ZINDEX, body=mlt_query, size=limit)
@@ -324,13 +338,14 @@ def __find_articles_like(recommended_articles_ids: 'list[int]', limit: int, arti
     articles = [a for a in articles if a.broken == 0]
     return articles
 
+
 def content_recommendations(user_id: int, language_id: int):
-       query = UserArticle.all_liked_articles_of_user_by_id(user_id)
-       
-       user_likes = []
-       for article in query:
-           if article.article.language_id == language_id:
-               user_likes.append(article.article_id)
-       
-       articles_to_recommend = __find_articles_like(user_likes, 20, 50, language_id)
-       return articles_to_recommend
+    query = UserArticle.all_liked_articles_of_user_by_id(user_id)
+
+    user_likes = []
+    for article in query:
+        if article.article.language_id == language_id:
+            user_likes.append(article.article_id)
+
+    articles_to_recommend = __find_articles_like(user_likes, 20, 50, language_id)
+    return articles_to_recommend

--- a/zeeguu/core/content_recommender/elastic_recommender.py
+++ b/zeeguu/core/content_recommender/elastic_recommender.py
@@ -168,10 +168,10 @@ def article_search_for_user(
     user,
     count,
     search_terms,
+    page=0,
     es_scale="3d",
     es_decay=0.8,
     es_weight=4.2,
-    page=0,
 ):
     final_article_mix = []
 

--- a/zeeguu/core/elastic/elastic_query_builder.py
+++ b/zeeguu/core/elastic/elastic_query_builder.py
@@ -32,7 +32,6 @@ def build_elastic_recommender_query(
     es_offset="1d",
     es_decay=0.5,
     es_weight=2.1,
-    second_try=False,
     page=0,
 ):
     """
@@ -103,18 +102,6 @@ def build_elastic_recommender_query(
     if len(topics_arr) > 0:
         must.append({"terms": {"topics": topics_arr}})
 
-    # Let's not filter all the articles
-    # if not second_try:
-    #     # on the second try we do not add the range;
-    #     # because we didn't find anything with it
-    #     bool_query_body["query"]["bool"].update(
-    #         {
-    #             "filter": {
-    #                 "range": {"fk_difficulty": {"gt": lower_bounds, "lt": upper_bounds}}
-    #             }
-    #         }
-    #     )
-
     bool_query_body["query"]["bool"].update({"must": must})
     bool_query_body["query"]["bool"].update({"must_not": must_not})
     # bool_query_body["query"]["bool"].update({"should": should})
@@ -170,14 +157,12 @@ def build_elastic_search_query(
     es_scale="3d",
     es_decay=0.8,
     es_weight=4.2,
-    second_try=False,
     page=0,
 ):
     """
     Builds an elastic search query for search terms.
-    If called with second_try it drops the difficulty constraints
-    It also weights more recent results higher
 
+    Uses the recency and the difficulty of articles to prioritize documents.
     """
 
     s = (

--- a/zeeguu/core/language/strategies/flesch_kincaid_difficulty_estimator.py
+++ b/zeeguu/core/language/strategies/flesch_kincaid_difficulty_estimator.py
@@ -37,6 +37,7 @@ class FleschKincaidDifficultyEstimator(DifficultyEstimatorStrategy):
             normalized=cls.normalize_difficulty(flesch_kincaid_index),
             discrete=cls.discrete_difficulty(flesch_kincaid_index),
             grade=cls.grade_difficulty(flesch_kincaid_index),
+            cefr_level=cls.discrete_difficulty_CEFR(flesch_kincaid_index),
         )
 
         return difficulty_scores
@@ -96,7 +97,7 @@ class FleschKincaidDifficultyEstimator(DifficultyEstimatorStrategy):
             return int(math.floor(syllables))  # Truncate the number of syllables
         else:
             # pyphen can't hyphenate on 'no' - so we use 'nb' instead
-            code = 'nb' if language.code == 'no' else language.code
+            code = "nb" if language.code == "no" else language.code
             dic = pyphen.Pyphen(lang=code)
             syllables = len(dic.positions(word)) + 1
             return syllables
@@ -118,6 +119,22 @@ class FleschKincaidDifficultyEstimator(DifficultyEstimatorStrategy):
             return "MEDIUM"
         else:
             return "HARD"
+
+    @classmethod
+    def discrete_difficulty_CEFR(cls, score: int):
+        # Divided the scale into 6 bands
+        if score > 83:
+            return "A1"
+        elif score > 66:
+            return "A2"
+        elif score > 49:
+            return "B1"
+        elif score > 32:
+            return "B2"
+        elif score > 15:
+            return "C1"
+        else:
+            return "C2"
 
     @classmethod
     def grade_difficulty(cls, score: int):

--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -96,22 +96,22 @@ class Article(db.Model):
     MINIMUM_WORD_COUNT = 90
 
     def __init__(
-            self,
-            url,
-            title,
-            authors,
-            content,
-            summary,
-            published_time,
-            feed,
-            language,
-            htmlContent="",
-            uploader=None,
-            found_by_user=0,  # tracks whether the user found this article (as opposed to us recommending it)
-            broken=0,
-            deleted=0,
-            video=0,
-            img_url=None,
+        self,
+        url,
+        title,
+        authors,
+        content,
+        summary,
+        published_time,
+        feed,
+        language,
+        htmlContent="",
+        uploader=None,
+        found_by_user=0,  # tracks whether the user found this article (as opposed to us recommending it)
+        broken=0,
+        deleted=0,
+        video=0,
+        img_url=None,
     ):
 
         if not summary:
@@ -132,6 +132,7 @@ class Article(db.Model):
         self.deleted = deleted
         self.video = video
         self.img_url = img_url
+        self.fk_cefr_level = None
 
         self.convertHTML2TextIfNeeded()
         self.compute_fk_and_wordcount()
@@ -140,11 +141,11 @@ class Article(db.Model):
         fk_estimator = DifficultyEstimatorFactory.get_difficulty_estimator("fk")
         fk_difficulty = fk_estimator.estimate_difficulty(
             self.content, self.language, None
-        )["grade"]
+        )
 
         # easier to store integer in the DB
         # otherwise we have to use Decimal, and it's not supported on all dbs
-        self.fk_difficulty = fk_difficulty
+        self.fk_difficulty = fk_difficulty["grade"]
         self.word_count = len(self.content.split())
 
     def __repr__(self):
@@ -195,6 +196,23 @@ class Article(db.Model):
         :return:
         """
 
+        # We don't need to store this in the DB.
+        # I was trying to use the self.compute_fk_and_wordcount()
+        # but this wasn't working to set the field?
+        def fk_to_cefr(fk_difficulty):
+            if fk_difficulty < 17:
+                return "A1"
+            elif fk_difficulty < 34:
+                return "A2"
+            elif fk_difficulty < 51:
+                return "B1"
+            elif fk_difficulty < 68:
+                return "B2"
+            elif fk_difficulty < 85:
+                return "C1"
+            else:
+                return "C2"
+
         summary = self.content[:MAX_CHAR_COUNT_IN_SUMMARY]
 
         result_dict = dict(
@@ -205,7 +223,9 @@ class Article(db.Model):
             topics=self.topics_as_string(),
             video=self.video,
             metrics=dict(
-                difficulty=self.fk_difficulty / 100, word_count=self.word_count
+                difficulty=self.fk_difficulty / 100,
+                word_count=self.word_count,
+                cefr_level=fk_to_cefr(self.fk_difficulty),
             ),
         )
 
@@ -333,7 +353,7 @@ class Article(db.Model):
 
     @classmethod
     def create_from_upload(
-            cls, session, title, content, htmlContent, uploader, language
+        cls, session, title, content, htmlContent, uploader, language
     ):
 
         current_time = datetime.now()
@@ -356,20 +376,20 @@ class Article(db.Model):
 
     @classmethod
     def find_or_create(
-            cls,
-            session,
-            url: str,
-            html_content=None,
-            title=None,
-            authors: str = "",
+        cls,
+        session,
+        url: str,
+        html_content=None,
+        title=None,
+        authors: str = "",
     ):
         """
 
-            If article for url found, return ID
+        If article for url found, return ID
 
-            If not found,
-                - if htmlContent is present, create article for that
-                - if not, download and create article then return
+        If not found,
+            - if htmlContent is present, create article for that
+            - if not, download and create article then return
         """
         from zeeguu.core.model import Url, Article, Language
 

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -20,13 +20,16 @@ from zeeguu.core.util import password_hash
 from zeeguu.core.model import db
 from zeeguu.logging import warning
 
+# This mapping reflects splitting
+# the scale of 0 - 100 into 6 bands.
+# Rounded up (16.6666 ~ 17)
 CEFR_TO_DIFFICULTY_MAPPING = {
-    1: (1, 5.5),
-    2: (1, 6),
-    3: (3, 7),
-    4: (3, 7),
-    5: (6, 9),
-    6: (7, 10),
+    1: (0, 1.7),
+    2: (1.7, 3.4),
+    3: (3.4, 5.1),
+    4: (5.1, 6.8),
+    5: (6.8, 8.5),
+    6: (8.5, 10),
 }
 
 


### PR DESCRIPTION
- We are currently using a hard filter that might is a bit too restrictive considering we don't have many sources at extreme levels.
- Instead, I propose using a gaussian function from ES that considers both the difficulty and the recency of an article when suggesting it to a user.
- I divide the FK scale into 6 equal bands to represent each CEFR level, and search articles around the middle point of that band with a tolerance slightly above that of a level step (2.1 vs 1.6). In a concrete example, a A1 student will see articles in a band centered around 0.85 +/- 2.1. Before we would allow from 1 -> 5.5, which for a A1 student might be too hard. This scale makes the scoring slightly more nuanced and continuous, hopefully helping users filter out easier articles.

Visually, it can be represented by something like this:

![image](https://github.com/zeeguu/api/assets/17390076/d479cb16-0e8e-47c9-bcfa-e1d64d9f1084)

- This graph represents the histogram for the total articles per FK score. I divide it into the different bands that is used in this PR with the colored lines representing which range articles are prioritized over for the different levels.

Generally, we can see that the extremes will have problems with the number of articles, but in the worst case (say, no articles around the user level, then the recency should be prioritized)