### PR TITLE
Add Error Reporting for ES Inserts + Add URL Keywords to Report

### DIFF
--- a/tools/report_generator/data_extractor.py
+++ b/tools/report_generator/data_extractor.py
@@ -59,6 +59,48 @@ class DataExtractor:
         df = pd.read_sql(query, con=self.db_connection)
         self.__add_feed_name(df, feed_df)
         return df
+    
+    def get_url_keyword_counts(self, min_count=100):
+        print("Getting URL keyword counts...")
+        # Update with values from the code.
+        query = f"""SELECT uk.id, l.name, keyword, count
+                    FROM url_keyword uk
+                    JOIN (SELECT url_keyword_id, count(*) count
+                          FROM article_url_keyword_map
+                          GROUP BY url_keyword_id) as keyword_count
+                    ON uk.id = keyword_count.url_keyword_id
+                    JOIN language l ON l.id = language_id
+                    WHERE count > {min_count}
+                    AND new_topic_id is NULL
+                    AND keyword not in (
+                                        "news",
+                                        "i",
+                                        "nyheter",
+                                        "article",
+                                        "nieuws",
+                                        "aktuell",
+                                        "artikel",
+                                        "wiadomosci",
+                                        "actualites",
+                                        "cronaca",
+                                        "nyheder",
+                                        "jan",
+                                        "feb",
+                                        "mar",
+                                        "apr",
+                                        "may",
+                                        "jun",
+                                        "jul",
+                                        "aug",
+                                        "sep",
+                                        "oct",
+                                        "nov",
+                                        "dec"
+                                        )
+                    ORDER BY count DESC;
+                """
+        df = pd.read_sql(query, con=self.db_connection)
+        return df
 
     def get_article_df_with_ids(self, feed_df, id_to_fetch: list[int]):
         print("Getting Articles with Ids...")

--- a/tools/report_generator/generate_report.py
+++ b/tools/report_generator/generate_report.py
@@ -76,9 +76,11 @@ def save_fig_params(filename):
     return rel_path
 
 
-def get_new_repeating_sents(pd_repeating_sents):
+def get_new_repeating_sents_table(pd_repeating_sents):
     return generate_html_table(pd_repeating_sents.sort_values("Count", ascending=False))
 
+def get_new_url_keywords_table(pd_url_keywords_count):
+    return generate_html_table(pd_url_keywords_count.sort_values("count", ascending=False))
 
 def get_rejected_sentences_table(total_deleted_sents):
     total_deleted_sents["Total"] = sum(total_deleted_sents.values())
@@ -570,6 +572,7 @@ def generate_html_page():
     top_subscribed_searches = data_extractor.get_top_search_subscriptions()
     top_filtered_searches = data_extractor.get_top_search_filters()
     newly_added_search_subscriptions = data_extractor.get_added_search_subscriptions()
+    pd_new_url_keywords = data_extractor.get_url_keyword_counts()
     crawl_report = CrawlReport()
     crawl_report.load_crawl_report_data(DAYS_FOR_REPORT)
     total_days_from_crawl_report = crawl_report.get_days_from_crawl_report_date()
@@ -693,6 +696,7 @@ def generate_html_page():
         """
     result += f"""
             <p><a href="#removed-articles">Removed Sents Table</a><p>
+            <p><a href="#new-url-keywords">New keywords without topics</a><p>
             <h1>Per Language Report:</h1>
             {lang_links}
             <hr />
@@ -700,10 +704,17 @@ def generate_html_page():
             <hr />
             <h1>Newly identified repeating patterns:</h1>
             <p>Sentences that occur in more than 10 articles during this weeks crawl, and were not filtered.<p>
-            {get_new_repeating_sents(pd_new_repeated_sents) if DAYS_FOR_REPORT <= 7 else "<p>Skipped due to long period.</p>"}
+            {get_new_repeating_sents_table(pd_new_repeated_sents) if DAYS_FOR_REPORT <= 7 else "<p>Skipped due to long period.</p>"}
             <h1 id="removed-articles">Removed Article Sents:</h1>
             <p>{warning_crawl_range}</p>
             {get_rejected_sentences_table(total_removed_sents)}
+        </body>
+    """
+
+    result += f"""
+            <h1 id="new-url-keywords">Newly url keywords without topics:</h1>
+            <p>URL Keywords that occur more than 100 times in articles and are not mapped to a topic. They are language unique.<p>
+            {get_new_url_keywords_table(pd_new_url_keywords) if DAYS_FOR_REPORT <= 7 else "<p>Skipped due to long period.</p>"}
         </body>
     """
 


### PR DESCRIPTION
- Improved the error reporting in the bulk inserts by printing the errors found and the total Success + Errors
- Added the URL keywords to report where any URL keywords seen more than 100 times with no Topic assigned will be shown in the table. 

Errors might have been due to the attempt to index broken articles with empty fields, which fail when adding to ES. To avoid these situations, I also filter the broken articles in the query now. I expect less errors now, but if we do we should get them printed out with some information about what was the cause. 