### PR TITLE
Provide reading completion for articles

### DIFF
--- a/zeeguu/core/behavioral_modeling/__init__.py
+++ b/zeeguu/core/behavioral_modeling/__init__.py
@@ -1,1 +1,4 @@
-from zeeguu.core.behavioral_modeling.scroll_last_reading_percentage import find_last_reading_percentage
+from zeeguu.core.behavioral_modeling.scroll_last_reading_percentage import (
+    find_last_reading_percentage,
+    last_reading_point_with_viewport,
+)

--- a/zeeguu/core/behavioral_modeling/scroll_last_reading_percentage.py
+++ b/zeeguu/core/behavioral_modeling/scroll_last_reading_percentage.py
@@ -1,33 +1,33 @@
 def find_last_reading_percentage(list, max_jump=10, max_total_update=40):
     """
-        Takes a list of scroll events which are composed of tuples (second, % read) and outputs
-        the last point the users has "read" to. This is an estimation, as it's impossible to 
-        determine where exactly a user as stopped reading. E.g. a user might scroll to keep what 
-        they are reading in the middle or read the entire screen and then scroll, etc...
+    Takes a list of scroll events which are composed of tuples (second, % read) and outputs
+    the last point the users has "read" to. This is an estimation, as it's impossible to
+    determine where exactly a user as stopped reading. E.g. a user might scroll to keep what
+    they are reading in the middle or read the entire screen and then scroll, etc...
 
-        In the frontend, the percentage corresponds to where the viewport ends in relation to 
-        an article. In other words, if the user viewport touches the end of the article, then it's 
-        considered 100%. In smaller screens the text is wrapped, so it can result in a small 
-        difference when going to a screen where the text fits the max-width.
-            
-        The method goes through the list of events and calculates how much % of the article the 
-        user scrolls past in a second. If the user scrolls more than 10% in a second, it's not 
-        considered that they have read that ammount of the article.
+    In the frontend, the percentage corresponds to where the viewport ends in relation to
+    an article. In other words, if the user viewport touches the end of the article, then it's
+    considered 100%. In smaller screens the text is wrapped, so it can result in a small
+    difference when going to a screen where the text fits the max-width.
 
-        However, let's say they scrolled quickly through the top image, and it's a rather small article,
-        then if the speed is quite low, and they haven't scrolled more than 40% of the last point,
-        then we consider that to be a valid update. 
+    The method goes through the list of events and calculates how much % of the article the
+    user scrolls past in a second. If the user scrolls more than 10% in a second, it's not
+    considered that they have read that ammount of the article.
 
-        There's a grace of 5% meaning if the user as gotten to 95% of the article, then it's considered
-        read.
+    However, let's say they scrolled quickly through the top image, and it's a rather small article,
+    then if the speed is quite low, and they haven't scrolled more than 40% of the last point,
+    then we consider that to be a valid update.
 
-        return percentage:float
+    There's a grace of 5% meaning if the user as gotten to 95% of the article, then it's considered
+    read.
+
+    return percentage:float
     """
     max_until_now = 0
-    for i in range(0, len(list)-1):
+    for i in range(0, len(list) - 1):
         t0, x0 = list[i]
-        t1, x1 = list[i+1]
-        v = abs(x1-x0) / (t1 - t0)
+        t1, x1 = list[i + 1]
+        v = abs(x1 - x0) / (t1 - t0)
         max_point = max(x0, x1)
         # mean_point = sum([e[1] for e in list[i:i+2]]) / 2
         dif_update = abs(max_point - max_until_now)
@@ -35,4 +35,21 @@ def find_last_reading_percentage(list, max_jump=10, max_total_update=40):
             max_until_now = max(max_until_now, max_point if max_point < 100 else 100)
     if max_until_now > 95:
         max_until_now = 100
