### PR TITLE
Fixed FitForStudy flag

### DIFF
--- a/zeeguu/api/endpoints/bookmarks_and_words.py
+++ b/zeeguu/api/endpoints/bookmarks_and_words.py
@@ -10,6 +10,7 @@ from zeeguu.core.model.bookmark_user_preference import UserWordExPreference
 from . import api, db_session
 from zeeguu.api.utils.json_result import json_result
 from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
+from zeeguu.core.word_scheduling.basicSR.basicSR import BasicSRSchedule
 
 
 @api.route("/user_words", methods=["GET"])
@@ -215,6 +216,8 @@ def set_user_word_exercise_dislike(bookmark_id):
     bookmark = Bookmark.find(bookmark_id)
     bookmark.user_preference = UserWordExPreference.DONT_USE_IN_EXERCISES
     bookmark.update_fit_for_study()
+
+    BasicSRSchedule.clear_bookmark_schedule(db_session, bookmark)
     db_session.commit()
     return "OK"
 
@@ -235,6 +238,8 @@ def set_is_fit_for_study(bookmark_id):
 def set_not_fit_for_study(bookmark_id):
     bookmark = Bookmark.find(bookmark_id)
     bookmark.fit_for_study = False
+
+    BasicSRSchedule.clear_bookmark_schedule(db_session, bookmark)
     db_session.commit()
     return "OK"
 

--- a/zeeguu/core/bookmark_quality/fit_for_study.py
+++ b/zeeguu/core/bookmark_quality/fit_for_study.py
@@ -5,17 +5,10 @@ from zeeguu.core.model.bookmark_user_preference import UserWordExPreference
 
 
 def fit_for_study(bookmark):
-    exercise_log = SortedExerciseLog(bookmark)
     return (
-        (
-            quality_bookmark(bookmark)
-            or bookmark.starred
-            or bookmark.user_preference == UserWordExPreference.USE_IN_EXERCISES
-        )
-        and not is_learned_based_on_exercise_outcomes(exercise_log)
-        and not feedback_prevents_further_study(exercise_log)
-        and not bookmark.user_preference == UserWordExPreference.DONT_USE_IN_EXERCISES
-    )
+        quality_bookmark(bookmark)
+        or bookmark.user_preference == UserWordExPreference.USE_IN_EXERCISES
+    ) and not bookmark.user_preference == UserWordExPreference.DONT_USE_IN_EXERCISES
 
 
 def feedback_prevents_further_study(exercise_log):

--- a/zeeguu/core/bookmark_quality/fit_for_study.py
+++ b/zeeguu/core/bookmark_quality/fit_for_study.py
@@ -1,6 +1,4 @@
 from zeeguu.core.bookmark_quality import quality_bookmark
-from zeeguu.core.definition_of_learned import is_learned_based_on_exercise_outcomes
-from zeeguu.core.model.sorted_exercise_log import SortedExerciseLog
 from zeeguu.core.model.bookmark_user_preference import UserWordExPreference
 
 

--- a/zeeguu/core/definition_of_learned/__init__.py
+++ b/zeeguu/core/definition_of_learned/__init__.py
@@ -1,2 +1,2 @@
 from .is_learned import is_learned_based_on_exercise_outcomes
-from .is_learned import CORRECTS_IN_DISTINCT_DAYS_FOR_LEARNED
+from .is_learned import LEARNING_CYCLE_LENGTH

--- a/zeeguu/core/definition_of_learned/is_learned.py
+++ b/zeeguu/core/definition_of_learned/is_learned.py
@@ -3,6 +3,9 @@ CORRECTS_IN_DISTINCT_DAYS_FOR_LEARNED = 4
 
 def is_learned_based_on_exercise_outcomes(exercise_log):
     """
+    10-06-2024 -> OUTDATED, now words are considered learned after the user
+    has completed a learning cycle and depeding on how the productive flag is set.
+
     :return:
     """
     if exercise_log.is_empty():

