### PR TITLE
Change scheduling for bookmarks

### DIFF
--- a/zeeguu/api/endpoints/exercises.py
+++ b/zeeguu/api/endpoints/exercises.py
@@ -41,6 +41,20 @@ def top_bookmarks_to_study():
     return json_result(json_bookmarks)
 
 
+@api.route("/bookmarks_to_learn_not_scheduled", methods=["GET"])
+@cross_domain
+@requires_session
+def bookmarks_to_learn_not_scheduled():
+    """
+    Return all the bookmarks that aren't learned and haven't been
+    scheduled to the user.
+    """
+    user = User.find_by_id(flask.g.user_id)
+    to_study = user.bookmarks_to_learn_not_in_pipeline()
+    json_bookmarks = [bookmark.json_serializable_dict() for bookmark in to_study]
+    return json_result(json_bookmarks)
+
+
 @api.route("/bookmarks_in_pipeline", methods=["GET"])
 @cross_domain
 @requires_session

--- a/zeeguu/api/endpoints/exercises.py
+++ b/zeeguu/api/endpoints/exercises.py
@@ -10,10 +10,10 @@ from . import api, db_session
 from flask import request
 
 
-@api.route("/bookmarks_to_study/<bookmark_count>", methods=["GET"])
+@api.route("/scheduled_bookmarks_to_study/<bookmark_count>", methods=["GET"])
 @cross_domain
 @requires_session
-def bookmarks_to_study(bookmark_count):
+def scheduled_bookmarks_to_study(bookmark_count):
     """
     Returns a number of <bookmark_count> bookmarks that
     are in the pipeline and are due today
@@ -22,7 +22,21 @@ def bookmarks_to_study(bookmark_count):
 
     int_count = int(bookmark_count)
     user = User.find_by_id(flask.g.user_id)
-    to_study = user.bookmarks_to_study(int_count)
+    to_study = user.bookmarks_to_study(bookmark_count=int_count)
+    json_bookmarks = [bookmark.json_serializable_dict() for bookmark in to_study]
+    return json_result(json_bookmarks)
+
+
+@api.route("/top_bookmarks_to_study", methods=["GET"])
+@cross_domain
+@requires_session
+def top_bookmarks_to_study():
+    """
+    Return all the possible bookmarks a user has to study ordered by
+    how common it is in the language and how close they are to being learned.
+    """
+    user = User.find_by_id(flask.g.user_id)
+    to_study = user.bookmarks_to_study(scheduled_only=False)
     json_bookmarks = [bookmark.json_serializable_dict() for bookmark in to_study]
     return json_result(json_bookmarks)
 
@@ -53,6 +67,19 @@ def has_bookmarks_in_pipeline_to_review():
     """
     user = User.find_by_id(flask.g.user_id)
     at_least_one_bookmark_in_pipeline = user.bookmarks_to_study(1)
+    return json_result(len(at_least_one_bookmark_in_pipeline) > 0)
+
+
+@api.route("/has_bookmarks_to_review", methods=["GET"])
+@cross_domain
+@requires_session
+def has_bookmarks_to_review():
+    """
+    Checks if there is at least one bookmark that can be exercised
+    today.
+    """
+    user = User.find_by_id(flask.g.user_id)
+    at_least_one_bookmark_in_pipeline = user.bookmarks_to_study(1, scheduled_only=False)
     return json_result(len(at_least_one_bookmark_in_pipeline) > 0)
 
 

--- a/zeeguu/core/model/bookmark.py
+++ b/zeeguu/core/model/bookmark.py
@@ -200,7 +200,7 @@ class Bookmark(db.Model):
 
         word_info = Word.stats(self.origin.word, self.origin.language.code)
 
-        learned_datetime = str(self.learned_time.date()) if self.learned else ""
+        learned_datetime = str(self.learned_time.date()) if self.learned_time is not None else ""
 
         created_day = "today" if self.time.date() == datetime.now().date() else ""
 

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -222,18 +222,22 @@ class User(db.Model):
     def has_bookmarks(self):
         return self.bookmark_count() > 0
 