-    return round(max_until_now)/100
+    return round(max_until_now) / 100
+
+
+def last_reading_point_with_viewport(scroll_data, viewport_settings):
+    if scroll_data == [] or scroll_data is None:
+        return 0
+    last_reading_point = find_last_reading_percentage(scroll_data)
+    if last_reading_point < 0.9 and last_reading_point > 0:
+        scrollHeight = viewport_settings["scrollHeight"]
+        clientHeight = viewport_settings["clientHeight"]
+        bottomRowHeight = viewport_settings["bottomRowHeight"]
+        tolerance = clientHeight / ((scrollHeight - bottomRowHeight)) / 4
+        last_reading_percentage = last_reading_point - tolerance
+        return last_reading_percentage
+    elif last_reading_point >= 0.9:
+        return 1
+    else:
+        return 0

--- a/zeeguu/core/model/user_activitiy_data.py
+++ b/zeeguu/core/model/user_activitiy_data.py
@@ -2,7 +2,7 @@ import json
 from datetime import datetime, timedelta
 from time import sleep
 
-from sqlalchemy import Column, String, Integer, Boolean, DateTime, ForeignKey
+from sqlalchemy import Column, String, Integer, Boolean, DateTime, ForeignKey, desc
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import relationship
 from zeeguu.core.model.user_reading_session import ALL_ARTICLE_INTERACTION_ACTIONS
@@ -19,7 +19,10 @@ from zeeguu.core.constants import (
     EVENT_USER_FEEDBACK,
     EVENT_USER_SCROLL,
 )
-from zeeguu.core.behavioral_modeling import find_last_reading_percentage
+from zeeguu.core.behavioral_modeling import (
+    find_last_reading_percentage,
+    last_reading_point_with_viewport,
+)
 import zeeguu
 
 from zeeguu.core.model import db
@@ -292,6 +295,35 @@ class UserActivityData(db.Model):
             return self.article_id
 
         return self._find_article_in_value_or_extra_data(db_session)
+
+    @classmethod
+    def get_reading_completion_for_article(
+        cls, article_id, user_id, number_of_activity_rows=2, threshold_for_read=0.9
+    ):
+        reading_activity = (
+            cls.query.filter(cls.article_id == article_id)
+            .filter(cls.user_id == user_id)
+            .filter(cls.event == "SCROLL")
+            .order_by(desc(cls.id))
+            .limit(number_of_activity_rows)
+            .all()
+        )
+        max_percentage_read = 0
+        for ra_row in reading_activity:
+            if not ra_row.value or not ra_row.extra_data:
+                continue
+            scroll_data = json.loads(ra_row.extra_data)
+            viewport_data = json.loads(ra_row.value)
+            if type(viewport_data) != dict:
+                return 0
+            total_percentage_read = last_reading_point_with_viewport(
+                scroll_data, viewport_data
+            )
+            max_percentage_read = max(max_percentage_read, total_percentage_read)
+        if max_percentage_read > threshold_for_read:
+            return 1
+        else:
+            return max_percentage_read
 
     @classmethod
     def get_scroll_events_for_user_in_date_range(cls, user, days_range=7, limit=1):

--- a/zeeguu/core/model/user_article.py
+++ b/zeeguu/core/model/user_article.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import random
 from sqlalchemy import (
     Column,
     UniqueConstraint,
@@ -8,6 +7,7 @@ from sqlalchemy import (
     DateTime,
     Boolean,
     or_,
+    desc,
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.exc import NoResultFound
@@ -250,6 +250,7 @@ class UserArticle(db.Model):
     ):
 
         from zeeguu.core.model import Bookmark
+        from zeeguu.core.model.user_activitiy_data import UserActivityData
 
         # Initialize returned info with the default article info
         returned_info = article.article_info(with_content=with_content)
@@ -286,6 +287,11 @@ class UserArticle(db.Model):
             returned_info["translations"] = []
 
         else:
+            returned_info["reading_completion"] = (
+                UserActivityData.get_reading_completion_for_article(
+                    user_article_info.article_id, user_article_info.user_id
+                )
+            )
             returned_info["starred"] = user_article_info.starred is not None
             returned_info["opened"] = user_article_info.opened is not None
             returned_info["liked"] = user_article_info.liked


### PR DESCRIPTION
Updated the API to send the reading completion of an article to the frontend. This allows users to see which articles they have started reading. Previously, this was only done for the unfinished article. 

