### PR TITLE
Lower the threshold to show read articles.

### DIFF
--- a/zeeguu/api/endpoints/user.py
+++ b/zeeguu/api/endpoints/user.py
@@ -107,7 +107,7 @@ def get_user_unfinished_reading_sessions(total_sessions: int = 1):
     list_result = []
     for s in last_sessions:
         art_id, date_read, viewport_settings, last_reading_point = s
-        if last_reading_point < 100 and last_reading_point > 0:
+        if last_reading_point < 0.9 and last_reading_point > 0:
             scrollHeight = viewport_settings["scrollHeight"]
             clientHeight = viewport_settings["clientHeight"]
             bottomRowHeight = viewport_settings["bottomRowHeight"]


### PR DESCRIPTION
- I realized the units weren't correct in the check. It should be in decimals (percentage) rather than int. - I can still see that sometimes I finish an article but it's still popping up in my feed, so maybe lowering it to 0.9 might be a good idea. @mircealungu has this ever occurred to you? 