### PR TITLE
Fix for extension not saving prgoress

### DIFF
--- a/zeeguu/core/model/user_activitiy_data.py
+++ b/zeeguu/core/model/user_activitiy_data.py
@@ -332,12 +332,11 @@ class UserActivityData(db.Model):
                     )
                     from zeeguu.core.util import ms_to_m, estimate_read_time
 
-                    last_reading_session = (
+                    total_reading_time = (
                         UserReadingSession.get_total_reading_for_user_article(
                             article, ra_row.user
                         )
                     )
-                    total_reading_time = last_reading_session.duration
                     if ms_to_m(total_reading_time) >= estimate_read_time(
                         article.word_count, ceil=False
                     ):

--- a/zeeguu/core/model/user_activitiy_data.py
+++ b/zeeguu/core/model/user_activitiy_data.py
@@ -310,19 +310,22 @@ class UserActivityData(db.Model):
             .limit(number_of_activity_rows)
             .all()
         )
+        article = Article.find_by_id(article_id)
         max_percentage_read = 0
         for ra_row in reading_activity:
-            if not ra_row.value or not ra_row.extra_data:
+            if max_percentage_read == 1:
+                break
+            if not ra_row.extra_data:
                 continue
             try:
                 scroll_data = json.loads(ra_row.extra_data)
-                viewport_data = json.loads(ra_row.value)
-                if type(viewport_data) != dict:
-                    return 0
-                total_percentage_read = last_reading_point_with_viewport(
-                    scroll_data, viewport_data
-                )
-                max_percentage_read = max(max_percentage_read, total_percentage_read)
+                total_percentage_read = find_last_reading_percentage(scroll_data)
+                if article.word_count < 150 and scroll_data[-1][0] >= 60:
+                    max_percentage_read = 1
+                else:
+                    max_percentage_read = max(
+                        max_percentage_read, total_percentage_read
+                    )
             except json.decoder.JSONDecodeError:
                 print("Failed to parse JSON data. Skipping row.")
 

--- a/zeeguu/core/model/user_activitiy_data.py
+++ b/zeeguu/core/model/user_activitiy_data.py
@@ -320,8 +320,29 @@ class UserActivityData(db.Model):
             try:
                 scroll_data = json.loads(ra_row.extra_data)
                 total_percentage_read = find_last_reading_percentage(scroll_data)
-                if article.word_count < 150 and scroll_data[-1][0] >= 60:
-                    max_percentage_read = 1
+                if article.get_word_count() < 200:
+                    """
+                    The method to estimate the reading percentage doesn't work well for
+                    very small texts. For that reason, we check if the reading time, is
+                    at least the same or longer than the estimated time, if so, we consider
+                    it read.
+                    """
+                    from zeeguu.core.model.user_reading_session import (
+                        UserReadingSession,
+                    )
+                    from zeeguu.core.util import ms_to_m, estimate_read_time
+
+                    last_reading_session = (
+                        UserReadingSession.get_total_reading_for_user_article(
+                            article, ra_row.user
+                        )
+                    )
+                    total_reading_time = last_reading_session.duration
+                    if ms_to_m(total_reading_time) >= estimate_read_time(
+                        article.word_count, ceil=False
+                    ):
+                        max_percentage_read = 1
+                        break
                 else:
                     max_percentage_read = max(
                         max_percentage_read, total_percentage_read

--- a/zeeguu/core/model/user_reading_session.py
+++ b/zeeguu/core/model/user_reading_session.py
@@ -146,12 +146,19 @@ class UserReadingSession(db.Model):
 
     @classmethod
     def get_total_reading_for_user_article(cls, article, user):
-        return (
-            cls.query(sum(cls.duration))
-            .filter(cls.article == article)
-            .filter(cls.user == user)
-            .one()
-        )
+        try:
+            return (
+                db.session.query(sum(cls.duration))
+                .filter(cls.article == article)
+                .filter(cls.user == user)
+                .one()
+            )[0]
+        except Exception as e:
+            from sentry_sdk import capture_exception
+
+            capture_exception(e)
+            print(e)
+            return 0
 
     @classmethod
     def find_by_article(

--- a/zeeguu/core/model/user_reading_session.py
+++ b/zeeguu/core/model/user_reading_session.py
@@ -1,13 +1,10 @@
-import sqlalchemy
-import zeeguu.core
-
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from zeeguu.core.model import User, Article
 
 from zeeguu.core.constants import *
 from zeeguu.core.util.encoding import datetime_to_json
-
+from sqlalchemy.sql.functions import sum
 from zeeguu.core.model import db
 
 VERY_FAR_IN_THE_PAST = "2000-01-01T00:00:00"
@@ -146,6 +143,15 @@ class UserReadingSession(db.Model):
 
         sessions = query.all()
         return sessions
+
+    @classmethod
+    def get_total_reading_for_user_article(cls, article, user):
+        return (
+            cls.query(sum(cls.duration))
+            .filter(cls.article == article)
+            .filter(cls.user == user)
+            .one()
+        )
 
     @classmethod
     def find_by_article(

--- a/zeeguu/core/util/__init__.py
+++ b/zeeguu/core/util/__init__.py
@@ -6,3 +6,4 @@ from zeeguu.core.util.hash import text_hash, password_hash
 from zeeguu.core.util.time import get_server_time_utc
 from zeeguu.core.util.list import remove_duplicates_keeping_order
 from zeeguu.core.util.reading_time_estimator import estimate_read_time
+from .time_conversion import ms_to_m

--- a/zeeguu/core/util/reading_time_estimator.py
+++ b/zeeguu/core/util/reading_time_estimator.py
@@ -1,9 +1,9 @@
 import math
 
 
-def estimate_read_time(word_count: int):
+def estimate_read_time(word_count: int, ceil: bool = True):
     """
     Returns the estimated reading time in minutes, assuming
     a reading rate of 160WPM.
     """
-    return math.ceil(word_count / 160)
+    return math.ceil(word_count / 160) if ceil else word_count / 160

--- a/zeeguu/core/util/time_conversion.py
+++ b/zeeguu/core/util/time_conversion.py
@@ -1,0 +1,5 @@
+def ms_to_m(ms: int):
+    """
+    Converts milliseconds to minutes.
+    """
+    return ms / 1000 / 60


### PR DESCRIPTION
- We noted that especially in smaller articles our estimation based on the scrolling percentage can perform quite poorly (not showing small articles as read). Instead of using the scroll percentage, we now use the total duration the user has read the article. This was made to ensure that if the user is off by a few seconds opening the article can resolve that issue.