### PR TITLE
Updated settings to avoid concurrency updates

### DIFF
--- a/zeeguu/api/endpoints/user.py
+++ b/zeeguu/api/endpoints/user.py
@@ -122,23 +122,15 @@ def user_settings():
     if submitted_name:
         user.name = submitted_name
 
-    submitted_native_language_code = data.get("native_language_code", None)
-    if not submitted_native_language_code:
-        submitted_native_language_code = data.get("native_language", None)
-
+    submitted_native_language_code = data.get("native_language", None)
     if submitted_native_language_code:
         user.set_native_language(submitted_native_language_code)
-
-    # deprecating the larned_language_code
-    # TR: Do we still need this?
-    submitted_learned_language_code = data.get("learned_language_code", None)
-    if not submitted_learned_language_code:
-        submitted_learned_language_code = data.get("learned_language", None)
 
     cefr_level = data.get("cefr_level", None)
     if cefr_level is None:
         return "ERROR"
 
+    submitted_learned_language_code = data.get("learned_language", None)
     if submitted_learned_language_code:
         user.set_learned_language(
             submitted_learned_language_code, cefr_level, zeeguu.core.model.db.session

--- a/zeeguu/api/endpoints/user.py
+++ b/zeeguu/api/endpoints/user.py
@@ -131,25 +131,23 @@ def user_settings():
         user.set_native_language(submitted_native_language_code)
 
     # deprecating the larned_language_code
+    # TR: Do we still need this?
     submitted_learned_language_code = data.get("learned_language_code", None)
     if not submitted_learned_language_code:
         submitted_learned_language_code = data.get("learned_language", None)
 
+    cefr_level = data.get("cefr_level", None)
+    if cefr_level is None:
+        return "ERROR"
+
     if submitted_learned_language_code:
         user.set_learned_language(
-            submitted_learned_language_code, zeeguu.core.model.db.session
+            submitted_learned_language_code, cefr_level, zeeguu.core.model.db.session
         )
-
-    language_level = data.get("language_level_data", None)
-    if language_level:
-        submitted_learned_language_data = json.loads(language_level)
-        for language_level in submitted_learned_language_data:
-            user.set_learned_language_level(
-                language_level[0], language_level[1], zeeguu.core.model.db.session
-            )
 
     submitted_email = data.get("email", None)
     if submitted_email:
+        print("Updating email!")
         user.email = submitted_email
 
     zeeguu.core.model.db.session.add(user)

--- a/zeeguu/api/endpoints/user.py
+++ b/zeeguu/api/endpoints/user.py
@@ -112,13 +112,12 @@ def get_user_details():
 def user_settings():
     """
     set the native language of the user in session
-    :param language_code:
     :return: OK for success
     """
 
     data = flask.request.form
-    print(flask.request)
     user = User.find_by_id(flask.g.user_id)
+
     submitted_name = data.get("name", None)
     if submitted_name:
         user.name = submitted_name

--- a/zeeguu/api/endpoints/user.py
+++ b/zeeguu/api/endpoints/user.py
@@ -147,7 +147,6 @@ def user_settings():
 
     submitted_email = data.get("email", None)
     if submitted_email:
-        print("Updating email!")
         user.email = submitted_email
 
     zeeguu.core.model.db.session.add(user)

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -171,7 +171,7 @@ class User(db.Model):
     def set_native_language(self, code):
         self.native_language = Language.find(code)
 
-    def set_learned_language(self, language_code, session=None):
+    def set_learned_language(self, language_code: str, cefr_level: int, session=None):
         self.learned_language = Language.find(language_code)
 
         from zeeguu.core.model import UserLanguage
@@ -191,16 +191,19 @@ class User(db.Model):
         language = UserLanguage.find_or_create(session, self, self.learned_language)
         language.reading_news = True
         language.doing_exercises = True
+        language.cefr_level = cefr_level
 
         if session:
             session.add(language)
 
-    def set_learned_language_level(self, language_code: str, level: str, session=None):
+    def set_learned_language_level(
+        self, language_code: str, cefr_level: str, session=None
+    ):
         learned_language = Language.find_or_create(language_code)
         from zeeguu.core.model import UserLanguage
 
         language = UserLanguage.find_or_create(session, self, learned_language)
-        language.cefr_level = int(level)
+        language.cefr_level = int(cefr_level)
         if session:
             session.add(language)
 

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -171,7 +171,9 @@ class User(db.Model):
     def set_native_language(self, code):
         self.native_language = Language.find(code)
 
-    def set_learned_language(self, language_code: str, cefr_level: int, session=None):
+    def set_learned_language(
+        self, language_code: str, cefr_level: int = None, session=None
+    ):
         self.learned_language = Language.find(language_code)
 
         from zeeguu.core.model import UserLanguage
@@ -191,10 +193,12 @@ class User(db.Model):
         language = UserLanguage.find_or_create(session, self, self.learned_language)
         language.reading_news = True
         language.doing_exercises = True
-        language.cefr_level = cefr_level
+        if cefr_level:
+            language.cefr_level = cefr_level
 
         if session:
             session.add(language)
+            
 
     def set_learned_language_level(
         self, language_code: str, cefr_level: str, session=None

--- a/zeeguu/core/test/test_language.py
+++ b/zeeguu/core/test/test_language.py
@@ -36,10 +36,21 @@ class LanguageTest(ModelTestMixIn, TestCase):
             assert LanguageRule.get_or_create_language(lan)
 
     def test_user_set_language(self):
-        language_should_be = LanguageRule().random
+        from zeeguu.core.model import UserLanguage
 
-        self.user.set_learned_language(language_should_be.code, db_session)
-        assert self.user.learned_language.id == language_should_be.id
+        language_should_be = LanguageRule().random
+        language_level_should_be = 2
+        self.user.set_learned_language(
+            language_should_be.code, language_level_should_be, db_session
+        )
+        db_session.commit()
+        user_language = UserLanguage.find_or_create(
+            db_session, self.user, language_should_be
+        )
+        assert (
+            self.user.learned_language.id == language_should_be.id
+            and user_language.cefr_level == language_level_should_be
+        )
 
     def test_native_language(self):
         language_should_be = LanguageRule().random


### PR DESCRIPTION
Changes to avoid conflicts when a user changes to a new language in the front-end settings. 

The issue involves changing to a language that the user has not studied and it can reliably cause a concurrency issue in the backend which also causes a failure at the front end.

To solve this, I made that whenever the endpoint is called from the frontend - all the updates are made in the same session and then committed, avoiding the concurrency. 

## Implementation:

- Removed code that is not used anymore related to language_level_data.
- Whenever we call user.set_learned_language, we now can pass the cefr_level, to ensure the object is updated with the right level.
- Update test to also check for cefr_level when it's updated

## Depends on:

https://github.com/zeeguu/web/pull/406