### PR TITLE
Create 24-01-16--fix-portuguese-language.sql

### DIFF
--- a/tools/migrations/24-01-16--fix-portuguese-language.sql
+++ b/tools/migrations/24-01-16--fix-portuguese-language.sql
@@ -1,0 +1,6 @@
+UPDATE
+    language
+SET
+    name = 'Portuguese'
+WHERE
+    name like 'Portughese';


### PR DESCRIPTION
This has been a small detail that I never understood, but now for the tokenizer this would cause issues so we should update "Portughese" -> "Portuguese" 

- Update the name of the Portuguese language
