### PR TITLE
Added language_id to a search

### DIFF
--- a/tools/migrations/24-09-24--adding-language-to-search.sql
+++ b/tools/migrations/24-09-24--adding-language-to-search.sql
@@ -1,0 +1,30 @@
+ALTER TABLE
+    `zeeguu_test`.`search`
+ADD
+    COLUMN `language_id` INT NULL
+AFTER
+    `id`,
+    CHANGE COLUMN `keywords` `keywords` VARCHAR(100) NULL DEFAULT NULL,
+ADD
+    INDEX `search_ibfk_1_idx` (`language_id` ASC) VISIBLE;
+
+;
+
+ALTER TABLE
+    `zeeguu_test`.`search`
+ADD
+    CONSTRAINT `search_ibfk_1` FOREIGN KEY (`language_id`) REFERENCES `zeeguu_test`.`language` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+UPDATE
+    `zeeguu_test`.`search` s
+    INNER JOIN `zeeguu_test`.`search_subscription` ssub ON s.id = ssub.search_id
+    INNER JOIN `zeeguu_test`.`user` u on u.id = ssub.user_id
+SET
+    s.language_id = u.learned_language_id;
+
+UPDATE
+    `zeeguu_test`.`search` s
+    INNER JOIN `zeeguu_test`.`search_filter` ssub ON s.id = ssub.search_id
+    INNER JOIN `zeeguu_test`.`user` u on u.id = ssub.user_id
+SET
+    s.language_id = u.learned_language_id;

--- a/zeeguu/api/endpoints/search.py
+++ b/zeeguu/api/endpoints/search.py
@@ -46,8 +46,8 @@ def subscribe_to_search(search_terms):
              This is used to display it in the UI.
 
     """
-    search = Search.find_or_create(db_session, search_terms)
     user = User.find_by_id(flask.g.user_id)
+    search = Search.find_or_create(db_session, search_terms, user.learned_language_id)
     receive_email = False
     subscription = SearchSubscription.find_or_create(
         db_session, user, search, receive_email
@@ -133,7 +133,7 @@ def filter_search(search_terms):
     :return: the search as a dictionary
     """
     user = User.find_by_id(flask.g.user_id)
-    search = Search.find_or_create(db_session, search_terms)
+    search = Search.find_or_create(db_session, search_terms, user.learned_language_id)
     SearchFilter.find_or_create(db_session, user, search)
 
     return json_result(search.as_dictionary())
@@ -287,9 +287,8 @@ def subscribe_to_email_search(search_terms):
     """
     A user can subscribe to email updates about a search
     """
-
-    search = Search.find(search_terms)
     user = User.find_by_id(flask.g.user_id)
+    search = Search.find(search_terms, user.learned_language_id)
     receive_email = True
     subscription = SearchSubscription.update_receive_email(
         db_session, user, search, receive_email
@@ -306,9 +305,9 @@ def unsubscribe_from_email_search(search_terms):
     """
     A user can unsubscribe to email updates about a search
     """
-
-    search = Search.find(search_terms)
     user = User.find_by_id(flask.g.user_id)
+    search = Search.find(search_terms, user.learned_language_id)
+
     receive_email = False
     subscription = SearchSubscription.update_receive_email(
         db_session, user, search, receive_email

--- a/zeeguu/core/model/search_filter.py
+++ b/zeeguu/core/model/search_filter.py
@@ -7,6 +7,7 @@ import sqlalchemy
 import zeeguu.core
 
 from zeeguu.core.model import db
+from zeeguu.core.model.search import Search
 
 
 class SearchFilter(db.Model):
@@ -55,7 +56,12 @@ class SearchFilter(db.Model):
 
     @classmethod
     def all_for_user(cls, user):
-        return cls.query.filter(cls.user == user).all()
+        return (
+            cls.query.join(Search)
+            .filter(cls.user == user)
+            .filter(Search.language_id == user.learned_language_id)
+            .all()
+        )
 
     @classmethod
     def with_search_id(cls, i, user):

--- a/zeeguu/core/model/search_subscription.py
+++ b/zeeguu/core/model/search_subscription.py
@@ -6,6 +6,7 @@ import sqlalchemy
 import zeeguu.core
 
 from zeeguu.core.model import db
+from zeeguu.core.model.search import Search
 
 
 class SearchSubscription(db.Model):
@@ -65,7 +66,13 @@ class SearchSubscription(db.Model):
 
     @classmethod
     def all_for_user(cls, user):
-        return cls.query.filter(cls.user == user).all()
+
+        return (
+            cls.query.join(Search)
+            .filter(cls.user == user)
+            .filter(Search.language_id == user.learned_language_id)
+            .all()
+        )
 
     @classmethod
     def with_search_id(cls, i, user):


### PR DESCRIPTION
- With the new subscription system if a user changes languages they would still see all the keywords that aren't really relevant for that language.
- This change seeks to store the language_id that the users were learning when they performed the search and they will only be retrieved if the user has that language set as current language.

I have tested this with a few languages in my local environment and it seems OK. However, I haven't got all the searches as I did some search deletion and as such there wasn't a lot of issues running the script. 

Some situations to look out for is people subscribed / filtering the same keyword with different languages, who do we pick? Do we just delete these and they can re-add it at some point? 