### PR TITLE
Check for quality before performing clean-up

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,12 @@ def ntlk_install_packages():
     # when API is run with mod_wsgi from container
     if os.path.exists("/var/www") and os.access("/var/www", os.W_OK):
         nltk.download("punkt", download_dir="/var/www/nltk_data/")
+        nltk.download("punkt_tab", download_dir="/var/www/nltk_data/")
         nltk.download("averaged_perceptron_tagger", download_dir="/var/www/nltk_data/")
     else:
         print("Downloading nltk packages...")
         nltk.download("punkt")
+        nltk.download("punkt_tab")
         nltk.download("averaged_perceptron_tagger")
 
 

--- a/zeeguu/core/content_retriever/__init__.py
+++ b/zeeguu/core/content_retriever/__init__.py
@@ -10,7 +10,7 @@ def download_and_parse(url):
     return np_article
 
 
-def download_with_reability(url):
+def readability_download_and_parse(url):
     from .parse_with_readability_server import download_and_parse as _download_and_parse
 
     np_article = _download_and_parse(url)

--- a/zeeguu/core/content_retriever/__init__.py
+++ b/zeeguu/core/content_retriever/__init__.py
@@ -1,4 +1,4 @@
-from zeeguu.core.content_cleaning import cleanup_text, cleanup_text_w_crawl_report
+from zeeguu.core.content_cleaning import cleanup_text
 
 
 def download_and_parse(url):
@@ -10,12 +10,9 @@ def download_and_parse(url):
     return np_article
 
 
-def download_and_parse_with_remove_sents(url, crawl_report, feed):
+def download_with_reability(url):
     from .parse_with_readability_server import download_and_parse as _download_and_parse
 
     np_article = _download_and_parse(url)
-    np_article.text = cleanup_text_w_crawl_report(
-        np_article.text, crawl_report, feed, url
-    )
 
     return np_article

--- a/zeeguu/core/content_retriever/article_downloader.py
+++ b/zeeguu/core/content_retriever/article_downloader.py
@@ -162,7 +162,11 @@ def download_from_feed(
             # Politiken sometimes has titles that have
             # strange characters instead of å æ ø
             if feed.id == 136:
-                new_article.title = new_article.title.replace("Ã¥","å").replace("Ã¸", "ø").replace("Ã¦", "æ")
+                new_article.title = (
+                    new_article.title.replace("Ã¥", "å")
+                    .replace("Ã¸", "ø")
+                    .replace("Ã¦", "æ")
+                )
 
             downloaded += 1
             if save_in_elastic and not new_article.broken:
@@ -246,10 +250,11 @@ def download_feed_item(session, feed, feed_item, url, crawl_report):
         raise SkippedAlreadyInDB()
 
     np_article = readability_download_and_parse(url)
-    is_quality_article, reason, code = sufficient_quality(np_article)    
-    np_article.text = cleanup_text_w_crawl_report(
-        np_article.text, crawl_report, feed, url
-    )
+    is_quality_article, reason, code = sufficient_quality(np_article)
+    if is_quality_article:
+        np_article.text = cleanup_text_w_crawl_report(
+            np_article.text, crawl_report, feed, url
+        )
 
     summary = feed_item["summary"]
     # however, this is not so easy... there have been cases where

--- a/zeeguu/core/content_retriever/article_downloader.py
+++ b/zeeguu/core/content_retriever/article_downloader.py
@@ -246,7 +246,7 @@ def download_feed_item(session, feed, feed_item, url, crawl_report):
         raise SkippedAlreadyInDB()
 
     np_article = readability_download_and_parse(url)
-    is_quality_article, reason, code = sufficient_quality(np_article, feed.language.code)    
+    is_quality_article, reason, code = sufficient_quality(np_article)    
     np_article.text = cleanup_text_w_crawl_report(
         np_article.text, crawl_report, feed, url
     )

--- a/zeeguu/core/content_retriever/article_downloader.py
+++ b/zeeguu/core/content_retriever/article_downloader.py
@@ -27,7 +27,7 @@ from sentry_sdk import capture_exception as capture_to_sentry
 from zeeguu.core.elastic.indexing import index_in_elasticsearch
 
 from zeeguu.core.content_retriever import (
-    download_with_reability,
+    readability_download_and_parse,
 )
 
 TIMEOUT_SECONDS = 10
@@ -245,7 +245,7 @@ def download_feed_item(session, feed, feed_item, url, crawl_report):
     if art:
         raise SkippedAlreadyInDB()
 
-    np_article = download_with_reability(url)
+    np_article = readability_download_and_parse(url)
     is_quality_article, reason, code = sufficient_quality(np_article, feed.language.code)    
     np_article.text = cleanup_text_w_crawl_report(
         np_article.text, crawl_report, feed, url

--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -281,7 +281,7 @@ class Article(db.Model):
         from zeeguu.core.model.article_broken_code_map import ArticleBrokenMap
 
         article_broken_map = ArticleBrokenMap.find_or_create(session, self, broken_code)
-        self.broken = BROKEN_ARTICLE_QUALITY
+        self.broken = MARKED_BROKEN_DUE_TO_LOW_QUALITY
         session.add(article_broken_map)
         session.add(self)
         session.commit()
@@ -301,7 +301,7 @@ class Article(db.Model):
         session.add(ua)
 
     def mark_as_low_quality_and_remove_from_index(self):
-        self.broken = BROKEN_ARTICLE_QUALITY
+        self.broken = MARKED_BROKEN_DUE_TO_LOW_QUALITY
         # if it was in ES, we delete it
         from zeeguu.core.elastic.indexing import remove_from_index
 

--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -22,6 +22,7 @@ article_topic_map = Table(
 )
 
 MAX_CHAR_COUNT_IN_SUMMARY = 300
+MARKED_BROKEN_DUE_TO_LOW_QUALITY = 100
 
 HTML_TAG_CLEANR = re.compile("<[^>]*>")
 
@@ -280,7 +281,7 @@ class Article(db.Model):
         from zeeguu.core.model.article_broken_code_map import ArticleBrokenMap
 
         article_broken_map = ArticleBrokenMap.find_or_create(session, self, broken_code)
-        self.broken = True
+        self.broken = BROKEN_ARTICLE_QUALITY
         session.add(article_broken_map)
         session.add(self)
         session.commit()
@@ -300,7 +301,7 @@ class Article(db.Model):
         session.add(ua)
 
     def mark_as_low_quality_and_remove_from_index(self):
-        self.broken = 100
+        self.broken = BROKEN_ARTICLE_QUALITY
         # if it was in ES, we delete it
         from zeeguu.core.elastic.indexing import remove_from_index
 

--- a/zeeguu/core/model/bookmark.py
+++ b/zeeguu/core/model/bookmark.py
@@ -254,6 +254,7 @@ class Bookmark(db.Model):
             is_last_in_cycle=cooling_interval == MAX_INTERVAL_8_DAY // ONE_DAY,
             can_update_schedule=can_update_schedule,
             user_preference=self.user_preference,
+            consecutive_correct_answers=basic_sr_schedule.consecutive_correct_answers,
         )
 
         if self.text.article:


### PR DESCRIPTION
This is the lines I think were the culprit.

If you look at the old `download_and_parse_with_remove_sents` the text would be stripped of all the repeating patterns that were used to distinguish if they are "paywalled" or not. 

To fix this, I renamed the method to reflect that we download and parse with readability, and then we text for the quality of the text before removing any patterns. 

One thing that I am not sure, is that now that we are storing the broken articles, should we then set the text to be what it was before the clean-up (in case we want to retrain the model later) or should we leave the clean text?

