### PR TITLE
198 students invisible when joining second classroom

### DIFF
--- a/tools/migrations/24-08-30--user_cohort_map.sql
+++ b/tools/migrations/24-08-30--user_cohort_map.sql
@@ -1,0 +1,27 @@
+CREATE TABLE `zeeguu_test`.`user_cohort_map` (
+    `user_id` INT NOT NULL,
+    `cohort_id` INT NOT NULL,
+    PRIMARY KEY (`user_id`, `cohort_id`),
+    INDEX `cohort_id_ibfk_1_idx` (`user_id` ASC) VISIBLE,
+    CONSTRAINT `user_cohort_map_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `zeeguu_test`.`user` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+    CONSTRAINT `user_cohort_map_ibfk_2` FOREIGN KEY (`cohort_id`) REFERENCES `zeeguu_test`.`cohort` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+);
+
+INSERT INTO
+    user_cohort_map (user_id, cohort_id)
+SELECT
+    id,
+    cohort_id
+from
+    user
+WHERE
+    cohort_id is not null;
+
+ALTER TABLE
+    `zeeguu_test`.`user` DROP FOREIGN KEY `user_ibfk_3`;
+
+ALTER TABLE
+    `zeeguu_test`.`user` DROP COLUMN `cohort_id`,
+    DROP INDEX `cohort_id`;
+
+;

--- a/zeeguu/api/endpoints/feature_toggles.py
+++ b/zeeguu/api/endpoints/feature_toggles.py
@@ -64,16 +64,16 @@ def _merle_exercises(user):
 
 
 def _no_audio_exercises(user):
-    return user.cohort and user.cohort.id == 447
+    return user.is_member_of_cohort(447)
 
 
 def _audio_exercises(user):
-    return user.cohort and user.cohort.id == 444
+    return user.is_member_of_cohort(444)
 
 
 def _extension_experiment_1(user):
     return (
-        (user.cohort and user.cohort.id == 437)
+        (user.is_member_of_cohort(437))
         or user.id in [3372, 3373, 2953, 3427, 2705]
         or user.id > 3555
     )

--- a/zeeguu/api/endpoints/student.py
+++ b/zeeguu/api/endpoints/student.py
@@ -30,6 +30,7 @@ def join_cohort_api():
         from sentry_sdk import capture_exception
 
         capture_exception(e)
+        print(e)
         flask.abort(500)
 
 
@@ -38,7 +39,7 @@ def join_cohort_api():
 @requires_session
 def student_info():
     user = User.find_by_id(flask.g.user_id)
-    user_cohorts = [] + [c.id for c in user.cohorts]
+    user_cohorts = [c.cohort.get_cohort_info() for c in user.cohorts]
     return json_result(
         {
             "name": user.name,

--- a/zeeguu/api/endpoints/student.py
+++ b/zeeguu/api/endpoints/student.py
@@ -22,9 +22,7 @@ def join_cohort_api():
     try:
         cohort = Cohort.find_by_code(invite_code)
         user = User.find_by_id(flask.g.user_id)
-        user.cohort_id = cohort.id
-        db_session.add(user)
-        db_session.commit()
+        user.add_user_to_cohort(cohort, db_session)
 
         return "OK"
 
@@ -40,11 +38,12 @@ def join_cohort_api():
 @requires_session
 def student_info():
     user = User.find_by_id(flask.g.user_id)
+    user_cohorts = [] + [c.id for c in user.cohorts]
     return json_result(
         {
             "name": user.name,
             "email": user.email,
-            "cohort_id": user.cohort_id,
+            "cohorts": user_cohorts,
         }
     )
 

--- a/zeeguu/api/endpoints/student.py
+++ b/zeeguu/api/endpoints/student.py
@@ -30,7 +30,6 @@ def join_cohort_api():
         from sentry_sdk import capture_exception
 
         capture_exception(e)
-        print(e)
         flask.abort(500)
 
 

--- a/zeeguu/api/endpoints/teacher_dashboard/_common_api_parameters.py
+++ b/zeeguu/api/endpoints/teacher_dashboard/_common_api_parameters.py
@@ -3,8 +3,11 @@ from datetime import timedelta, datetime
 import flask
 from sqlalchemy.orm.exc import NoResultFound
 
-from zeeguu.api.endpoints.teacher_dashboard._permissions import check_permission_for_user
-from zeeguu.core.model import User, Cohort
+from zeeguu.api.endpoints.teacher_dashboard._permissions import (
+    check_permission_for_user,
+)
+from zeeguu.core.model.user import User
+from zeeguu.core.model.cohort import Cohort
 from zeeguu.core.sql.query_building import date_format, datetime_format
 
 
@@ -35,7 +38,7 @@ def _get_student_cohort_and_period_from_POST_params(
     except NoResultFound:
         flask.abort(400)
 
-    check_permission_for_user(user.id)
+    check_permission_for_user(user.id, cohort.id)
 
     from_date, to_date = _convert_number_of_days_to_date_interval(
         number_of_days, to_string

--- a/zeeguu/api/endpoints/teacher_dashboard/_permissions.py
+++ b/zeeguu/api/endpoints/teacher_dashboard/_permissions.py
@@ -23,18 +23,12 @@ def check_permission_for_cohort(cohort_id):
         flask.abort(401)
 
 
-def _abort_if_no_permission_for_user(user_id):
-    # TODO: optimize this to only use one query
-    user = User.query.filter_by(id=user_id).one()
-    check_permission_for_cohort(user.cohort_id)
-
-
-def check_permission_for_user(id):
+def check_permission_for_user(user_id, cohort_id):
     try:
-        user = User.query.filter_by(id=id).one()
-        if not has_permission_for_cohort(user.cohort_id):
-            flask.abort(401)
-        return user
+        user = User.query.filter_by(id=user_id).one()
+        if user.is_member_of_cohort(cohort_id):
+            return user
+        flask.abort(401)
     except KeyError:
         flask.abort(400)
         return "KeyError"

--- a/zeeguu/api/endpoints/teacher_dashboard/cohorts.py
+++ b/zeeguu/api/endpoints/teacher_dashboard/cohorts.py
@@ -238,15 +238,17 @@ def add_colleague_to_cohort():
     return "OK"
 
 
-@api.route("/remove_user_from_cohort/<user_id>", methods=["GET"])
+@api.route("/remove_user_from_cohort/<user_id>/<cohort_id>", methods=["GET"])
 @requires_session
 @only_teachers
-def remove_user_from_cohort(user_id):
-    check_permission_for_user(user_id)
-
-    u = User.find_by_id(user_id)
-    u.cohorts = []
-    db.session.add(u)
-    db.session.commit()
-
-    return "OK"
+def remove_user_from_cohort(user_id, cohort_id):
+    try:
+        check_permission_for_user(user_id, cohort_id)
+        u = User.find_by_id(user_id)
+        u.remove_from_cohort(cohort_id)
+        db.session.add(u)
+        db.session.commit()
+        return "OK"
+    except Exception as e:
+        print(e)
+        return "FAIL"

--- a/zeeguu/api/endpoints/teacher_dashboard/cohorts.py
+++ b/zeeguu/api/endpoints/teacher_dashboard/cohorts.py
@@ -47,7 +47,7 @@ def remove_cohort(cohort_id):
         selected_cohort = Cohort.query.filter_by(id=cohort_id).one()
 
         for student in selected_cohort.get_students():
-            student.cohort_id = None
+            student.cohorts = []
             db.session.add(student)
 
         links = TeacherCohortMap.query.filter_by(cohort_id=cohort_id).all()
@@ -245,7 +245,7 @@ def remove_user_from_cohort(user_id):
     check_permission_for_user(user_id)
 
     u = User.find_by_id(user_id)
-    u.cohort_id = None
+    u.cohorts = []
     db.session.add(u)
     db.session.commit()
 

--- a/zeeguu/api/endpoints/teacher_dashboard/helpers.py
+++ b/zeeguu/api/endpoints/teacher_dashboard/helpers.py
@@ -32,8 +32,10 @@ def all_user_info_from_cohort(id, from_date: str, to_date: str):
     """
     Takes id for a cohort and returns all users belonging to that cohort.
     """
+    from zeeguu.core.model.user_cohort_map import UserCohortMap
+
     c = Cohort.query.filter_by(id=id).one()
-    users = User.query.filter_by(cohort_id=c.id).all()
+    users = User.query.join(UserCohortMap).filter_by(cohort_id=c.id).all()
     users_info = []
 
     for u in users:

--- a/zeeguu/api/endpoints/teacher_dashboard/student.py
+++ b/zeeguu/api/endpoints/teacher_dashboard/student.py
@@ -26,13 +26,14 @@ from zeeguu.core.model import db
 @api.route("/basic_user_info/<id>", methods=["GET"])
 @requires_session
 def basic_user_info(id):
+    # This method doesn't seem to be used by the frontend
     user = check_permission_for_user(id)
 
     return jsonify(
         {
             "name": user.name,
             "email": user.email,
-            "cohort_ids": [uc.id for uc in user.cohorts],
+            "cohorts": [uc.cohort.get_cohort_info() for uc in user.cohorts],
         }
     )
 

--- a/zeeguu/api/endpoints/teacher_dashboard/student.py
+++ b/zeeguu/api/endpoints/teacher_dashboard/student.py
@@ -29,7 +29,11 @@ def basic_user_info(id):
     user = check_permission_for_user(id)
 
     return jsonify(
-        {"name": user.name, "email": user.email, "cohort_id": user.cohort_id}
+        {
+            "name": user.name,
+            "email": user.email,
+            "cohort_ids": [uc.id for uc in user.cohorts],
+        }
     )
 
 
@@ -37,7 +41,7 @@ def basic_user_info(id):
 @requires_session
 def user_info_api():
     user, cohort, from_date, to_date = _get_student_cohort_and_period_from_POST_params()
-    check_permission_for_user(user.id)
+    check_permission_for_user(user.id, cohort.id)
 
     return jsonify(student_info_for_teacher_dashboard(user, cohort, from_date, to_date))
 

--- a/zeeguu/api/endpoints/user.py
+++ b/zeeguu/api/endpoints/user.py
@@ -8,7 +8,7 @@ from zeeguu.core.model import User
 from zeeguu.api.utils.json_result import json_result
 from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
 from . import api
-from ...core.model import UserPreference, UserActivityData, UserArticle, Article
+from ...core.model import UserActivityData, UserArticle, Article
 
 
 @api.route("/learned_language", methods=["GET"])
@@ -88,17 +88,22 @@ def learned_and_native_language():
     res = dict(native=user.native_language_id, learned=user.learned_language_id)
     return json_result(res)
 
+
 @api.route("/get_unfinished_user_reading_sessions", methods=("GET",))
-@api.route("/get_unfinished_user_reading_sessions/<int:total_sessions>", methods=("GET",))
+@api.route(
+    "/get_unfinished_user_reading_sessions/<int:total_sessions>", methods=("GET",)
+)
 @cross_domain
 @requires_session
-def get_user_unfinished_reading_sessions(total_sessions:int=1):
+def get_user_unfinished_reading_sessions(total_sessions: int = 1):
     """
-        Retrieves the last uncompleted sessions based on the SCROLL events of the user.
+    Retrieves the last uncompleted sessions based on the SCROLL events of the user.
 
     """
     user = User.find_by_id(flask.g.user_id)
-    last_sessions = UserActivityData.get_scroll_events_for_user_in_date_range(user, limit=total_sessions)
+    last_sessions = UserActivityData.get_scroll_events_for_user_in_date_range(
+        user, limit=total_sessions
+    )
     list_result = []
     for s in last_sessions:
         art_id, date_str, viewport_settings, last_reading_point = s
@@ -113,7 +118,7 @@ def get_user_unfinished_reading_sessions(total_sessions:int=1):
             # art_info["pixel_to_scroll_to"] = (scrollHeight - clientHeight - bottomRowHeight) * (last_reading_point)
             art_info["time_until_last_read"] = date_str
             # Give a tolerance based on the viewPort to scroll a bit before the maximum point.
-            tolerance = ((clientHeight/((scrollHeight-bottomRowHeight))/4))
+            tolerance = clientHeight / ((scrollHeight - bottomRowHeight)) / 4
             last_reading_percentage = last_reading_point - tolerance
             if last_reading_percentage <= 0:
                 continue
@@ -121,6 +126,7 @@ def get_user_unfinished_reading_sessions(total_sessions:int=1):
             list_result.append(art_info)
 
     return json_result(list_result)
+
 
 @api.route("/get_user_details", methods=("GET",))
 @cross_domain
@@ -192,3 +198,24 @@ def send_feedback():
     user = User.find_by_id(flask.g.user_id)
     ZeeguuMailer.send_feedback("Feedback", context, message, user)
     return "OK"
+
+
+@api.route("/leave_cohort/<cohort_id>", methods=["GET"])
+@cross_domain
+@requires_session
+def leave_cohort(cohort_id):
+    from zeeguu.core.model import db
+
+    """
+    set the native language of the user in session
+    :return: OK for success
+    """
+    try:
+        user = User.find_by_id(flask.g.user_id)
+        user.remove_from_cohort(cohort_id)
+        db.session.add(user)
+        db.session.commit()
+        return "OK"
+    except Exception as e:
+        print(e)
+        return "FAIL"

--- a/zeeguu/api/endpoints/user.py
+++ b/zeeguu/api/endpoints/user.py
@@ -150,7 +150,6 @@ def get_user_details():
 @requires_session
 def user_settings():
     """
-    set the native language of the user in session
     :return: OK for success
     """
 
@@ -212,9 +211,7 @@ def leave_cohort(cohort_id):
     """
     try:
         user = User.find_by_id(flask.g.user_id)
-        user.remove_from_cohort(cohort_id)
-        db.session.add(user)
-        db.session.commit()
+        user.remove_from_cohort(cohort_id, db.session)
         return "OK"
     except Exception as e:
         print(e)

--- a/zeeguu/core/account_management/user_account_creation.py
+++ b/zeeguu/core/account_management/user_account_creation.py
@@ -57,12 +57,12 @@ def create_account(
             username,
             password,
             invitation_code=invite_code,
-            cohort=cohort,
             learned_language=learned_language,
             native_language=native_language,
         )
-
         db_session.add(new_user)
+        if cohort_name != "":
+            new_user.add_user_to_cohort(cohort, db_session)
         new_user.create_default_user_preference()
         learned_language = UserLanguage.find_or_create(
             db_session, new_user, learned_language

--- a/zeeguu/core/language/strategies/flesch_kincaid_difficulty_estimator.py
+++ b/zeeguu/core/language/strategies/flesch_kincaid_difficulty_estimator.py
@@ -6,7 +6,7 @@ from zeeguu.core.language.difficulty_estimator_strategy import (
     DifficultyEstimatorStrategy,
 )
 from zeeguu.core.util.text import split_words_from_text
-from zeeguu.core.model import Language
+from zeeguu.core.model.language import Language
 from collections import Counter
 
 

--- a/zeeguu/core/model/__init__.py
+++ b/zeeguu/core/model/__init__.py
@@ -24,18 +24,21 @@ import zeeguu
 
 
 # the core model
+from .user_cohort_map import UserCohortMap
 from .language import Language
 from .url import Url
 from .domain_name import DomainName
 from .article import Article
 from .bookmark import Bookmark
 from .text import Text
-from .user import User
 from .user_word import UserWord
 from .user_preference import UserPreference
 from .session import Session
 from .unique_code import UniqueCode
 from .article_broken_code_map import ArticleBrokenMap, LowQualityTypes
+
+from .user import User
+from .cohort import Cohort
 
 from .user_language import UserLanguage
 
@@ -63,13 +66,15 @@ from .exercise_source import ExerciseSource
 from .user_activitiy_data import UserActivityData
 
 # teachers and cohorts
-from .cohort import Cohort
+
+
 from .teacher_cohort_map import TeacherCohortMap
 from .teacher import Teacher
 from .cohort_article_map import CohortArticleMap
 
 from .user_reading_session import UserReadingSession
 from .user_exercise_session import UserExerciseSession
+
 
 # bookmark scheduling
 from .word_to_study import WordToStudy

--- a/zeeguu/core/model/cohort.py
+++ b/zeeguu/core/model/cohort.py
@@ -73,6 +73,13 @@ class Cohort(db.Model):
 
         return TeacherCohortMap.get_teachers_for(self)
 
+    def get_cohort_info(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "language_id": self.language_id,
+        }
+
     @classmethod
     def find(cls, id):
         return cls.query.filter_by(id=id).one()

--- a/zeeguu/core/model/cohort.py
+++ b/zeeguu/core/model/cohort.py
@@ -1,6 +1,7 @@
 import zeeguu.core
 from sqlalchemy import Column, Integer, Boolean
 from sqlalchemy.orm import relationship
+from sqlalchemy.sql import exists
 from zeeguu.core.model.language import Language
 
 from zeeguu.core.model import db
@@ -56,10 +57,11 @@ class Cohort(db.Model):
         if self.inv_code and len(self.inv_code) > 1:
             # adding those users that are only assigned based on
             # invitation code; this is for bacwards compatibility reasons
+            users_in_UserCohortMap = exists().where(User.id == UserCohortMap.user_id)
             users.extend(
-                User.query.filter_by(invitation_code=self.inv_code)
-                .filter(id.notin_(UserCohortMap.user_id))
-                .all()
+                User.query.filter_by(invitation_code=self.inv_code).filter(
+                    ~users_in_UserCohortMap
+                )
             )
 
         users.extend(

--- a/zeeguu/core/model/cohort.py
+++ b/zeeguu/core/model/cohort.py
@@ -19,6 +19,8 @@ class Cohort(db.Model):
     declared_level_max = Column(Integer)
     is_cohort_of_teachers = Column(Boolean)
 
+    users = relationship("UserCohortMap", back_populates="cohort")
+
     def __init__(
         self, inv_code, name, language, max_students, level_min=0, level_max=10
     ):
@@ -32,8 +34,11 @@ class Cohort(db.Model):
 
     def get_current_student_count(self):
         from zeeguu.core.model.user import User
+        from zeeguu.core.model.user_cohort_map import UserCohortMap
 
-        users_in_cohort = User.query.filter_by(cohort_id=self.id).all()
+        users_in_cohort = (
+            User.query.join(UserCohortMap).filter_by(cohort_id=self.id).all()
+        )
         return len(users_in_cohort)
 
     def cohort_still_has_capacity(self):

--- a/zeeguu/core/model/cohort.py
+++ b/zeeguu/core/model/cohort.py
@@ -50,18 +50,21 @@ class Cohort(db.Model):
 
     def get_students(self):
         from zeeguu.core.model.user import User
+        from zeeguu.core.model.user_cohort_map import UserCohortMap
 
         users = []
         if self.inv_code and len(self.inv_code) > 1:
             # adding those users that are only assigned based on
             # invitation code; this is for bacwards compatibility reasons
             users.extend(
-                User.query.filter_by(
-                    invitation_code=self.inv_code, cohort_id=None
-                ).all()
+                User.query.filter_by(invitation_code=self.inv_code)
+                .filter(id.notin_(UserCohortMap.user_id))
+                .all()
             )
 
-        users.extend(User.query.filter(User.cohort == self).all())
+        users.extend(
+            User.query.join(UserCohortMap).filter(UserCohortMap.cohort == self).all()
+        )
 
         return users
 

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -132,7 +132,6 @@ class User(db.Model):
     def details_as_dictionary(self):
         from zeeguu.core.model import UserLanguage
 
-        print()
         result = dict(
             email=self.email,
             name=self.name,
@@ -323,7 +322,6 @@ class User(db.Model):
         from zeeguu.core.model.user_cohort_map import UserCohortMap
 
         new_cohort = UserCohortMap(user=self, cohort=cohort)
-        print("New user in cohort!")
         session.add(new_cohort)
         session.commit()
 

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -332,8 +332,10 @@ class User(db.Model):
         try:
             for c in self.cohorts:
                 cohort = Cohort.find(c.cohort_id)
-                cohort_articles = CohortArticleMap.get_articles_info_for_cohort(cohort)
-                all_articles += cohort_articles
+                if cohort.language_id == self.learned_language_id:
+                    # Only add texts on the current "learning language"
+                    cohort_articles = CohortArticleMap.get_articles_info_for_cohort(cohort)
+                    all_articles += cohort_articles
             return all_articles
         except NoResultFound as e:
             return []

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -121,13 +121,15 @@ class User(db.Model):
         cohort_id = int(cohort_id)
         return any([c.cohort_id == cohort_id for c in self.cohorts])
 
-    def remove_from_cohort(self, cohort_id):
+    def remove_from_cohort(self, cohort_id, session):
         from zeeguu.core.model.user_cohort_map import UserCohortMap
 
         cohort_id = int(cohort_id)
         UserCohortMap.query.filter(UserCohortMap.user_id == self.id).filter(
             UserCohortMap.cohort_id == cohort_id
         ).delete()
+        session.add(self)
+        session.commit()
 
     def details_as_dictionary(self):
         from zeeguu.core.model import UserLanguage
@@ -334,7 +336,9 @@ class User(db.Model):
                 cohort = Cohort.find(c.cohort_id)
                 if cohort.language_id == self.learned_language_id:
                     # Only add texts on the current "learning language"
-                    cohort_articles = CohortArticleMap.get_articles_info_for_cohort(cohort)
+                    cohort_articles = CohortArticleMap.get_articles_info_for_cohort(
+                        cohort
+                    )
                     all_articles += cohort_articles
             return all_articles
         except NoResultFound as e:

--- a/zeeguu/core/model/user_cohort_map.py
+++ b/zeeguu/core/model/user_cohort_map.py
@@ -1,0 +1,14 @@
+from zeeguu.core.model import db
+from sqlalchemy import Column, ForeignKey
+from sqlalchemy.orm import relationship
+from .cohort import Cohort
+from .user import User
+
+
+class UserCohortMap(db.Model):
+    __table_args__ = {"mysql_collate": "utf8_bin"}
+    __tablename__ = "user_cohort_map"
+    user_id = Column(ForeignKey("user.id"), primary_key=True)
+    cohort_id = Column(ForeignKey("cohort.id"), primary_key=True)
+    user = relationship(User, back_populates="cohorts")
+    cohort = relationship(Cohort, back_populates="users")

--- a/zeeguu/core/model/user_exercise_session.py
+++ b/zeeguu/core/model/user_exercise_session.py
@@ -97,7 +97,13 @@ class UserExerciseSession(db.Model):
         Get exercise sessions by cohort
         return: object or None if not found
         """
-        query = cls.query.join(User).filter(User.cohort_id == cohort_id)
+        from .user_cohort_map import UserCohortMap
+
+        query = (
+            cls.query.join(User)
+            .join(UserCohortMap)
+            .filter(UserCohortMap.cohort_id == cohort_id)
+        )
         query = query.filter(cls.start_time >= from_date)
         query = query.filter(cls.start_time <= to_date)
 

--- a/zeeguu/core/model/user_preference.py
+++ b/zeeguu/core/model/user_preference.py
@@ -3,7 +3,7 @@ from sqlalchemy import Column, String
 from sqlalchemy.orm.exc import NoResultFound
 from datetime import time
 
-from zeeguu.core.model import User
+from zeeguu.core.model.user import User
 
 from zeeguu.logging import log, logp
 

--- a/zeeguu/core/model/user_reading_session.py
+++ b/zeeguu/core/model/user_reading_session.py
@@ -130,7 +130,9 @@ class UserReadingSession(db.Model):
         Get reading sessions by cohort
         return: object or None if not found
         """
-        query = cls.query.join(User).filter(User.cohort_id == cohort)
+        from .user_cohort_map import UserCohortMap
+
+        query = cls.query.join(User).join(UserCohortMap).filter(UserCohortMap.cohort_id == cohort)
         query = query.filter(UserReadingSession.start_time >= from_date)
         query = query.filter(UserReadingSession.start_time <= to_date)
 
@@ -154,8 +156,9 @@ class UserReadingSession(db.Model):
         Get reading sessions by article
         return: object or None if not found
         """
+        from .user_cohort_map import UserCohortMap
         if cohort is not None:
-            query = cls.query.join(User).filter(User.cohort_id == cohort)
+            query = cls.query.join(User).join(UserCohortMap).filter(UserCohortMap.cohort_id == cohort)
         else:
             query = cls.query
         query = query.filter(cls.article_id == article)

--- a/zeeguu/core/user_statistics/exercise_sessions.py
+++ b/zeeguu/core/user_statistics/exercise_sessions.py
@@ -3,20 +3,23 @@ from sqlalchemy import text
 import zeeguu.core
 
 from zeeguu.core.model import db
+from zeeguu.core.model.cohort import Cohort
 
 
 def total_time_in_exercise_sessions(user_id, cohort_id, start_time, end_time):
     # TODO: use also the cohort_id somehow
-    query = """
+    cohort = Cohort.find(cohort_id)
+    query = f"""
         select sum(duration)
-        
-        from 
-            user_exercise_session as ues
-        
-        where 
-            ues.start_time > :start_time
-            and ues.last_action_time < :end_time
-            and user_id = :user_id
+        from user_exercise_session as ues
+        WHERE ues.id in (SELECT e.session_id from exercise e
+                        INNER JOIN bookmark_exercise_mapping bem on e.id = bem.exercise_id
+                        INNER JOIN bookmark b ON bem.bookmark_id = b.id
+                        INNER JOIN user_word uw ON b.origin_id = uw.id
+                        WHERE uw.language_id = {cohort.language_id})
+        and ues.start_time > :start_time
+        and ues.last_action_time < :end_time
+        and ues.user_id = :user_id
     """
 
     rows = db.session.execute(

--- a/zeeguu/core/util/text.py
+++ b/zeeguu/core/util/text.py
@@ -5,7 +5,7 @@ import pyphen
 import regex
 from collections import Counter
 from nltk import SnowballStemmer
-from zeeguu.core.model import Language
+from zeeguu.core.model.language import Language
 
 AVERAGE_SYLLABLE_LENGTH = 2.5
 
@@ -15,40 +15,47 @@ AVERAGE_SYLLABLE_LENGTH = 2.5
 
 
 def split_words_from_text(text):
-    words = regex.findall(r'(\b\p{L}+\b)', text)
+    words = regex.findall(r"(\b\p{L}+\b)", text)
     return words
 
-def split_unique_words_from_text(text, language:Language):
+
+def split_unique_words_from_text(text, language: Language):
     words = split_words_from_text(text)
     stemmer = SnowballStemmer(language.name.lower())
     return set([stemmer.stem(w.lower()) for w in words])
 
+
 def length(text):
     return len(split_words_from_text(text))
+
 
 def unique_length(text, language: Language):
     words_unique = split_unique_words_from_text(text, language)
     return len(words_unique)
 
+
 def number_of_sentences(text):
     return len(nltk.sent_tokenize(text))
 
+
 def average_sentence_length(text):
-    return length(text)/number_of_sentences(text)
+    return length(text) / number_of_sentences(text)
+
 
 def median_sentence_length(text):
     sentence_lengths = [length(s) for s in nltk.sent_tokenize(text)]
     sentence_lengths = sorted(sentence_lengths)
 
-    return sentence_lengths[int(len(sentence_lengths)/2)]
+    return sentence_lengths[int(len(sentence_lengths) / 2)]
 
-def number_of_syllables(text, language:Language):
+
+def number_of_syllables(text, language: Language):
     words = [w.lower() for w in split_words_from_text(text)]
 
     number_of_syllables = 0
     for word, freq in Counter(words).items():
         if language.code == "zh-CN":
-            syllables = int(math.floor(max(len(word) / AVERAGE_SYLLABLE_LENGTH,1)))
+            syllables = int(math.floor(max(len(word) / AVERAGE_SYLLABLE_LENGTH, 1)))
         else:
             dic = pyphen.Pyphen(lang=language.code)
             syllables = len(dic.positions(word)) + 1
@@ -57,12 +64,13 @@ def number_of_syllables(text, language:Language):
 
     return number_of_syllables
 
-def average_word_length(text, language:Language):
-    return number_of_syllables(text, language)/length(text)
 
-def median_word_length(text, language:Language):
-    word_lengths = [number_of_syllables(w, language) for w in split_words_from_text(text)]
-    return word_lengths[int(len(word_lengths)/2)]
+def average_word_length(text, language: Language):
+    return number_of_syllables(text, language) / length(text)
 
 
-
+def median_word_length(text, language: Language):
+    word_lengths = [
+        number_of_syllables(w, language) for w in split_words_from_text(text)
+    ]
+    return word_lengths[int(len(word_lengths) / 2)]


### PR DESCRIPTION
Change to support the UI changes to allow multiple classrooms for one user (https://github.com/zeeguu/web/pull/526)

## Changelist

- Removed the `cohort_id` from the user table, instead a mapping table was introduced to track this relationship.
- The script first inserts all the `cohort_id` into the mapping table, so users remain in their current classrooms.
- Testing membership of users is now done by a method `is_member_of_cohort` which expects an ID and checks that mapping exists for the user.
- `basic_user_info` now sends a list of cohorts if the user is in multiple classrooms.
- Change methods to call their new equivalent, overall maintaining the same logic the end-points used to have. This mostly means that now we need to check for multiple entries and find if a specific ID is present.
- TeacherDashboard now reflects the time spent on exercises for the specific language, rather than all exercises done by a student. 

### Question:
(Before commiting @mircealungu)
- When we add/remove a user from a cohort, should we commit immediately or add it to the session and then the developer can decide when to commit the change?  