--- a/zeeguu/core/definition_of_learned/is_learned.py
+++ b/zeeguu/core/definition_of_learned/is_learned.py
@@ -1,18 +1,34 @@
-CORRECTS_IN_DISTINCT_DAYS_FOR_LEARNED = 4
+from zeeguu.core.word_scheduling.basicSR.basicSR import NEXT_COOLING_INTERVAL_ON_SUCCESS
+
+LEARNING_CYCLE_LENGTH = len(NEXT_COOLING_INTERVAL_ON_SUCCESS)
 
 
-def is_learned_based_on_exercise_outcomes(exercise_log):
+def is_learned_based_on_exercise_outcomes(exercise_log, is_productive=True):
     """
-    10-06-2024 -> OUTDATED, now words are considered learned after the user
-    has completed a learning cycle and depeding on how the productive flag is set.
+    Checks if the user has reported the exercise as too easy or looks into the
+    streaks of this exercise log. Currently (14/06/2024), Zeeguu uses 2 cycles of
+    4 different days in spaced repetition to concider a word learned.
 
-    :return:
+    If a user has 2 streaks of 4, it means they have completed a 2 full cycles,
+    and therefor have learned the word.
+
+    The user also has the option of saying they do not want productive exercises.
+    In this case, we only need to have a single streak of 4 to consider the bookmark
+    learned.
+
+    :return:Boolean, the bookmark is learned based on the exercises or not.
     """
     if exercise_log.is_empty():
         return False
 
-    return (
-        exercise_log.last_exercise().is_too_easy()
-        or len(exercise_log.most_recent_correct_dates())
-        >= CORRECTS_IN_DISTINCT_DAYS_FOR_LEARNED
-    )
+    # For a bookmark to be learned it needs to have 1 or 2 cycles
+    # completed depending on the user preference.
+    if exercise_log.last_exercise().is_too_easy():
+        return True
+
+    streak_counts = exercise_log.count_number_of_streaks()
+    full_cycles_completed = streak_counts.get(LEARNING_CYCLE_LENGTH)
+    if is_productive:
+        return full_cycles_completed == 2
+    else:
+        return full_cycles_completed == 1

--- a/zeeguu/core/model/bookmark.py
+++ b/zeeguu/core/model/bookmark.py
@@ -360,6 +360,17 @@ class Bookmark(db.Model):
         except NoResultFound:
             return False
 
