### PR TITLE
Updates to support user word preferences

### DIFF
--- a/tools/migrations/24-05-29--add_user_preference_to_bookmark.sql
+++ b/tools/migrations/24-05-29--add_user_preference_to_bookmark.sql
@@ -1,0 +1,13 @@
+ALTER TABLE
+    `zeeguu_test`.`bookmark`
+ADD
+    COLUMN `user_preference` TINYINT NULL DEFAULT 0
+AFTER
+    `learning_cycle`;
+
+UPDATE
+    `zeeguu_test`.`bookmark`
+SET
+    `user_preference` = `starred`
+WHERE
+    starred is not NULL;

--- a/zeeguu/api/endpoints/bookmarks_and_words.py
+++ b/zeeguu/api/endpoints/bookmarks_and_words.py
@@ -197,27 +197,23 @@ def report_learned_bookmark(bookmark_id):
     return "OK"
 
 
-@api.route("/is_user_preference/<bookmark_id>", methods=["POST"])
+@api.route("/use_in_exercises/<bookmark_id>", methods=["POST"])
 @cross_domain
 @requires_session
 def set_user_word_exercise_preference(bookmark_id):
     bookmark = Bookmark.find(bookmark_id)
     bookmark.user_preference = UserWordExPreference.USE_IN_EXERCISES
-    # Keep Start Interaction?
-    bookmark.starred = True
     bookmark.update_fit_for_study()
     db_session.commit()
     return "OK"
 
 
-@api.route("/not_user_preference/<bookmark_id>", methods=["POST"])
+@api.route("/dont_use_in_exercises/<bookmark_id>", methods=["POST"])
 @cross_domain
 @requires_session
 def set_user_word_exercise_dislike(bookmark_id):
     bookmark = Bookmark.find(bookmark_id)
     bookmark.user_preference = UserWordExPreference.DONT_USE_IN_EXERCISES
-    # Keep Start Interaction?
-    bookmark.starred = False
     bookmark.update_fit_for_study()
     db_session.commit()
     return "OK"

--- a/zeeguu/api/endpoints/bookmarks_and_words.py
+++ b/zeeguu/api/endpoints/bookmarks_and_words.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from zeeguu.core.bookmark_quality import top_bookmarks
 from zeeguu.core.model import User, Article, Bookmark, ExerciseSource, ExerciseOutcome
+from zeeguu.core.model.bookmark_user_preference import UserWordExPreference
 from . import api, db_session
 from zeeguu.api.utils.json_result import json_result
 from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
@@ -193,6 +194,32 @@ def report_learned_bookmark(bookmark_id):
         db_session,
     )
 
+    return "OK"
+
+
+@api.route("/is_user_preference/<bookmark_id>", methods=["POST"])
+@cross_domain
+@requires_session
+def set_user_word_exercise_preference(bookmark_id):
+    bookmark = Bookmark.find(bookmark_id)
+    bookmark.user_preference = UserWordExPreference.USE_IN_EXERCISES
+    # Keep Start Interaction?
+    bookmark.starred = True
+    bookmark.update_fit_for_study()
+    db_session.commit()
+    return "OK"
+
+
+@api.route("/not_user_preference/<bookmark_id>", methods=["POST"])
+@cross_domain
+@requires_session
+def set_user_word_exercise_dislike(bookmark_id):
+    bookmark = Bookmark.find(bookmark_id)
+    bookmark.user_preference = UserWordExPreference.DONT_USE_IN_EXERCISES
+    # Keep Start Interaction?
+    bookmark.starred = False
+    bookmark.update_fit_for_study()
+    db_session.commit()
     return "OK"
 
 

--- a/zeeguu/core/bookmark_quality/fit_for_study.py
+++ b/zeeguu/core/bookmark_quality/fit_for_study.py
@@ -1,19 +1,20 @@
 from zeeguu.core.bookmark_quality import quality_bookmark
 from zeeguu.core.definition_of_learned import is_learned_based_on_exercise_outcomes
 from zeeguu.core.model.sorted_exercise_log import SortedExerciseLog
