### PR TITLE
Fix failing tests with exercise outcomes

### DIFF
--- a/zeeguu/core/model/sorted_exercise_log.py
+++ b/zeeguu/core/model/sorted_exercise_log.py
@@ -70,15 +70,21 @@ class SortedExerciseLog(object):
         return distinct_days
 
     def count_number_of_streaks(self):
+        from datetime import datetime
+
         def save_streak(count_dict, current_count):
             count_dict[current_count] = count_dict.get(current_count, 0) + 1
 
         current_streak = 0
+        last_exercise_date = datetime.min.date()
         total_streak_counts = {}
-        for exercise in self.exercises:
+        # Go from least recent to most recent.
+        for exercise in self.exercises[::-1]:
             is_correct = exercise.is_correct()
-            if is_correct:
+            exercise_date = exercise.time.date()
+            if is_correct and (exercise_date > last_exercise_date):
                 current_streak += 1
+                last_exercise_date = exercise_date
             if not is_correct or current_streak == LEARNING_CYCLE_LENGTH:
                 # To move to a next cycle you need a streak of 4 exercises.
                 # If the exercise is not correct or is at the end of the cycle

--- a/zeeguu/core/test/test_bookmark.py
+++ b/zeeguu/core/test/test_bookmark.py
@@ -241,23 +241,24 @@ class BookmarkTest(ModelTestMixIn):
         )
         correct_bookmark = random_bookmarks[2]
         correct_bookmark.learning_cycle = LearningCycle.PRODUCTIVE
-        exercises = 0
+        day_interval = 1
         distinct_dates = set()
         last_exercise_date = None
         while not (
-            exercises >= (total_exercises_productive_cycle)
+            day_interval >= (total_exercises_productive_cycle)
             and len(distinct_dates) >= total_exercises_productive_cycle
         ):
             correct_exercise = ExerciseRule(exercise_session).exercise
             correct_exercise.outcome = OutcomeRule().correct
             correct_bookmark.add_new_exercise(correct_exercise)
-            exercises += 1
+
             if not last_exercise_date:
                 last_exercise_date = correct_exercise.time
             else:
                 correct_exercise.time = last_exercise_date + timedelta(
-                    days=exercises * 2
+                    days=day_interval
                 )
+                day_interval += 1
             last_exercise_date = correct_exercise.time
             distinct_dates.add(last_exercise_date.date())
 


### PR DESCRIPTION
- The old implementation would generate random exercises until having at least a number of different dates. This doesn't really reflect what we expect. So instead, I have changed it to insert exercises with increasing cooldowns to reflect the behavior we expect from users. Currently, this increases 1 day per exercise. 
- Added a condition that the exercise only counts in the streaks if the dates are different.