### PR TITLE
Added new topics to url_keywords

### DIFF
--- a/tools/migrations/24-11-04--updating-url-keyword-mapping.sql
+++ b/tools/migrations/24-11-04--updating-url-keyword-mapping.sql
@@ -1,0 +1,350 @@
+# Swedish 'ekonomi' -> Business
+update
+    url_keyword
+set
+    new_topic_id = 6
+WHERE
+    keyword like 'ekonomi'
+    and language_id = 18;
+
+# German 'kunstmarkt' -> Culture & Art
+update
+    url_keyword
+set
+    new_topic_id = 2
+WHERE
+    keyword like 'kunstmarkt'
+    and language_id = 3;
+
+# German 'wintersport' -> Sports
+update
+    url_keyword
+set
+    new_topic_id = 1
+WHERE
+    keyword like 'wintersport'
+    and language_id = 3;
+
+# German 'technik' -> Technology & Science
+update
+    url_keyword
+set
+    new_topic_id = 3
+WHERE
+    keyword like 'technik'
+    and language_id = 3;
+
+# German 'buehne und konzert' -> Culture & Art
+update
+    url_keyword
+set
+    new_topic_id = 2
+WHERE
+    keyword like 'patrimoine'
+    and language_id = 3;
+
+# German 'bildung' -> Health & Society
+update
+    url_keyword
+set
+    new_topic_id = 5
+WHERE
+    keyword like 'bildung'
+    and language_id = 3;
+
+# German 'mode design' -> Culture & Art ?
+update
+    url_keyword
+set
+    new_topic_id = 2
+WHERE
+    keyword like 'mode design'
+    and language_id = 3;
+
+# Danish 'krop sundhed' -> Health & Society
+update
+    url_keyword
+set
+    new_topic_id = 5
+WHERE
+    keyword like 'krop sundhed'
+    and language_id = 2;
+
+# Danish 'naturvidenskab' -> Technology & Science
+update
+    url_keyword
+set
+    new_topic_id = 3
+WHERE
+    keyword like 'naturvidenskab'
+    and language_id = 2;
+
+# Danish 'boganmeldelser' -> Culture & Art
+update
+    url_keyword
+set
+    new_topic_id = 2
+WHERE
+    keyword like 'boganmeldelser'
+    and language_id = 2;
+
+# Danish 'wimbledon' -> Sports
+update
+    url_keyword
+set
+    new_topic_id = 1
+WHERE
+    keyword like 'wimbledon'
+    and language_id = 2;
+
+# Danish 'ep valg' -> Politics
+update
+    url_keyword
+set
+    new_topic_id = 7
+WHERE
+    keyword like 'ep valg'
+    and language_id = 2;
+
+# Danish 'badminton' -> Sports
+update
+    url_keyword
+set
+    new_topic_id = 1
+WHERE
+    keyword like 'badminton'
+    and language_id = 2;
+
+# Danish 'superliga' -> Sports
+update
+    url_keyword
+set
+    new_topic_id = 1
+WHERE
+    keyword like 'superliga'
+    and language_id = 2;
+
+# Danish 'uddannelse' -> Health & Society
+update
+    url_keyword
+set
+    new_topic_id = 5
+WHERE
+    keyword like 'uddannelse'
+    and language_id = 2;
+
+# Danish 'kvindelandsholdet' -> Sports
+update
+    url_keyword
+set
+    new_topic_id = 1
+WHERE
+    keyword like 'kvindelandsholdet'
+    and language_id = 2;
+
+# Danish 'rummet' -> Technology & Science
+update
+    url_keyword
+set
+    new_topic_id = 3
+WHERE
+    keyword like 'rummet'
+    and language_id = 2;
+
+# Danish 'erhverv' -> Business
+update
+    url_keyword
+set
+    new_topic_id = 6
+WHERE
+    keyword like 'erhverv'
+    and language_id = 2;
+
+# Danish 'sundhed' -> Health & Society
+update
+    url_keyword
+set
+    new_topic_id = 5
+WHERE
+    keyword like 'sundhed'
+    and language_id = 2;
+
+# Danish 'valg i usa' -> Politics
+update
+    url_keyword
+set
+    new_topic_id = 7
+WHERE
+    keyword like 'valg i usa'
+    and language_id = 2;
+
+# Danish 'teknologi' -> Technology & Science
+update
+    url_keyword
+set
+    new_topic_id = 3
+WHERE
+    keyword like 'teknologi'
+    and language_id = 2;
+
+# French 'sport auto' -> Sports
+update
+    url_keyword
+set
+    new_topic_id = 1
+WHERE
+    keyword like 'sport auto'
+    and language_id = 7;
+
+# French 'entreprises' -> Business
+update
+    url_keyword
+set
+    new_topic_id = 6
+WHERE
+    keyword like 'entreprises'
+    and language_id = 7;
+
+# French 'economie francaise' -> Business
+update
+    url_keyword
+set
+    new_topic_id = 6
+WHERE
+    keyword like 'economie francaise'
+    and language_id = 7;
+
+# French 'tennis de table' -> Sports
+update
+    url_keyword
+set
+    new_topic_id = 1
+WHERE
+    keyword like 'tennis de table'
+    and language_id = 7;
+
+# French 'judo' -> Sports
+update
+    url_keyword
+set
+    new_topic_id = 1
+WHERE
+    keyword like 'judo'
+    and language_id = 7;
+
+# French 'surf' -> Sports
+update
+    url_keyword
+set
+    new_topic_id = 1
+WHERE
+    keyword like 'surf'
+    and language_id = 7;
+
+# French 'histoire' -> Culture & Art
+update
+    url_keyword
+set
+    new_topic_id = 2
+WHERE
+    keyword like 'histoire'
+    and language_id = 7;
+
+# French 'patrimoine' -> Culture & Art
+update
+    url_keyword
+set
+    new_topic_id = 2
+WHERE
+    keyword like 'patrimoine'
+    and language_id = 7;
+
+# French 'gastronomie' -> Travel & Tourism
+update
+    url_keyword
+set
+    new_topic_id = 4
+WHERE
+    keyword like 'gastronomie'
+    and language_id = 7;
+
+# French 'rallye' -> Sports
+update
+    url_keyword
+set
+    new_topic_id = 1
+WHERE
+    keyword like 'rallye'
+    and language_id = 7;
+
+# French 'theatre' -> Culture & Art
+update
+    url_keyword
+set
+    new_topic_id = 2
+WHERE
+    keyword like 'theatre'
+    and language_id = 7;
+
+# French 'cultures pop' -> Culture & Art
+update
+    url_keyword
+set
+    new_topic_id = 2
+WHERE
+    keyword like 'cultures pop'
+    and language_id = 7;
+
+# French 'festival de cannes' -> Culture & Art
+update
+    url_keyword
+set
+    new_topic_id = 2
+WHERE
+    keyword like 'festival de cannes'
+    and language_id = 7;
+
+# French 'festival de cannes' -> Culture & Art
+update
+    url_keyword
+set
+    new_topic_id = 2
+WHERE
+    keyword like 'festival de cannes'
+    and language_id = 7;
+
+# French 'jeux olympiques' -> Sports
+update
+    url_keyword
+set
+    new_topic_id = 1
+WHERE
+    keyword like 'jeux olympiques'
+    and language_id = 7;
+
+# French 'volley ball' -> Sports
+update
+    url_keyword
+set
+    new_topic_id = 1
+WHERE
+    keyword like 'volley ball'
+    and language_id = 7;
+
+# Italian 'casa' -> Health & Society
+update
+    url_keyword
+set
+    new_topic_id = 5
+WHERE
+    keyword like 'casa'
+    and language_id = 8;
+
+# Italian 'formulauno' -> Sports
+update
+    url_keyword
+set
+    new_topic_id = 1
+WHERE
+    keyword like 'formulauno'
+    and language_id = 8;


