### PR TITLE
Adding general invitation code

### DIFF
--- a/default_docker.cfg
+++ b/default_docker.cfg
@@ -13,7 +13,7 @@ SECRET_KEY="lalalal"
 ## sending password reset requests.
 SMTP_EMAIL = ''
 
-INVITATION_CODES=['test']
+INVITATION_CODES=['test', 'zeeguu-preview']
 
 SEND_NOTIFICATION_EMAILS=False
 

--- a/zeeguu/api/endpoints/feature_toggles.py
+++ b/zeeguu/api/endpoints/feature_toggles.py
@@ -35,6 +35,14 @@ def features_for_user(user):
     return features
 
 
+"""
+    We have a code 'zeeguu-preview' which is used to invite
+    general users and should give access to the latest feature set
+    of Zeeguu. It can be used for usability tests and can be also
+    spread by word of mouth to new participants.
+"""
+
+
 def _feature_map():
     return {
         "audio_exercises": _audio_exercises,

--- a/zeeguu/api/endpoints/feature_toggles.py
+++ b/zeeguu/api/endpoints/feature_toggles.py
@@ -58,6 +58,7 @@ def _merle_exercises(user):
         user.invitation_code == "Merle"
         or user.invitation_code == "MerleITU"
         or user.invitation_code == "PTCT"
+        or user.invitation_code == "zeeguu-preview"
         or user.id in [534, 2953, 4022, 4089, 4607]
     )
     return right_user


### PR DESCRIPTION
These "cohortless" invite codes seem to be added by using a config file, so you will have to add it in Production for it to work.

For now, I added the feature set under Merle's features (so the new exercises are available). I left a comment in the `feature_map.py` file to remember us that this invitation code is available and should be used to allow the latest features to be available. 

