### PR TITLE
CEFR Level shouldn't be necessary in user settings

### DIFF
--- a/zeeguu/api/endpoints/user.py
+++ b/zeeguu/api/endpoints/user.py
@@ -165,11 +165,9 @@ def user_settings():
         user.set_native_language(submitted_native_language_code)
 
     cefr_level = data.get("cefr_level", None)
-    if cefr_level is None:
-        return "ERROR"
-
     submitted_learned_language_code = data.get("learned_language", None)
-    if submitted_learned_language_code:
+
+    if submitted_learned_language_code and cefr_level:
         user.set_learned_language(
             submitted_learned_language_code, cefr_level, zeeguu.core.model.db.session
         )


### PR DESCRIPTION
- If no CEFR level is passed in the settings then the settings update to the user is not run. The reason for this was because we had issues before where if a user would switch languages the field for their level might go empty and that would cause some data corruption. Now, settings have been isolated and it's not possible to change language without setting a level. Meaning that this constraint shouldn't be in place (or at least should not require the frontend to always send the cefr_level).

### Changes:

- Instead of cancelling the user update if cefr_level isn't provided, instead no update is made to the learned_language if no cefr_level is provided.