-    def bookmarks_to_study(self, bookmark_count=10):
+    def bookmarks_to_study(self, bookmark_count=None, scheduled_only=True):
         """
         We now use a logic to sort the words, if we call this everytime
         we want similar words it might bottleneck the application.
 
-        :param bookmark_count: by default we recommend 10 words
+        :param bookmark_count: If None all bookmarks are returned
+        :param scheduled_only: Only use bookmarks that are scheduled
         :return:
         """
         from zeeguu.core.word_scheduling.basicSR.basicSR import BasicSRSchedule
 
-        to_study = BasicSRSchedule.priority_bookmarks_to_study(self, bookmark_count)
-        return to_study
+        if scheduled_only:
+            to_study = BasicSRSchedule.priority_scheduled_bookmarks_to_study(self)
+        else:
+            to_study = BasicSRSchedule.all_bookmarks_priority_to_study(self)
+        return to_study if bookmark_count is None else to_study[:bookmark_count]
 
     def get_new_bookmarks_to_study(self, bookmarks_count):
         from zeeguu.core.sql.queries.query_loader import load_query
@@ -690,6 +694,25 @@ class User(db.Model):
 
     def bookmark_count(self):
         return len(self.all_bookmarks())
+
+    def total_exercises_completed_today(self):
+        from zeeguu.core.model import Exercise
+        from zeeguu.core.model.bookmark import Bookmark, bookmark_exercise_mapping
+        from zeeguu.core.model import UserWord
+
+        current_date = datetime.datetime.now().date()
+        total_exercises = (
+            Exercise.query.join(bookmark_exercise_mapping)
+            .join(Bookmark)
+            .join(User)
+            .join(UserWord, UserWord.id == Bookmark.origin_id)
+            .filter(User.id == self.id)
+            .filter(Exercise.time >= current_date)
+            .filter(Bookmark.user_id == self.id)
+            .filter(UserWord.language_id == self.learned_language_id)
+            .count()
+        )
+        return total_exercises
 
     def word_count(self):
         return len(self.user_words())

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -282,11 +282,20 @@ class User(db.Model):
 
         word_for_study = BasicSRSchedule.bookmarks_to_study(self, bookmark_count)
         return word_for_study
+    
+    def bookmarks_to_learn_not_in_pipeline(self):
+        """
+        :return gets all bookmarks that are going to be shown in exercises
+        but haven't been scheduled yet.
+        """
+        from zeeguu.core.word_scheduling.basicSR.basicSR import BasicSRSchedule
+        words_not_started_learning = BasicSRSchedule.get_unscheduled_bookmarks_for_user(self)
+        return words_not_started_learning
+
 
     def bookmarks_in_pipeline(self):
         """
-        :param bookmark_count: by default we recommend 10 words
-        :return: a list of 10 words that are scheduled to be learned.
+        :return get all the bookmarks that are in the pipeline
         """
         from zeeguu.core.word_scheduling.basicSR.basicSR import BasicSRSchedule
 


### PR DESCRIPTION
- We came to the conclusion that limiting the words a user is learning might damage the user experience. To address this, we will instead just focus on using all available bookmarks and prioritize the easiest bookmarks first, and if that information is not available we take those furthest in the learning process.
- I added an extra endpoint to check the total number of exercises performed in the current day. This is currently not being used but I think it could used for the goal setting/milestones, so I will leave it in for now.
- The scheduled only method/endpoint was still left - I think we might be able to revisit this at some point where the user can decide when they schedule new words or at some point they might only want to practice words they are already studying without introducing new ones(?)

The main method to be used in the frontend will be the `top_bookmarks_to_study` which will return all the bookmarks that are available to exercise for that user. This means, either words on schedule or new words that haven't been practiced yet. These are prioritized by how often they occur in the respective language. 

