### PR TITLE
Passes consecutive_correct_answers to frontend

### DIFF
--- a/zeeguu/core/model/bookmark.py
+++ b/zeeguu/core/model/bookmark.py
@@ -254,6 +254,7 @@ class Bookmark(db.Model):
             is_last_in_cycle=cooling_interval == MAX_INTERVAL_8_DAY // ONE_DAY,
             can_update_schedule=can_update_schedule,
             user_preference=self.user_preference,
+            consecutive_correct_answers=basic_sr_schedule.consecutive_correct_answers,
         )
 
         if self.text.article:


### PR DESCRIPTION
This pr introduces updates to the API to support new difficulty levels based on memory retrieval concepts of recognition and recall. It passes `consecutive_correct_answers` to the frontend, which is used for assigning exercises to a bookmark.