### PR DESCRIPTION
Added mappings for a variety of url keywords.

# Swedish 
- 'ekonomi' -> Business

# German 

 - 'kunstmarkt' -> Culture & Art
- 'wintersport' -> Sports
- 'technik' -> Technology & Science
- 'buehne und konzert' -> Culture & Art
- 'bildung' -> Health & Society
- 'mode design' -> Culture & Art  @mircealungu  (or Health & Society?)
# Danish 

- 'krop sundhed' -> Health & Society
- 'naturvidenskab' -> Technology & Science
- 'boganmeldelser' -> Culture & Art
- 'wimbledon' -> Sports
- 'ep valg' -> Politics
- 'badminton' -> Sports
- 'superliga' -> Sports
- 'uddannelse' -> Health & Society
- 'kvindelandsholdet' -> Sports
- 'rummet' -> Technology & Science
- 'erhverv' -> Business
- 'sundhed' -> Health & Society
- 'valg i usa' -> Politics
- 'teknologi' -> Technology & Science

# French 
- 'sport auto' -> Sports
- 'entreprises' -> Business
- 'economie francaise' -> Business
- 'tennis de table' -> Sports
- 'judo' -> Sports
- 'surf' -> Sports
- 'histoire' -> Culture & Art
- 'patrimoine' -> Culture & Art
- 'gastronomie' -> Travel & Tourism
- 'rallye' -> Sports
- 'theatre' -> Culture & Art
- 'cultures pop' -> Culture & Art
- 'festival de cannes' -> Culture & Art
- 'festival de cannes' -> Culture & Art
- 'jeux olympiques' -> Sports
- 'volley ball' -> Sports

# Italian
- 'casa' -> Health & Society
- 'formulauno' -> Sports