### PR TITLE
Improved Performance of Starting Exercises

### DIFF
--- a/zeeguu/api/endpoints/exercises.py
+++ b/zeeguu/api/endpoints/exercises.py
@@ -35,9 +35,16 @@ def top_bookmarks_to_study():
     Return all the possible bookmarks a user has to study ordered by
     how common it is in the language and how close they are to being learned.
     """
+    import time
+
+    start = time.time()
     user = User.find_by_id(flask.g.user_id)
     to_study = user.bookmarks_to_study(scheduled_only=False)
     json_bookmarks = [bookmark.json_serializable_dict() for bookmark in to_study]
+    end = time.time() - start
+    print(
+        f"### INFO: `top_bookmarks_to_study` took: {end:.4f} seconds, total: {len(json_bookmarks)}"
+    )
     return json_result(json_bookmarks)
 
 
@@ -49,9 +56,16 @@ def bookmarks_to_learn_not_scheduled():
     Return all the bookmarks that aren't learned and haven't been
     scheduled to the user.
     """
+    import time
+
+    start = time.time()
     user = User.find_by_id(flask.g.user_id)
     to_study = user.bookmarks_to_learn_not_in_pipeline()
     json_bookmarks = [bookmark.json_serializable_dict() for bookmark in to_study]
+    end = time.time() - start
+    print(
+        f"### INFO: `bookmarks_to_learn_not_scheduled` took: {end:.4f} seconds, total: {len(json_bookmarks)}"
+    )
     return json_result(json_bookmarks)
 
 

--- a/zeeguu/api/endpoints/exercises.py
+++ b/zeeguu/api/endpoints/exercises.py
@@ -35,16 +35,9 @@ def top_bookmarks_to_study():
     Return all the possible bookmarks a user has to study ordered by
     how common it is in the language and how close they are to being learned.
     """
-    import time
-
-    start = time.time()
     user = User.find_by_id(flask.g.user_id)
     to_study = user.bookmarks_to_study(scheduled_only=False)
     json_bookmarks = [bookmark.json_serializable_dict() for bookmark in to_study]
-    end = time.time() - start
-    print(
-        f"### INFO: `top_bookmarks_to_study` took: {end:.4f} seconds, total: {len(json_bookmarks)}"
-    )
     return json_result(json_bookmarks)
 
 
@@ -56,16 +49,10 @@ def bookmarks_to_learn_not_scheduled():
     Return all the bookmarks that aren't learned and haven't been
     scheduled to the user.
     """
-    import time
-
-    start = time.time()
     user = User.find_by_id(flask.g.user_id)
     to_study = user.bookmarks_to_learn_not_in_pipeline()
     json_bookmarks = [bookmark.json_serializable_dict() for bookmark in to_study]
-    end = time.time() - start
-    print(
-        f"### INFO: `bookmarks_to_learn_not_scheduled` took: {end:.4f} seconds, total: {len(json_bookmarks)}"
-    )
+
     return json_result(json_bookmarks)
 
 

--- a/zeeguu/core/model/user.py
+++ b/zeeguu/core/model/user.py
@@ -222,7 +222,7 @@ class User(db.Model):
     def has_bookmarks(self):
         return self.bookmark_count() > 0
 
-    def bookmarks_to_study(self, bookmark_count=None, scheduled_only=False):
+    def bookmarks_to_study(self, bookmark_count=100, scheduled_only=False):
         """
         We now use a logic to sort the words, if we call this everytime
         we want similar words it might bottleneck the application.
@@ -234,9 +234,13 @@ class User(db.Model):
         from zeeguu.core.word_scheduling.basicSR.basicSR import BasicSRSchedule
 
         if scheduled_only:
-            to_study = BasicSRSchedule.priority_scheduled_bookmarks_to_study(self)
+            to_study = BasicSRSchedule.priority_scheduled_bookmarks_to_study(
+                self, bookmark_count
+            )
         else:
-            to_study = BasicSRSchedule.all_bookmarks_priority_to_study(self)
+            to_study = BasicSRSchedule.all_bookmarks_priority_to_study(
+                self, bookmark_count
+            )
         return to_study if bookmark_count is None else to_study[:bookmark_count]
 
     def get_new_bookmarks_to_study(self, bookmarks_count):
@@ -291,7 +295,7 @@ class User(db.Model):
         from zeeguu.core.word_scheduling.basicSR.basicSR import BasicSRSchedule
 
         words_not_started_learning = BasicSRSchedule.get_unscheduled_bookmarks_for_user(
-            self
+            self, None
         )
         return words_not_started_learning
 

--- a/zeeguu/core/word_scheduling/basicSR/basicSR.py
+++ b/zeeguu/core/word_scheduling/basicSR/basicSR.py
@@ -259,9 +259,6 @@ class BasicSRSchedule(db.Model):
         1. Words that are most common in the language (utilizing the word rank in the db
         2. Words that are closest to being learned (indicated by `cooling_interval`, the highest the closest it is)
         """
-        import time
-
-        start = time.time()
 
         def priority_by_rank(bookmark):
             # If this is updated remember to update the order_by in
@@ -282,10 +279,6 @@ class BasicSRSchedule(db.Model):
         sorted_candidates = sorted(
             no_duplicate_bookmarks, key=lambda x: priority_by_rank(x)
         )
-        end = time.time() - start
-        print(
-            f"### INFO: `all_bookmarks_priority_to_study` took: {end:.4f} seconds, total: {len(sorted_candidates)}"
-        )
         return sorted_candidates
 
     @classmethod
@@ -301,9 +294,6 @@ class BasicSRSchedule(db.Model):
         1. Words that are closest to being learned (indicated by `cooling_interval`, the highest the closest it is)
         2. Words that are most common in the language (utilizing the word rank in the db)
         """
-        import time
-
-        start = time.time()
 
         def priority_by_cooling_interval(bookmark):
             bookmark_info = bookmark.json_serializable_dict()
@@ -319,10 +309,6 @@ class BasicSRSchedule(db.Model):
 
         sorted_candidates = sorted(
             no_duplicate_bookmarks, key=lambda x: priority_by_cooling_interval(x)
-        )
-        end = time.time() - start
-        print(
-            f"### INFO: `priority_scheduled_bookmarks_to_study` took: {end:.4f} seconds"
         )
         return sorted_candidates
 


### PR DESCRIPTION
We were retrieving all the bookmarks to start the exercises, which for users with many bookmarks would cause waiting times to start exercises (up to 15 seconds!). This would happen every time they start exercises, and there is no need to load all the available bookmarks. 

Instead, now the query only limits to the number of bookmarks requested by the frontend, and by default it's 100. This is used in the exercises, which can query up to 200 bookmarks, (100 scheduled and 100 unscheduled) which are then sorted and returned. This results in a reduction to about 1-2 seconds in my own server, which is OK for our purposes.

We still have an issue when users have many bookmarks and they go to the Words page, where all the bookmarks are loaded. In this case, maybe we could use pagination or something along those lines? 

## Running times:

(Same user, goes to exercises)

**Before:**

`all_bookmarks_priority_to_study took: 14.7286 seconds, total: 1802`

**After:**

`all_bookmarks_priority_to_study took: 1.7743 seconds, total: 131`