### PR TITLE
Fixed Tests for Levels and Learning Cycles

### DIFF
--- a/zeeguu/api/endpoints/feature_toggles.py
+++ b/zeeguu/api/endpoints/feature_toggles.py
@@ -70,19 +70,15 @@ def _tiago_exercises(user):
 
 
 def _merle_exercises(user):
-    right_user = (
-        user.invitation_code == "Merle"
-        or user.invitation_code == "MerleITU"
-        or user.invitation_code == "PTCT"
-        or user.invitation_code == "zeeguu-preview"
-        or user.id in [2953, 4089]
-    )
+    ## This is the exercises with 2 stages.
+    right_user = user.invitation_code == "learning-cycle"
     return right_user
 
 
 def _exercise_levels(user):
     "This is such a cool feature that it should be used by everybody"
-    return True
+    # A user can only have either _merle_exercies or _exercise_levels.
+    return True and user.invitation_code != "learning-cycle"
 
 
 def _no_audio_exercises(user):

--- a/zeeguu/core/test/test_bookmark.py
+++ b/zeeguu/core/test/test_bookmark.py
@@ -14,9 +14,7 @@ from zeeguu.core.test.rules.text_rule import TextRule
 from zeeguu.core.test.rules.user_rule import UserRule
 from zeeguu.core.model import Bookmark
 from zeeguu.core.model import db
-from zeeguu.core.word_scheduling import (
-    TwoLearningCyclesPerWord,
-)
+from zeeguu.core.word_scheduling import TwoLearningCyclesPerWord, FourLevelsPerWord
 
 
 class BookmarkTest(ModelTestMixIn):
@@ -26,6 +24,11 @@ class BookmarkTest(ModelTestMixIn):
         self.user_rule = UserRule()
         self.user_rule.add_bookmarks(random.randint(3, 5))
         self.user = self.user_rule.user
+
+        self.user_rule_cycle = UserRule()
+        self.user_rule_cycle.add_bookmarks(random.randint(3, 5))
+        self.user_learning_cycle = self.user_rule_cycle.user
+        self.user_learning_cycle.invitation_code = "learning-cycle"
 
     def test_user_has_bookmarks(self):
         assert self.user.has_bookmarks()
@@ -232,8 +235,10 @@ class BookmarkTest(ModelTestMixIn):
         from zeeguu.core.model.learning_cycle import LearningCycle
         from datetime import timedelta
 
-        random_bookmarks = [BookmarkRule(self.user).bookmark for _ in range(0, 4)]
-        exercise_session = ExerciseSessionRule(self.user).exerciseSession
+        random_bookmarks = [
+            BookmarkRule(self.user_learning_cycle).bookmark for _ in range(0, 4)
+        ]
+        exercise_session = ExerciseSessionRule(self.user_learning_cycle).exerciseSession
         # A bookmark with CORRECTS_IN_A_ROW_FOR_LEARNED correct exercises in a row
         # returns true and the time of the last exercise
         total_exercises_productive_cycle = (
@@ -285,8 +290,10 @@ class BookmarkTest(ModelTestMixIn):
 
     def test_is_learned_based_on_exercise_outcomes_receptive_not_set(self):
 
-        random_bookmarks = [BookmarkRule(self.user).bookmark for _ in range(0, 4)]
-        exercise_session = ExerciseSessionRule(self.user).exerciseSession
+        random_bookmarks = [
+            BookmarkRule(self.user_learning_cycle).bookmark for _ in range(0, 4)
+        ]
+        exercise_session = ExerciseSessionRule(self.user_learning_cycle).exerciseSession
         # A bookmark with CORRECTS_IN_A_ROW_FOR_LEARNED correct exercises in a row
         # returns true and the time of the last exercise
         total_exercises_productive_cycle = (
@@ -298,6 +305,47 @@ class BookmarkTest(ModelTestMixIn):
         while not (
             exercises >= (total_exercises_productive_cycle)
             and len(distinct_dates) >= total_exercises_productive_cycle
+        ):
+            correct_exercise = ExerciseRule(exercise_session).exercise
+            correct_exercise.outcome = OutcomeRule().correct
+            correct_bookmark.add_new_exercise(correct_exercise)
+            exercises += 1
+            distinct_dates.add(correct_exercise.time.date())
+
+        correct_bookmark.update_learned_status(db.session)
+
+        learned = correct_bookmark.is_learned_based_on_exercise_outcomes()
+        db.session.commit()
+
+        assert learned
+
+        log = SortedExerciseLog(correct_bookmark)
+        learned_time_from_log = log.last_exercise_time()
+        result_time = log.last_exercise_time()
+        assert result_time == learned_time_from_log
+
+        # A bookmark with no TOO EASY outcome or less than 5 correct exercises in a row returns False, None
+        wrong_exercise_bookmark = random_bookmarks[3]
+        wrong_exercise = ExerciseRule(exercise_session).exercise
+        wrong_exercise.outcome = OutcomeRule().wrong
+        random_bookmarks[3].add_new_exercise(wrong_exercise)
+
+        learned = wrong_exercise_bookmark.is_learned_based_on_exercise_outcomes()
+        assert not learned
+
+    def test_is_learned_based_on_exercise_outcomes_levels(self):
+
+        random_bookmarks = [BookmarkRule(self.user).bookmark for _ in range(0, 4)]
+        exercise_session = ExerciseSessionRule(self.user).exerciseSession
+        # A bookmark with CORRECTS_IN_A_ROW_FOR_LEARNED correct exercises in a row
+        # returns true and the time of the last exercise
+        total_exercises_levels = FourLevelsPerWord.get_learning_cycle_length()
+        correct_bookmark = random_bookmarks[2]
+        exercises = 0
+        distinct_dates = set()
+        while not (
+            exercises >= (total_exercises_levels)
+            and len(distinct_dates) >= total_exercises_levels
         ):
             correct_exercise = ExerciseRule(exercise_session).exercise
             correct_exercise.outcome = OutcomeRule().correct

--- a/zeeguu/core/test/test_scheduling.py
+++ b/zeeguu/core/test/test_scheduling.py
@@ -32,13 +32,13 @@ class SchedulerTest(ModelTestMixIn):
         # A user with the two cycles rule
         self.user_rule_cycle = UserRule()
         self.two_cycles_user = self.user_rule_cycle.user
+        self.two_cycles_user.invitation_code = "learning-cycle"
         self.two_cycles_bookmark1 = BookmarkRule(self.two_cycles_user).bookmark
         self.two_cycles_bookmark2 = BookmarkRule(self.two_cycles_user).bookmark
 
         # A user with the four levels
         self.user_rule_levels = UserRule()
         self.four_levels_user = self.user_rule_levels.user
-        self.four_levels_user.invitation_code = "exercise_levels"
 
         db_session.add(self.four_levels_user)
         db_session.commit()


### PR DESCRIPTION
- Now the default is the levels, so we need to update the tests to reflect that.
- I have also left the tests to the learning cycles. This requires a flag to turn off the levels for a user, since that's how the tests are setup. I introduced an invite code: 'learning-cycle' which has not used before and can be used to toggle between levels and learning cycles.