### PR TITLE
Removed deletion of texts

### DIFF
--- a/zeeguu/api/endpoints/bookmarks_and_words.py
+++ b/zeeguu/api/endpoints/bookmarks_and_words.py
@@ -171,13 +171,8 @@ def bookmarks_for_article_2(article_id):
 def delete_bookmark(bookmark_id):
     try:
         bookmark = Bookmark.find(bookmark_id)
-        bookmark_text = Text.find_by_id(bookmark.text_id)
 
         db_session.delete(bookmark)
-        if len(bookmark_text.all_bookmarks_for_text()) == 0:
-            print("Deleting text: ", bookmark_text)
-            db_session.delete(bookmark_text)
-
         db_session.commit()
     except NoResultFound:
         return "Inexistent"


### PR DESCRIPTION
- We often delete bookmarks to create the fused bookmarks in the frontend. This enters in conflict with deleting the text since the context of the fuse bookmarks can be the same, and can be deleted during the process of the new bookmark creation since the translations have a delay. For this reason, instead of cleaning up orphaned texts on deletion, we should do it as a maintenance script to ensure the users do not run into occasions where they loose bookmarks.