+from zeeguu.core.model.bookmark_user_preference import UserWordExPreference
 
 
 def fit_for_study(bookmark):
     exercise_log = SortedExerciseLog(bookmark)
-
     return (
-
-            (quality_bookmark(bookmark) or bookmark.starred) and
-
-            not is_learned_based_on_exercise_outcomes(exercise_log) and
-
-            not feedback_prevents_further_study(exercise_log)
-
+        (
+            quality_bookmark(bookmark)
+            or bookmark.starred
+            or bookmark.user_preference == UserWordExPreference.USE_IN_EXERCISES
+        )
+        and not is_learned_based_on_exercise_outcomes(exercise_log)
+        and not feedback_prevents_further_study(exercise_log)
+        and not bookmark.user_preference == UserWordExPreference.DONT_USE_IN_EXERCISES
     )
 
 
@@ -23,9 +24,4 @@ def feedback_prevents_further_study(exercise_log):
     if not last_outcome:
         return False
 
-    return (
-
-            last_outcome.free_text_feedback() or
-
-            last_outcome.too_easy()
-    )
+    return last_outcome.free_text_feedback() or last_outcome.too_easy()

--- a/zeeguu/core/model/bookmark.py
+++ b/zeeguu/core/model/bookmark.py
@@ -20,6 +20,7 @@ from zeeguu.core.model.user import User
 from zeeguu.core.model.user_word import UserWord
 from zeeguu.core.util.encoding import datetime_to_json
 from zeeguu.core.model.learning_cycle import LearningCycle
+from zeeguu.core.model.bookmark_user_preference import UserWordExPreference
 
 import zeeguu
 
@@ -70,6 +71,8 @@ class Bookmark(db.Model):
 
     learning_cycle = db.Column(db.Integer)
 
+    user_preference = db.Column(db.Integer)
+
     bookmark = db.relationship("WordToStudy", backref="bookmark", passive_deletes=True)
 
     def __init__(
@@ -90,6 +93,7 @@ class Bookmark(db.Model):
         self.fit_for_study = fit_for_study(self)
         self.learned = False
         self.learning_cycle = learning_cycle
+        self.user_preference = UserWordExPreference.NO_PREFERENCE
 
     def __repr__(self):
         return "Bookmark[{3} of {4}: {0}->{1} in '{2}...']\n".format(
@@ -216,7 +220,9 @@ class Bookmark(db.Model):
             ).one()
             cooling_interval = basic_sr_schedule.cooling_interval // ONE_DAY
             next_practice_time = basic_sr_schedule.next_practice_time
-            can_update_schedule = next_practice_time <= BasicSRSchedule.get_end_of_today()
+            can_update_schedule = (
+                next_practice_time <= BasicSRSchedule.get_end_of_today()
+            )
         except sqlalchemy.exc.NoResultFound:
             cooling_interval = None
             can_update_schedule = None
@@ -250,6 +256,7 @@ class Bookmark(db.Model):
             cooling_interval=cooling_interval,
             is_last_in_cycle=cooling_interval == MAX_INTERVAL_8_DAY // ONE_DAY,
             can_update_schedule=can_update_schedule,
+            user_preference = self.user_preference
         )
 
         if self.text.article:

--- a/zeeguu/core/model/bookmark_user_preference.py
+++ b/zeeguu/core/model/bookmark_user_preference.py
@@ -1,0 +1,6 @@
+class UserWordExPreference(object):
+    # Defines user preference to use worrd
+    # in exercises
+    DONT_USE_IN_EXERCISES = -1
+    NO_PREFERENCE = 0
+    USE_IN_EXERCISES = 1


### PR DESCRIPTION
Changes to support: https://github.com/zeeguu/web/pull/392

- Supports functionality for the user to force a word to be presented in the exercises or not.
- This is handled by an extra column in the bookmark table that functions similarly to the Star interaction in the past.


**Question: Should we align the star interaction whenever the user adds a word to the exercises?**