### PR TITLE
FIX: Handle RSS feeds Publish Times

### DIFF
--- a/zeeguu/core/feed_handler/feed_handler.py
+++ b/zeeguu/core/feed_handler/feed_handler.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timezone, timedelta
 from zeeguu.core.util.time import normalize_to_server_time
+from datetime import datetime
+from time import mktime, struct_time
 
 
 class FeedHandler:
@@ -11,9 +13,17 @@ class FeedHandler:
         self.image_url_string = ""
 
     def get_server_time(self, article_date) -> datetime:
-        if type(article_date) is datetime:
-            return normalize_to_server_time(article_date)
-        return datetime.now()
+        try:
+            if type(article_date) is struct_time:
+                # Convert in case it is a struct_time obj
+                article_date = datetime.fromtimestamp(mktime(article_date))
+            if type(article_date) is datetime:
+                return normalize_to_server_time(article_date)
+        except Exception as e:
+            print(
+                f"Failed parsing into Datetime, using current date: '{article_date}', '{e}'"
+            )
+            return datetime.now()
 
     def extract_feed_metadata() -> None:
         """

--- a/zeeguu/core/feed_handler/feed_handler.py
+++ b/zeeguu/core/feed_handler/feed_handler.py
@@ -22,6 +22,7 @@ class FeedHandler:
             print(
                 f"Failed parsing into Datetime, using current date. Date was: '{article_date}', Failed with: '{e}'"
             )
+        finally:
             return datetime.now()
 
     def extract_feed_metadata() -> None:

--- a/zeeguu/core/feed_handler/feed_handler.py
+++ b/zeeguu/core/feed_handler/feed_handler.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timezone, timedelta
 from zeeguu.core.util.time import normalize_to_server_time
-from datetime import datetime
 from time import mktime, struct_time
 
 

--- a/zeeguu/core/feed_handler/feed_handler.py
+++ b/zeeguu/core/feed_handler/feed_handler.py
@@ -1,8 +1,3 @@
-from datetime import datetime, timezone, timedelta
-from zeeguu.core.util.time import normalize_to_server_time
-from time import mktime, struct_time
-
-
 class FeedHandler:
     def __init__(self, url: str, feed_type: int):
         self.url = url
@@ -10,20 +5,6 @@ class FeedHandler:
         self.title = ""
         self.description = ""
         self.image_url_string = ""
-
-    def get_server_time(self, article_date) -> datetime:
-        try:
-            if type(article_date) is struct_time:
-                # Convert in case it is a struct_time obj
-                article_date = datetime.fromtimestamp(mktime(article_date))
-            if type(article_date) is datetime:
-                return normalize_to_server_time(article_date)
-        except Exception as e:
-            print(
-                f"Failed parsing into Datetime, using current date. Date was: '{article_date}', Failed with: '{e}'"
-            )
-        finally:
-            return datetime.now()
 
     def extract_feed_metadata() -> None:
         """

--- a/zeeguu/core/feed_handler/feed_handler.py
+++ b/zeeguu/core/feed_handler/feed_handler.py
@@ -21,7 +21,7 @@ class FeedHandler:
                 return normalize_to_server_time(article_date)
         except Exception as e:
             print(
-                f"Failed parsing into Datetime, using current date: '{article_date}', '{e}'"
+                f"Failed parsing into Datetime, using current date. Date was: '{article_date}', Failed with: '{e}'"
             )
             return datetime.now()
 

--- a/zeeguu/core/feed_handler/newspaperfeed.py
+++ b/zeeguu/core/feed_handler/newspaperfeed.py
@@ -10,7 +10,6 @@ class NewspaperFeed(FeedHandler):
         url: str,
         feed_type: int,
         use_cache: bool = True,
-        is_stored_db: bool = False,
     ):
         self.use_cache = use_cache
         super().__init__(url, feed_type)

--- a/zeeguu/core/feed_handler/newspaperfeed.py
+++ b/zeeguu/core/feed_handler/newspaperfeed.py
@@ -1,4 +1,5 @@
 import newspaper
