### PR TITLE
fix of subscribe to search - an open issue in the web #459

### DIFF
--- a/zeeguu/core/model/search.py
+++ b/zeeguu/core/model/search.py
@@ -43,13 +43,10 @@ class Search(db.Model):
 
     @classmethod
     def find_or_create(cls, session, keywords):
-        try:
-            return cls.query.filter(cls.keywords == keywords).one()
-        except sqlalchemy.orm.exc.NoResultFound:
-            new = cls(keywords)
-            session.add(new)
-            session.commit()
-            return new
+        new = cls(keywords)
+        session.add(new)
+        session.commit()
+        return new
 
     @classmethod
     def find(cls, keywords):


### PR DESCRIPTION
With the last changes, we made sure no duplications were added to search (after discussion with Mircea). But I do think duplications is necessary. The users can both add the same search subscription, but the issue is when removing the subscription again. Because there should then be two objects, where each user can delete "their own". But not having duplications results in only one object in the database, and neither/only one can remove the search.


This is a fix of an open issue in the web, https://github.com/zeeguu/web/issues/459.