+    def is_learned_based_on_exercise_outcomes(self):
+        from zeeguu.core.model.sorted_exercise_log import SortedExerciseLog
+        from zeeguu.core.definition_of_learned import (
+            is_learned_based_on_exercise_outcomes,
+        )
+
+        exercise_log = SortedExerciseLog(self)
+        return is_learned_based_on_exercise_outcomes(
+            exercise_log, self.learning_cycle == LearningCycle.PRODUCTIVE
+        )
+
     def update_learned_status(self, session):
         from zeeguu.core.definition_of_learned import (
             is_learned_based_on_exercise_outcomes,

--- a/zeeguu/core/model/bookmark.py
+++ b/zeeguu/core/model/bookmark.py
@@ -8,9 +8,8 @@ from wordstats import Word
 
 from zeeguu.logging import log
 from zeeguu.core.bookmark_quality.fit_for_study import fit_for_study
-from zeeguu.core.definition_of_learned import is_learned_based_on_exercise_outcomes
+
 from zeeguu.core.model import Article
-from zeeguu.core.model.sorted_exercise_log import SortedExerciseLog
 from zeeguu.core.model.exercise import Exercise
 from zeeguu.core.model.exercise_outcome import ExerciseOutcome
 from zeeguu.core.model.exercise_source import ExerciseSource
@@ -25,8 +24,6 @@ from zeeguu.core.model.bookmark_user_preference import UserWordExPreference
 import zeeguu
 
 from zeeguu.core.model import db
-
-CORRECTS_IN_A_ROW_FOR_LEARNED = 4
 
 bookmark_exercise_mapping = Table(
     "bookmark_exercise_mapping",
@@ -318,6 +315,8 @@ class Bookmark(db.Model):
         return bookmark
 
     def sorted_exercise_log(self):
+        from zeeguu.core.model.sorted_exercise_log import SortedExerciseLog
+
         return SortedExerciseLog(self)
 
     @classmethod
@@ -362,15 +361,21 @@ class Bookmark(db.Model):
             return False
 
     def update_learned_status(self, session):
+        from zeeguu.core.definition_of_learned import (
+            is_learned_based_on_exercise_outcomes,
+        )
+        from zeeguu.core.model.sorted_exercise_log import SortedExerciseLog
+
         """
             To call when something happened to the bookmark,
              that requires it's "learned" status to be updated.
         :param session:
         :return:
         """
-
         exercise_log = SortedExerciseLog(self)
-        is_learned = is_learned_based_on_exercise_outcomes(exercise_log)
+        is_learned = is_learned_based_on_exercise_outcomes(
+            exercise_log, self.learning_cycle == LearningCycle.PRODUCTIVE
+        )
         if is_learned:
             log(f"Log: {exercise_log.summary()}: bookmark {self.id} learned!")
             self.learned_time = exercise_log.last_exercise_time()

--- a/zeeguu/core/model/bookmark.py
+++ b/zeeguu/core/model/bookmark.py
@@ -256,7 +256,7 @@ class Bookmark(db.Model):
             cooling_interval=cooling_interval,
             is_last_in_cycle=cooling_interval == MAX_INTERVAL_8_DAY // ONE_DAY,
             can_update_schedule=can_update_schedule,
-            user_preference = self.user_preference
+            user_preference=self.user_preference,
         )
 
         if self.text.article:

--- a/zeeguu/core/model/exercise.py
+++ b/zeeguu/core/model/exercise.py
@@ -22,7 +22,9 @@ class Exercise(db.Model):
     time = db.Column(db.DateTime, nullable=False)
     feedback = db.Column(db.String(255))
 
-    session_id = db.Column(db.Integer, db.ForeignKey(UserExerciseSession.id), nullable=True)
+    session_id = db.Column(
+        db.Integer, db.ForeignKey(UserExerciseSession.id), nullable=True
+    )
     session = db.relationship(UserExerciseSession)
 
     def __init__(self, outcome, source, solving_speed, time, session_id, feedback=""):
@@ -96,4 +98,4 @@ class Exercise(db.Model):
         return self.outcome.outcome in ExerciseOutcome.too_easy_outcomes
 
     def is_correct(self):
-        return self.outcome.outcome in ExerciseOutcome.correct_outcomes
+        return ExerciseOutcome.is_correct(self.outcome.outcome)

--- a/zeeguu/core/model/exercise_outcome.py
+++ b/zeeguu/core/model/exercise_outcome.py
@@ -28,6 +28,7 @@ class ExerciseOutcome(db.Model):
 
     wrong_outcomes = ["W", WRONG, SHOW_SOLUTION, ASKED_FOR_HINT]
 
+    @classmethod
     def is_valid_attempt(cls, outcome: str):
         """
         The user might have multiple attempts:
@@ -40,6 +41,7 @@ class ExerciseOutcome(db.Model):
         allowed_attempts = set(["C", "W", "T", "S", "H"])
         return allowed_attempts.issuperset(set([c for c in outcome]))
 
+    @classmethod
     def is_correct(cls, outcome: str):
         is_correct = outcome == ExerciseOutcome.CORRECT
         # allow for a few translations before hitting the correct; they work like hints

--- a/zeeguu/core/model/exercise_outcome.py
+++ b/zeeguu/core/model/exercise_outcome.py
@@ -28,6 +28,30 @@ class ExerciseOutcome(db.Model):
 
     wrong_outcomes = ["W", WRONG, SHOW_SOLUTION, ASKED_FOR_HINT]
 
+    def is_valid_attempt(cls, outcome: str):
+        """
+        The user might have multiple attempts:
+            e.g. "WWWHHC",
+                 "WWTTHC"...
+        By checking if the characters in the answer are part
+        of the set of possible reports of the exercise, we can
+        conclude it is a user attempt.
+        """
+        allowed_attempts = set(["C", "W", "T", "S", "H"])
+        return allowed_attempts.issuperset(set([c for c in outcome]))
+
+    def is_correct(cls, outcome: str):
+        is_correct = outcome == ExerciseOutcome.CORRECT
+        # allow for a few translations before hitting the correct; they work like hints
+        is_correct_after_translation = outcome in [
+            "TC",
+            "TTC",
+            "TTTC",
+        ]
+        # if it's correct after hint it should still be fine
+        is_correct_after_hint = outcome == "HC"
+        return is_correct or is_correct_after_translation or is_correct_after_hint
+
     def __init__(self, outcome):
         self.outcome = outcome
 
@@ -46,17 +70,13 @@ class ExerciseOutcome(db.Model):
         return self.outcome in self.too_easy_outcomes
 
     def free_text_feedback(self):
-        """
-        this can happen since the user can provide any free
-        text feedback. in such a case it would probably be
-        safest not to show such a bookmark until somebody
-        manually verified the appropriateness of the
-        feedback"""
-        return (
+        result = (
             self.outcome not in self.correct_outcomes
             and self.outcome not in self.wrong_outcomes
             and self.outcome not in self.too_easy_outcomes
+            and not ExerciseOutcome.is_valid_attempt(self.outcome)
         )
+        return result
 
     @classmethod
     def find(cls, outcome: str):

--- a/zeeguu/core/model/sorted_exercise_log.py
+++ b/zeeguu/core/model/sorted_exercise_log.py
@@ -76,14 +76,16 @@ class SortedExerciseLog(object):
         current_streak = 0
         total_streak_counts = {}
         for exercise in self.exercises:
-            if not exercise.is_correct() or current_streak == LEARNING_CYCLE_LENGTH:
+            is_correct = exercise.is_correct()
+            if is_correct:
+                current_streak += 1
+            if not is_correct or current_streak == LEARNING_CYCLE_LENGTH:
                 # To move to a next cycle you need a streak of 4 exercises.
                 # If the exercise is not correct or is at the end of the cycle
                 # We store that information
                 save_streak(total_streak_counts, current_streak)
                 current_streak = 0
-            else:
-                current_streak += 1
+
         save_streak(total_streak_counts, current_streak)
         # If we want the resulting dictionary sorted by keys.
         # return dict(sorted(total_streak_counts.items()))

--- a/zeeguu/core/model/sorted_exercise_log.py
+++ b/zeeguu/core/model/sorted_exercise_log.py
@@ -1,25 +1,24 @@
-from zeeguu.core.definition_of_learned import CORRECTS_IN_DISTINCT_DAYS_FOR_LEARNED
+from zeeguu.core.definition_of_learned import LEARNING_CYCLE_LENGTH
 
 
 class SortedExerciseLog(object):
 
     def __init__(self, bookmark):
         self.exercises = sorted(
-            bookmark.exercise_log,
-            key=lambda x: x.time,
-            reverse=True)
+            bookmark.exercise_log, key=lambda x: x.time, reverse=True
+        )
 
     # string rep for logging
     def summary(self):
-        return ' '.join(
-            [exercise.short_string_summary() for exercise in self.exercises])
+        return " ".join(
+            [exercise.short_string_summary() for exercise in self.exercises]
+        )
 
     # string rep
     def compact_sorted_exercise_log(self):
         result = ""
         for ex in self.exercises:
-            result += (f"{ex.time.day}/{ex.time.month} " +
-                       f"{ex.outcome.outcome[:4]}   ")
+            result += f"{ex.time.day}/{ex.time.month} " + f"{ex.outcome.outcome[:4]}   "
         return result
 
     # string rep good for Learned Words in the Web
@@ -28,7 +27,7 @@ class SortedExerciseLog(object):
         distinct_days = self.most_recent_correct_dates()
 
         result = []
-        for day in list(distinct_days)[:CORRECTS_IN_DISTINCT_DAYS_FOR_LEARNED]:
+        for day in list(distinct_days)[:LEARNING_CYCLE_LENGTH]:
             result.append(day.strftime("%b.%d "))
         return " ".join(result)
 
@@ -69,3 +68,22 @@ class SortedExerciseLog(object):
         for exercise in self.most_recent_corrects():
             distinct_days.add(exercise.time.date())
         return distinct_days
+
+    def count_number_of_streaks(self):
+        current_streak = 0
+        total_streak_counts = {}
+        for exercise in self.exercises:
+            if not exercise.is_correct() or current_streak == LEARNING_CYCLE_LENGTH:
+                # To move to a next cycle you need a streak of 4 exercises.
+                # If the exercise is not correct or is at the end of the cycle
+                # We store that information
+                total_streak_counts[current_streak] = (
+                    total_streak_counts.get(current_streak, 0) + 1
+                )
+                current_streak = 0
+            else:
+                current_streak += 1
+        total_streak_counts[current_streak] = (
+            total_streak_counts.get(current_streak, 0) + 1
+        )
+        return total_streak_counts

--- a/zeeguu/core/model/sorted_exercise_log.py
+++ b/zeeguu/core/model/sorted_exercise_log.py
@@ -70,6 +70,9 @@ class SortedExerciseLog(object):
         return distinct_days
 
     def count_number_of_streaks(self):
+        def save_streak(count_dict, current_count):
+            count_dict[current_count] = count_dict.get(current_count, 0) + 1
+
         current_streak = 0
         total_streak_counts = {}
         for exercise in self.exercises:
@@ -77,13 +80,11 @@ class SortedExerciseLog(object):
                 # To move to a next cycle you need a streak of 4 exercises.
                 # If the exercise is not correct or is at the end of the cycle
                 # We store that information
-                total_streak_counts[current_streak] = (
-                    total_streak_counts.get(current_streak, 0) + 1
-                )
+                save_streak(total_streak_counts, current_streak)
                 current_streak = 0
             else:
                 current_streak += 1
-        total_streak_counts[current_streak] = (
-            total_streak_counts.get(current_streak, 0) + 1
-        )
+        save_streak(total_streak_counts, current_streak)
+        # If we want the resulting dictionary sorted by keys.
+        # return dict(sorted(total_streak_counts.items()))
         return total_streak_counts

--- a/zeeguu/core/test/test_bookmark.py
+++ b/zeeguu/core/test/test_bookmark.py
@@ -254,24 +254,21 @@ class BookmarkTest(ModelTestMixIn):
 
         correct_bookmark.update_learned_status(db.session)
 
-        log = SortedExerciseLog(correct_bookmark)
-        learned = is_learned_based_on_exercise_outcomes(log, True)
-        result_time = log.last_exercise_time()
-        print("Testing is learned!")
+        learned = correct_bookmark.is_learned_based_on_exercise_outcomes()
         assert learned
 
         log = SortedExerciseLog(correct_bookmark)
         learned_time_from_log = log.last_exercise_time()
-        print("Testing is learned date!")
+        result_time = log.last_exercise_time()
         assert result_time == learned_time_from_log
 
         # A bookmark with no TOO EASY outcome or less than 5 correct exercises in a row returns False, None
+        wrong_exercise_bookmark = random_bookmarks[3]
         wrong_exercise = ExerciseRule(exercise_session).exercise
         wrong_exercise.outcome = OutcomeRule().wrong
-        random_bookmarks[3].add_new_exercise(wrong_exercise)
+        wrong_exercise_bookmark.add_new_exercise(wrong_exercise)
 
-        log = SortedExerciseLog(random_bookmarks[3])
-        learned = is_learned_based_on_exercise_outcomes(log, True)
+        learned = wrong_exercise_bookmark.is_learned_based_on_exercise_outcomes()
         print("Testing is not learned")
         assert not learned
 
@@ -297,25 +294,22 @@ class BookmarkTest(ModelTestMixIn):
 
         correct_bookmark.update_learned_status(db.session)
 
-        log = SortedExerciseLog(correct_bookmark)
-        learned = is_learned_based_on_exercise_outcomes(log, False)
-        result_time = log.last_exercise_time()
-        print(log.str_most_recent_correct_dates())
-        print(learned)
+        learned = correct_bookmark.is_learned_based_on_exercise_outcomes()
+        
         assert learned
 
         log = SortedExerciseLog(correct_bookmark)
         learned_time_from_log = log.last_exercise_time()
+        result_time = log.last_exercise_time()
         assert result_time == learned_time_from_log
 
         # A bookmark with no TOO EASY outcome or less than 5 correct exercises in a row returns False, None
+        wrong_exercise_bookmark = random_bookmarks[3]
         wrong_exercise = ExerciseRule(exercise_session).exercise
         wrong_exercise.outcome = OutcomeRule().wrong
         random_bookmarks[3].add_new_exercise(wrong_exercise)
 
-        log = SortedExerciseLog(random_bookmarks[3])
-        learned = is_learned_based_on_exercise_outcomes(log, False)
-        print(learned)
+        learned = wrong_exercise_bookmark.is_learned_based_on_exercise_outcomes()
         assert not learned
 
     def test_top_bookmarks(self):

--- a/zeeguu/core/test/test_bookmark.py
+++ b/zeeguu/core/test/test_bookmark.py
@@ -3,10 +3,10 @@ import random
 from zeeguu.core.bookmark_quality import top_bookmarks, bad_quality_bookmark
 from zeeguu.core.definition_of_learned import (
     is_learned_based_on_exercise_outcomes,
-    CORRECTS_IN_DISTINCT_DAYS_FOR_LEARNED,
+    LEARNING_CYCLE_LENGTH,
 )
 from zeeguu.core.model.sorted_exercise_log import SortedExerciseLog
-from zeeguu.core.model.bookmark import CORRECTS_IN_A_ROW_FOR_LEARNED
+from zeeguu.core.definition_of_learned import LEARNING_CYCLE_LENGTH
 from zeeguu.core.test.model_test_mixin import ModelTestMixIn
 
 from zeeguu.core.test.rules.bookmark_rule import BookmarkRule
@@ -198,7 +198,7 @@ class BookmarkTest(ModelTestMixIn):
             == SortedExerciseLog(random_bookmark).latest_exercise_outcome()
         )
 
-    def test_is_learned_based_on_exercise_outcomes(self):
+    def test_empty_exercises_is_not_learned(self):
         random_bookmarks = [BookmarkRule(self.user).bookmark for _ in range(0, 4)]
 
         # Empty exercise_log should lead to a False return
@@ -206,6 +206,9 @@ class BookmarkTest(ModelTestMixIn):
             SortedExerciseLog(random_bookmarks[0])
         )
         assert not learned
+
+    def test_is_too_easy_sets_to_learned(self):
+        random_bookmarks = [BookmarkRule(self.user).bookmark for _ in range(0, 4)]
 
         # An exercise with Outcome equal to TOO EASY results in True, and time of last exercise
         exercise_session = ExerciseSessionRule(self.user).exerciseSession
@@ -226,14 +229,22 @@ class BookmarkTest(ModelTestMixIn):
         )
         assert learned
 
+    def test_is_learned_based_on_exercise_outcomes_productive(self):
+        from zeeguu.core.model.learning_cycle import LearningCycle
+
+        print("Testing Productive Outcome!")
+        random_bookmarks = [BookmarkRule(self.user).bookmark for _ in range(0, 4)]
+        exercise_session = ExerciseSessionRule(self.user).exerciseSession
         # A bookmark with CORRECTS_IN_A_ROW_FOR_LEARNED correct exercises in a row
         # returns true and the time of the last exercise
+        total_exercises_productive_cycle = LEARNING_CYCLE_LENGTH * 2
         correct_bookmark = random_bookmarks[2]
+        correct_bookmark.learning_cycle = LearningCycle.PRODUCTIVE
         exercises = 0
         distinct_dates = set()
         while not (
-            exercises >= CORRECTS_IN_A_ROW_FOR_LEARNED
-            and len(distinct_dates) >= CORRECTS_IN_DISTINCT_DAYS_FOR_LEARNED
+            exercises >= (total_exercises_productive_cycle)
+            and len(distinct_dates) >= total_exercises_productive_cycle
         ):
             correct_exercise = ExerciseRule(exercise_session).exercise
             correct_exercise.outcome = OutcomeRule().correct
@@ -244,8 +255,53 @@ class BookmarkTest(ModelTestMixIn):
         correct_bookmark.update_learned_status(db.session)
 
         log = SortedExerciseLog(correct_bookmark)
-        learned = is_learned_based_on_exercise_outcomes(log)
+        learned = is_learned_based_on_exercise_outcomes(log, True)
         result_time = log.last_exercise_time()
+        print("Testing is learned!")
+        assert learned
+
+        log = SortedExerciseLog(correct_bookmark)
+        learned_time_from_log = log.last_exercise_time()
+        print("Testing is learned date!")
+        assert result_time == learned_time_from_log
+
+        # A bookmark with no TOO EASY outcome or less than 5 correct exercises in a row returns False, None
+        wrong_exercise = ExerciseRule(exercise_session).exercise
+        wrong_exercise.outcome = OutcomeRule().wrong
+        random_bookmarks[3].add_new_exercise(wrong_exercise)
+
+        log = SortedExerciseLog(random_bookmarks[3])
+        learned = is_learned_based_on_exercise_outcomes(log, True)
+        print("Testing is not learned")
+        assert not learned
+
+    def test_is_learned_based_on_exercise_outcomes_receptive_not_set(self):
+
+        random_bookmarks = [BookmarkRule(self.user).bookmark for _ in range(0, 4)]
+        exercise_session = ExerciseSessionRule(self.user).exerciseSession
+        # A bookmark with CORRECTS_IN_A_ROW_FOR_LEARNED correct exercises in a row
+        # returns true and the time of the last exercise
+        total_exercises_productive_cycle = LEARNING_CYCLE_LENGTH
+        correct_bookmark = random_bookmarks[2]
+        exercises = 0
+        distinct_dates = set()
+        while not (
+            exercises >= (total_exercises_productive_cycle)
+            and len(distinct_dates) >= total_exercises_productive_cycle
+        ):
+            correct_exercise = ExerciseRule(exercise_session).exercise
+            correct_exercise.outcome = OutcomeRule().correct
+            correct_bookmark.add_new_exercise(correct_exercise)
+            exercises += 1
+            distinct_dates.add(correct_exercise.time.date())
+
+        correct_bookmark.update_learned_status(db.session)
+
+        log = SortedExerciseLog(correct_bookmark)
+        learned = is_learned_based_on_exercise_outcomes(log, False)
+        result_time = log.last_exercise_time()
+        print(log.str_most_recent_correct_dates())
+        print(learned)
         assert learned
 
         log = SortedExerciseLog(correct_bookmark)
@@ -258,7 +314,8 @@ class BookmarkTest(ModelTestMixIn):
         random_bookmarks[3].add_new_exercise(wrong_exercise)
 
         log = SortedExerciseLog(random_bookmarks[3])
-        learned = is_learned_based_on_exercise_outcomes(log)
+        learned = is_learned_based_on_exercise_outcomes(log, False)
+        print(learned)
         assert not learned
 
     def test_top_bookmarks(self):


### PR DESCRIPTION
Includes fixes for the issues:

## https://github.com/zeeguu/api/issues/159

`ExerciseOutcome.free_text_feedback` was outdated, and most of the logic was handled in the Update part of the BasicScheduler. Which means even if the flag is set to 0, the user still sees it in the exercises. 

Since this is an outdated method, we don't really use it anymore, but for completion I provided a solution that checks for the set of characters in the outcome. If it contains the "expected" outcome letters, then it's not considered other feedback.  

## https://github.com/zeeguu/api/issues/157

Whenever the user toggles the words that are scheduled to not be studied anymore they need to be deleted from the scheduler. This was not done with the new UserPreference calls and was added. This is done by checking if the bookmark has a schedule associated in `BasicSRSchedule` and deleting it from that table.

For consistency, I also set the user preference if they ever give feedback on a word - as it is synonymous to explicitly saying they don't want that word to be used anymore. 

## Other Changes:

I have also moved the correctness test to `ExerciseOutcome.is_correct` as that seems the place where we test for the outcome of an exercise, rather than a local test at the `BasicSRSchedule.update` method. 