### PR TITLE
Fixed FK violation, when deleting excluding searches

### DIFF
--- a/zeeguu/api/endpoints/search.py
+++ b/zeeguu/api/endpoints/search.py
@@ -155,8 +155,10 @@ def unfilter_search():
     try:
         to_delete = SearchFilter.with_search_id(search_id, user)
         db_session.delete(to_delete)
-        to_delete = Search.find_by_id(search_id)
-        db_session.delete(to_delete)
+        total_excluding = SearchFilter.get_number_of_users_excluding(search_id)
+        if total_excluding == 0:
+            search = Search.find_by_id(search_id)
+            db_session.delete(search)
         db_session.commit()
 
     except Exception as e:

--- a/zeeguu/core/model/search_filter.py
+++ b/zeeguu/core/model/search_filter.py
@@ -64,6 +64,10 @@ class SearchFilter(db.Model):
         )
 
     @classmethod
+    def get_number_of_users_excluding(cls, search_id):
+        return cls.query.filter(cls.search_id == search_id).count()
+
+    @classmethod
     def with_search_id(cls, i, user):
         return (cls.query.filter(cls.search_id == i).filter(cls.user == user)).one()
 


### PR DESCRIPTION
@igawaclawska Was testing the keyword filtering and noted that she couldn't delete the word "trump". This is the same issue we saw with the interests, but the logic wasn't updated for SearchFilters. I have done the same as in https://github.com/zeeguu/api/pull/191 for the SearchSubscriptions. 