+from zeeguu.core.util.time import covert_to_server_time
 from .feed_handler import FeedHandler
 
 from zeeguu.logging import log, logp
@@ -46,7 +47,7 @@ class NewspaperFeed(FeedHandler):
         for article in feed_data:
             article.download()
             article.parse()
-            publish_date = self.get_server_time(article.publish_date)
+            publish_date = covert_to_server_time(article.publish_date)
 
             new_item_data_dict = dict(
                 title=article.title,

--- a/zeeguu/core/feed_handler/rssfeed.py
+++ b/zeeguu/core/feed_handler/rssfeed.py
@@ -1,6 +1,7 @@
 import feedparser
 import requests
 
+from zeeguu.core.util.time import covert_to_server_time
 from .feed_handler import FeedHandler
 from zeeguu.logging import log, logp
 
@@ -58,7 +59,7 @@ class RSSFeed(FeedHandler):
 
             log(f"** Articles in feed: {len(feed_data.entries)}")
             for item in feed_data.entries:
-                publish_time = self.get_server_time(item.get("published_parsed"))
+                publish_time = covert_to_server_time(item.get("published_parsed"))
                 new_item_data_dict = dict(
                     title=item.get("title", ""),
                     url=item.get("link", ""),

--- a/zeeguu/core/util/time.py
+++ b/zeeguu/core/util/time.py
@@ -81,12 +81,11 @@ def covert_to_server_time(date: datetime):
         if type(date) is struct_time:
             # Convert in case it is a struct_time obj
             date = datetime.fromtimestamp(mktime(date))
+        return date.astimezone(
+            timezone(timedelta(hours=SERVER_HOUR_DIFFERENCE))
+        ).replace(tzinfo=None)
     except Exception as e:
         print(
             f"Failed parsing into Datetime, using current date. Date was: '{date}', Failed with: '{e}'"
         )
-        date = datetime.now()
-
-    return date.astimezone(timezone(timedelta(hours=SERVER_HOUR_DIFFERENCE))).replace(
-        tzinfo=None
-    )
+        return datetime.now()

--- a/zeeguu/core/util/time.py
+++ b/zeeguu/core/util/time.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone, timedelta
+from time import mktime, struct_time
 
 
 SERVER_HOUR_DIFFERENCE = 1  # Frankfurt is +1 from UTC
@@ -28,11 +29,12 @@ means we have likely used the server time as reference for all our operations. T
 when an article gets parsed, we should call normalize_to_server_time(). 
 """
 
+
 def get_server_time_utc():
     # Returns the time with the time delta of the server, converted
     # to UTC. This is now a time aware object. This can be useful
     # if we need to perform operations between the server time and
-    # a timezone aware datetime object. 
+    # a timezone aware datetime object.
     # This is not used at this time, see explanation above.
     return (
         datetime.now()
@@ -41,40 +43,50 @@ def get_server_time_utc():
     )
 
 
-def normalize_to_server_time(date: datetime):
+def covert_to_server_time(date: datetime):
     """
-        Takes a datetime that MIGHT be a timezone aware object and converts it to
-        the server time and makes it not time aware (so it can be operated on with datetime.now()).
+    Takes a datetime that MIGHT be a timezone aware object and converts it to
+    the server time and makes it not time aware (so it can be operated on with datetime.now()).
 
-        Examples:
-        ## Case there is a non-tz aware object
-        # A non-timezone aware object is created
-        >>> example1 = datetime.fromisoformat('2011-11-04 10:05:23.283')
-        datetime.datetime(2011, 11, 4, 10, 5, 23, 283000)
-        >>> example1 - datetime.now()
-        datetime.timedelta(days=-4473, seconds=1087, microseconds=670042)
-        >>> example1_timeaware = example1.astimezone(timezone(timedelta(hours=1)))
-        datetime.datetime(2011, 11, 4, 10, 5, 23, 283000, tzinfo=datetime.timezone(datetime.timedelta(seconds=3600)))
-        >>> example1_timeaware - datetime.now()
-        Traceback (most recent call last):
-        File "<stdin>", line 1, in <module>
-        TypeError: can't subtract offset-naive and offset-aware datetimes
-        >>> example1_timeaware.replace(tzinfo=None)
-        datetime.datetime(2011, 11, 4, 10, 5, 23, 283000)
-        # We obtain the same object, it is assumed that the datetime was already in the server time.
+    Examples:
+    ## Case there is a non-tz aware object
+    # A non-timezone aware object is created
+    >>> example1 = datetime.fromisoformat('2011-11-04 10:05:23.283')
+    datetime.datetime(2011, 11, 4, 10, 5, 23, 283000)
+    >>> example1 - datetime.now()
+    datetime.timedelta(days=-4473, seconds=1087, microseconds=670042)
+    >>> example1_timeaware = example1.astimezone(timezone(timedelta(hours=1)))
+    datetime.datetime(2011, 11, 4, 10, 5, 23, 283000, tzinfo=datetime.timezone(datetime.timedelta(seconds=3600)))
+    >>> example1_timeaware - datetime.now()
+    Traceback (most recent call last):
+    File "<stdin>", line 1, in <module>
+    TypeError: can't subtract offset-naive and offset-aware datetimes
+    >>> example1_timeaware.replace(tzinfo=None)
+    datetime.datetime(2011, 11, 4, 10, 5, 23, 283000)
+    # We obtain the same object, it is assumed that the datetime was already in the server time.
 
-        ## Case if there is a tz aware object
-        # This time is +3 UTC, +2 from Frankfurt
-        >>> example2 = datetime.fromisoformat('2011-11-04 10:05:23.283+03:00')
-        datetime.datetime(2011, 11, 4, 10, 5, 23, 283000, tzinfo=datetime.timezone(datetime.timedelta(seconds=10800)))
-        >>> example2_server_time = example2.astimezone(timezone(timedelta(hours=1)))
-        datetime.datetime(2011, 11, 4, 8, 5, 23, 283000, tzinfo=datetime.timezone(datetime.timedelta(seconds=3600)))
-        # Notice that the hours went back 2 in time (matches the fact that there is a 2 hour difference)
-        >>> example2_server_time.replace(tzinfo=None)
-        datetime.datetime(2011, 11, 4, 8, 5, 23, 283000)
-        # We end up with a datetime object with the date converted to server time, not tz aware.
+    ## Case if there is a tz aware object
+    # This time is +3 UTC, +2 from Frankfurt
+    >>> example2 = datetime.fromisoformat('2011-11-04 10:05:23.283+03:00')
+    datetime.datetime(2011, 11, 4, 10, 5, 23, 283000, tzinfo=datetime.timezone(datetime.timedelta(seconds=10800)))
+    >>> example2_server_time = example2.astimezone(timezone(timedelta(hours=1)))
+    datetime.datetime(2011, 11, 4, 8, 5, 23, 283000, tzinfo=datetime.timezone(datetime.timedelta(seconds=3600)))
+    # Notice that the hours went back 2 in time (matches the fact that there is a 2 hour difference)
+    >>> example2_server_time.replace(tzinfo=None)
+    datetime.datetime(2011, 11, 4, 8, 5, 23, 283000)
+    # We end up with a datetime object with the date converted to server time, not tz aware.
 
     """
+    try:
+        if type(date) is struct_time:
+            # Convert in case it is a struct_time obj
+            date = datetime.fromtimestamp(mktime(date))
+    except Exception as e:
+        print(
+            f"Failed parsing into Datetime, using current date. Date was: '{date}', Failed with: '{e}'"
+        )
+        date = datetime.now()
+
     return date.astimezone(timezone(timedelta(hours=SERVER_HOUR_DIFFERENCE))).replace(
         tzinfo=None
     )


### PR DESCRIPTION
I have noticed that the RSS feeds are not parsed as datetimes and for that reason they were always been set to be published at crawl time. I have now handled this, where the struct_time is converted to datetime before being normalized to server time.