### PR TITLE
Fixed hanging when similar words is called

### DIFF
--- a/zeeguu/core/exercises/similar_words.py
+++ b/zeeguu/core/exercises/similar_words.py
@@ -20,10 +20,11 @@ def similar_words(word, language, user, number_of_words_to_return=2):
         candidates_filtered = remove_words_based_on_list(
             candidates_filtered, PROPER_NAMES_LIST
         )
-        candidates_filtered = [w for w in candidates_filtered if len(w) > 1]
+        # Update candidates to be based on the filtered words.
+        candidates = [w for w in candidates_filtered if len(w) > 1]
 
-    random_sample = random.sample(candidates_filtered, number_of_words_to_return)
+    random_sample = random.sample(candidates, number_of_words_to_return)
     while word in random_sample:
-        random_sample = random.sample(candidates_filtered, number_of_words_to_return)
+        random_sample = random.sample(candidates, number_of_words_to_return)
 
     return random_sample


### PR DESCRIPTION
- When introducing the filtered list, if the user has more than 10 words the method would fail since it would have an undefined variable.
- Fixed by making the final variable candidates so it matches both paths of the if statement.

@mircealungu I tested this and this seems to be the issue. When testing this change, I only called the API with an empty user so the error didn't show up - this should ensure we always have a valid word set to sample from. 