### PR TITLE
Update to tokenization

### DIFF
--- a/zeeguu/core/test/test_tokenizer.py
+++ b/zeeguu/core/test/test_tokenizer.py
@@ -183,6 +183,35 @@ class TokenizationTest(ModelTestMixIn):
         ] == [t.text for t in tokens]
         assert all([t.token_i == i for i, t in enumerate(tokens)])
 
+    def test_french_tokenization_2(self):
+        text = """Un jour, en hiver, une reine qui n'a pas d'enfants se pique le doigt en cousant devant sa fenêtre."""
+        tokens = self.fr_tokenizer.tokenize_text(text, False)
+        assert [
+            "Un",
+            "jour",
+            ",",
+            "en",
+            "hiver",
+            ",",
+            "une",
+            "reine",
+            "qui",
+            "n'a",
+            "pas",
+            "d'enfants",
+            "se",
+            "pique",
+            "le",
+            "doigt",
+            "en",
+            "cousant",
+            "devant",
+            "sa",
+            "fenêtre",
+            ".",
+        ] == [t.text for t in tokens]
+        assert all([t.token_i == i for i, t in enumerate(tokens)])
+
     def test_spanish_tokenization_1(self):
         text = """¿qué es esto?"""
         tokens = self.es_tokenizer.tokenize_text(text, False)

--- a/zeeguu/core/tokenization/stanza_tokenizer.py
+++ b/zeeguu/core/tokenization/stanza_tokenizer.py
@@ -114,8 +114,8 @@ class StanzaTokenizer(ZeeguuTokenizer):
                     particle_with_apostrophe
                     and particle_with_apostrophe.group(0) == text
                     and i + 1 < len(sentence.tokens)
-                    and len(sentence.tokens[i + 1].text)
-                    > 1  # avoid situations like call'? where it's followed by a punctuation
+                    and sentence.tokens[i + 1].text
+                    not in Token.PUNCTUATION  # avoid situations like call'? where it's followed by a punctuation
                     and not has_space
                 ):
                     # Do not accumulate in case it's the only token in the sentence.

--- a/zeeguu/core/tokenization/token.py
+++ b/zeeguu/core/tokenization/token.py
@@ -27,7 +27,7 @@ class Token:
 
     @classmethod
     def is_like_symbols(cls, text):
-        return Token.URL_REGEX.match(text) is not None
+        return text in Token.SYMBOLS
 
     @classmethod
     def is_punctuation(cls, text):


### PR DESCRIPTION
- Found a case in French where the assumption that the apostrophe wouldn't be followed by a single character doesn't hold. Made that condition specifically for punctuation rather than a token in general.

"n'a" - should be a token, rather than "n'", "a".