### PR TITLE
Fix Politikens Feed

### DIFF
--- a/tools/migrations/24-08-15--fix_politikens_titles.sql
+++ b/tools/migrations/24-08-15--fix_politikens_titles.sql
@@ -1,0 +1,23 @@
+UPDATE
+    article
+SET
+    title = REPLACE(title, "Ã¥", "å")
+WHERE
+    title like '%Ã¥%'
+    AND feed_id = 136;
+
+UPDATE
+    article
+SET
+    title = REPLACE(title, "Ã¸", "ø")
+WHERE
+    title like '%Ã¸%'
+    AND feed_id = 136;
+
+UPDATE
+    article
+SET
+    title = REPLACE(title, "Ã¦", "æ")
+WHERE
+    title like '%Ã¦%'
+    AND feed_id = 136;

--- a/zeeguu/core/content_retriever/article_downloader.py
+++ b/zeeguu/core/content_retriever/article_downloader.py
@@ -158,6 +158,11 @@ def download_from_feed(
                 url,
                 crawl_report,
             )
+            # Politiken sometimes has titles that have
+            # strange characters instead of å æ ø
+            if feed.id == 136:
+                new_article.title = new_article.title.replace("Ã¥","å").replace("Ã¸", "ø").replace("Ã¦", "æ")
+
             downloaded += 1
             if save_in_elastic and not new_article.broken:
                 if new_article:


### PR DESCRIPTION
Sometimes politikens feed will encode danish characters with strange characters, it only happens in the title which gets displayed in the home page for the users.

Difficult to test, as it only happens occasionally.

Would this be fine? I made the change just specifically for the feed with issues so it doesn't affect anything else. 