### PR TITLE
205 frontpage remains static for long

### DIFF
--- a/tools/send_subscription_emails.py
+++ b/tools/send_subscription_emails.py
@@ -38,8 +38,15 @@ def send_subscription_emails():
     user_subscriptions = {}
     for subscription in all_subscriptions:
         user = User.find_by_id(subscription.user_id)
+        # Use the same query as in the MySearches
         articles = article_search_for_user(
-            user, 2, subscription.search.keywords, page=0
+            user,
+            3,
+            subscription.search.keywords,
+            page=0,
+            use_published_priority=True,
+            use_readability_priority=True,
+            score_threshold=0,
         )
         new_articles_found = [
             article

--- a/zeeguu/api/endpoints/search.py
+++ b/zeeguu/api/endpoints/search.py
@@ -268,7 +268,7 @@ def search_for_latest_search_terms(search_terms):
     user = User.find_by_id(flask.g.user_id)
     articles = article_search_for_user(
         user,
-        5,
+        3,
         search_terms,
         page=0,
         use_published_priority=True,

--- a/zeeguu/api/endpoints/search.py
+++ b/zeeguu/api/endpoints/search.py
@@ -244,8 +244,6 @@ def search_for_search_terms(search_terms, page: int = 0):
         use_readability_priority=use_readability_priority,
     )
     article_infos = [UserArticle.user_article_info(user, a) for a in articles]
-    print("Print sending articles")
-    print(article_infos)
     return json_result(article_infos)
 
 

--- a/zeeguu/api/endpoints/search.py
+++ b/zeeguu/api/endpoints/search.py
@@ -226,7 +226,6 @@ def search_for_search_terms(search_terms, page: int = 0):
     use_readability_priority = True
 
     if request.method == "POST":
-        print(request.form)
         use_published_priority = (
             request.form.get("use_publish_priority", "false") == "true"
         )

--- a/zeeguu/api/endpoints/user_articles.py
+++ b/zeeguu/api/endpoints/user_articles.py
@@ -14,6 +14,8 @@ from . import api
 
 from flask import request
 
+MAX_ARTICLES_PER_TOPIC = 20
+
 
 # ---------------------------------------------------------------------------
 @api.route("/user_articles/recommended", methods=("GET",))
@@ -29,7 +31,7 @@ def user_articles_recommended(count: int = 20, page: int = 0):
     It prioritizes Difficulty and Recency so the users see
     new articles every day.
 
-    It also includes articles from User saved searches if they
+    It also includes articles from user's search subscriptions if they
     are relevant enough. The articles are then sorted by published date.
 
     """
@@ -73,7 +75,6 @@ def user_articles_topic_filtered():
     """
     recommendations based on filters coming from the UI
     """
-    MAX_ARTICLES_PER_TOPIC = 20
 
     topic = request.form.get("topic")
     newer_than = request.form.get("newer_than", None)

--- a/zeeguu/api/endpoints/user_articles.py
+++ b/zeeguu/api/endpoints/user_articles.py
@@ -24,7 +24,14 @@ from flask import request
 @requires_session
 def user_articles_recommended(count: int = 20, page: int = 0):
     """
-    recommendations for all languages
+    Home Page recomendation for the users.
+
+    It prioritizes Difficulty and Recency so the users see
+    new articles every day.
+
+    It also includes articles from User saved searches if they
+    are relevant enough. The articles are then sorted by published date.
+
     """
     user = User.find_by_id(flask.g.user_id)
     try:

--- a/zeeguu/core/content_recommender/elastic_recommender.py
+++ b/zeeguu/core/content_recommender/elastic_recommender.py
@@ -29,6 +29,10 @@ from zeeguu.core.util.timer_logging_decorator import time_this
 from zeeguu.core.elastic.settings import ES_CONN_STRING, ES_ZINDEX
 
 
+def filter_hits_on_score(hits, score_threshold):
+    return [h for h in hits if h["_score"] > score_threshold]
+
+
 def _prepare_user_constraints(user):
     language = user.learned_language
 
@@ -84,17 +88,25 @@ def article_recommendations_for_user(
     user,
     count,
     page=0,
-    es_scale="30d",
+    es_scale="1d",
     es_offset="1d",
     es_decay=0.6,
     es_weight=4.2,
+    score_threshold_for_search=5,
+    maximum_added_search_articles=10,
 ):
     """
+        Retrieve up to :param count + maximum_added_search_articles articles
+        which are equally distributed over all the feeds to which the :param user
+        is registered to.
 
-            Retrieve :param count articles which are equally distributed
-            over all the feeds to which the :param user is registered to.
+        The articles are prioritized based on recency and the difficulty, preferring
+        articles that are close to the users level.
 
-            Fails if no language is selected.
+        The search articles prioritize finding the searches the user has saved, so that
+        these articles are still shown even if not tagged by the topics selected.
+
+        Fails if no language is selected.
 
     :return:
 
@@ -135,29 +147,17 @@ def article_recommendations_for_user(
     final_article_mix.extend(_to_articles_from_ES_hits(hit_list))
 
     # Get articles based on Search preferences
-    print("USER SEARCHES: ", wanted_user_searches)
+    articles_from_searches = []
     for search in wanted_user_searches.split():
-        print("Adding searches for: ", search)
-        query_body = build_elastic_search_query(
-            1,
-            search,
-            topics_to_include,
-            topics_to_exclude,
-            wanted_user_searches,
-            unwanted_user_searches,
-            language,
-            upper_bounds,
-            lower_bounds,
-            es_scale,
-            es_decay,
-            es_weight,
-            page=page,
+        articles_from_searches += article_search_for_user(
+            user, 1, search, page, score_threshold=score_threshold_for_search
         )
-        res = es.search(index=ES_ZINDEX, body=query_body)
-        hit_list = res["hits"].get("hits")
-        final_article_mix.extend(_to_articles_from_ES_hits(hit_list))
 
-    articles = [a for a in final_article_mix if a is not None and not a.broken]
+    # Limit the searched added articles to a maximum of 10 extra articles.
+    articles = [
+        a for a in final_article_mix if a is not None and not a.broken
+    ] + articles_from_searches[:maximum_added_search_articles]
+
     sorted_articles = sorted(articles, key=lambda x: x.published_time, reverse=True)
 
     return sorted_articles
@@ -169,9 +169,12 @@ def article_search_for_user(
     count,
     search_terms,
     page=0,
-    es_scale="3d",
-    es_decay=0.8,
-    es_weight=4.2,
+    es_time_scale="1d",
+    es_time_offset="1d",
+    es_time_decay=0.65,
+    use_published_priority=False,
+    use_readability_priority=True,
+    score_threshold=0,
 ):
     final_article_mix = []
 
@@ -196,19 +199,24 @@ def article_search_for_user(
         language,
         upper_bounds,
         lower_bounds,
-        es_scale,
-        es_decay,
-        es_weight,
-        page=page,
+        es_time_scale,
+        es_time_offset,
+        es_time_decay,
+        page,
+        use_published_priority,
+        use_readability_priority,
     )
 
     es = Elasticsearch(ES_CONN_STRING)
     res = es.search(index=ES_ZINDEX, body=query_body)
 
     hit_list = res["hits"].get("hits")
+    if score_threshold > 0:
+        hit_list = filter_hits_on_score(hit_list, score_threshold)
     final_article_mix.extend(_to_articles_from_ES_hits(hit_list))
+    final_articles = [a for a in final_article_mix if a is not None and not a.broken]
 
-    return [a for a in final_article_mix if a is not None and not a.broken]
+    return final_articles
 
 
 def topic_filter_for_user(

--- a/zeeguu/core/content_recommender/elastic_recommender.py
+++ b/zeeguu/core/content_recommender/elastic_recommender.py
@@ -150,7 +150,13 @@ def article_recommendations_for_user(
     articles_from_searches = []
     for search in wanted_user_searches.split():
         articles_from_searches += article_search_for_user(
-            user, 1, search, page, score_threshold=score_threshold_for_search
+            user,
+            1,
+            search,
+            page,
+            score_threshold=score_threshold_for_search,
+            use_published_priority=True,
+            use_readability_priority=True,
         )
 
     # Limit the searched added articles to a maximum of 10 extra articles.

--- a/zeeguu/core/elastic/elastic_query_builder.py
+++ b/zeeguu/core/elastic/elastic_query_builder.py
@@ -178,7 +178,6 @@ def build_elastic_search_query(
     # using function scores to weight more recent results higher
     # https://github.com/elastic/elasticsearch-dsl-py/issues/608
     preferences = []
-    print("Current values: ", use_published_priority, use_readability_priority)
     if use_published_priority:
         preferences.append(
             SF(
@@ -204,8 +203,6 @@ def build_elastic_search_query(
     weighted_query = Q("function_score", query=s.query, functions=preferences)
 
     query = {"from": page * count, "size": count, "query": weighted_query.to_dict()}
-    print("Performing Search: ")
-    pprint(query)
     return query
 
 

--- a/zeeguu/core/elastic/elastic_query_builder.py
+++ b/zeeguu/core/elastic/elastic_query_builder.py
@@ -84,10 +84,10 @@ def build_elastic_recommender_query(
     if not user_topics:
         user_topics = ""
 
-    if user_topics:
-        search_string = user_topics
-        should.append(match("content", search_string))
-        should.append(match("title", search_string))
+    # if user_topics:
+    # search_string = user_topics
+    # should.append(match("content", search_string))
+    # should.append(match("title", search_string))
 
     unwanted_topics_arr = array_of_lowercase_topics(unwanted_topics)
     if len(unwanted_topics_arr) > 0:
@@ -104,7 +104,7 @@ def build_elastic_recommender_query(
 
     bool_query_body["query"]["bool"].update({"must": must})
     bool_query_body["query"]["bool"].update({"must_not": must_not})
-    bool_query_body["query"]["bool"].update({"should": should})
+    # bool_query_body["query"]["bool"].update({"should": should})
     full_query = {
         "from": page * count,
         "size": count,
@@ -178,7 +178,7 @@ def build_elastic_search_query(
         "function_score",
         query=s.query,
         functions=[
-            SF("exp", published_time={"scale": "30d", "offset": "7d", "decay": 0.9}),
+            SF("exp", published_time={"scale": "1d", "offset": "0d", "decay": 0.9}),
             SF(
                 "exp",
                 fk_difficulty={

--- a/zeeguu/core/elastic/elastic_query_builder.py
+++ b/zeeguu/core/elastic/elastic_query_builder.py
@@ -1,6 +1,7 @@
 from elasticsearch_dsl import Search, Q, SF
 from datetime import timedelta, datetime
 from zeeguu.core.model import Language
+from pprint import pprint
 
 
 def match(key, value):
@@ -28,11 +29,11 @@ def build_elastic_recommender_query(
     language,
     upper_bounds,
     lower_bounds,
-    es_scale="30d",
-    es_offset="1d",
-    es_decay=0.5,
-    es_weight=2.1,
-    page=0,
+    es_scale,
+    es_offset,
+    es_decay,
+    es_weight,
+    page,
 ):
     """
 
@@ -85,9 +86,9 @@ def build_elastic_recommender_query(
         user_topics = ""
 
     # if user_topics:
-    # search_string = user_topics
-    # should.append(match("content", search_string))
-    # should.append(match("title", search_string))
+    #     search_string = user_topics
+    #     should.append(match("content", search_string))
+    #     should.append(match("title", search_string))
 
     unwanted_topics_arr = array_of_lowercase_topics(unwanted_topics)
     if len(unwanted_topics_arr) > 0:
@@ -105,6 +106,7 @@ def build_elastic_recommender_query(
     bool_query_body["query"]["bool"].update({"must": must})
     bool_query_body["query"]["bool"].update({"must_not": must_not})
     # bool_query_body["query"]["bool"].update({"should": should})
+
     full_query = {
         "from": page * count,
         "size": count,
@@ -140,7 +142,7 @@ def build_elastic_recommender_query(
         {"functions": [recency_preference, difficulty_prefference]}
     )
     full_query["query"]["function_score"].update(bool_query_body)
-    print(full_query)
+    pprint(full_query)
     return full_query
 
 
@@ -154,10 +156,12 @@ def build_elastic_search_query(
     language,
     upper_bounds,
     lower_bounds,
-    es_scale="3d",
-    es_decay=0.8,
-    es_weight=4.2,
+    es_time_scale="1d",
+    es_time_offset="1d",
+    es_time_decay=0.65,
     page=0,
+    use_published_priority=True,
+    use_readability_priority=True,
 ):
     """
     Builds an elastic search query for search terms.
@@ -171,27 +175,37 @@ def build_elastic_search_query(
         .filter("term", language=language.name.lower())
         .exclude("match", description="pg15")
     )
-
     # using function scores to weight more recent results higher
     # https://github.com/elastic/elasticsearch-dsl-py/issues/608
-    weighted_query = Q(
-        "function_score",
-        query=s.query,
-        functions=[
-            SF("exp", published_time={"scale": "1d", "offset": "0d", "decay": 0.9}),
+    preferences = []
+    print("Current values: ", use_published_priority, use_readability_priority)
+    if use_published_priority:
+        preferences.append(
+            SF(
+                "exp",
+                published_time={
+                    "scale": es_time_scale,
+                    "offset": es_time_offset,
+                    "decay": es_time_decay,
+                },
+            ),
+        )
+    if use_readability_priority:
+        preferences.append(
             SF(
                 "exp",
                 fk_difficulty={
                     "origin": ((upper_bounds + lower_bounds) / 2),
                     "scale": 21,
-                    "decay": 0.9,
+                    "decay": 0.5,
                 },
             ),
-        ],
-    )
+        )
+    weighted_query = Q("function_score", query=s.query, functions=preferences)
 
     query = {"from": page * count, "size": count, "query": weighted_query.to_dict()}
-
+    print("Performing Search: ")
+    pprint(query)
     return query
 
 


### PR DESCRIPTION
## Changes

Re-worked the priority given to the different parameters in the query.
- In the home page, we no longer use the should query to include the user searches, but instead do a small query to find if there are any relevant new articles which are then ordered with the general topic preferences and recency filter. The home page essentially prioritizes Topic > (Recency == Difficulty Level)
- Extended the Search endpoint to allow users to fine-control their searches. The user can use the UI to specify they'd rather see more relevant content at the cost of less recent articles or difficulty. 


The UI changes are implemented in:  https://github.com/zeeguu/web/pull/530