### PR TITLE
Re-introduce user interests in the recommendations

### DIFF
--- a/zeeguu/core/elastic/elastic_query_builder.py
+++ b/zeeguu/core/elastic/elastic_query_builder.py
@@ -104,7 +104,7 @@ def build_elastic_recommender_query(
 
     bool_query_body["query"]["bool"].update({"must": must})
     bool_query_body["query"]["bool"].update({"must_not": must_not})
-    # bool_query_body["query"]["bool"].update({"should": should})
+    bool_query_body["query"]["bool"].update({"should": should})
     full_query = {
         "from": page * count,
         "size": count,


### PR DESCRIPTION
Just making this to re-enable the User Interests in case we want to test the functionality of adding user searches.

| No User Interests | With "dyr" (animal) in User Interests |
| -------- | ------- |
|![image](https://github.com/zeeguu/api/assets/17390076/dab39c88-4464-4343-93f9-e48f4a128a35) | ![image](https://github.com/zeeguu/api/assets/17390076/539b7927-7e4f-4963-8a23-0ff95f29e3da) |