### PR TITLE
Ml topic classification based on text

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 services:
-
   # main db
   mysql:
     image: mysql:5.7
@@ -13,7 +12,6 @@ services:
     networks:
       - zeeguu_backend
     restart: unless-stopped
-
 
   # main db
   fmd_mysql:
@@ -29,7 +27,6 @@ services:
       - zeeguu_backend
     restart: unless-stopped
 
-
   elasticsearch_v8:
     image: elasticsearch:8.12.2
     platform: linux/amd64
@@ -41,7 +38,7 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=false
     volumes:
-      - ./data/elasticsearch_db_v8/data:/usr/share/elasticsearch/data
+      - "${ZEEGUU_DATA_FOLDER}/elasticsearch/data:/usr/share/elasticsearch/data"
     networks:
       - zeeguu_backend
     restart: unless-stopped
@@ -67,13 +64,13 @@ services:
     entrypoint: "python ./semantic-emb-api/app/app.py"
     volumes:
       - .:/Zeeguu-API
-      - ./data/zeeguu/language-models:/semantic-emb-api/semantic-emb-api/app/semantic_vector/binaries
+      - "${ZEEGUU_RESOURCES_FOLDER}/language-models:/semantic-emb-api/semantic-emb-api/app/semantic_vector/binaries"
     networks:
       - zeeguu_backend
     # When encoding certain longer documents, it might use more than
     # the available memory allocated to the container, in that case restart the service.
     mem_limit: 2512m # From testing usually the container needs about 2GBs to run
-    # However, as a Dev safeguard, if needed the container is restarted to avoid 
+    # However, as a Dev safeguard, if needed the container is restarted to avoid
     # taking too much memory from the host.
     restart: unless-stopped
 
@@ -109,8 +106,8 @@ services:
       GOOGLE_APPLICATION_CREDENTIALS: /Zeeguu-API/lu-mir-zeeguu-credentials.json
       WORDNIK_API_KEY: ${WORDNIK_API_KEY}
       MULTI_LANG_TRANSLATOR_AB_TESTING: ${MULTI_LANG_TRANSLATOR_AB_TESTING}
-      ZEEGUU_ES_CONN_STRING: 'http://elasticsearch_v8:9200'
-      ZEEGUU_EMB_API_CONN_STRING: 'http://semantic_emb_api:3654'
+      ZEEGUU_ES_CONN_STRING: "http://elasticsearch_v8:9200"
+      ZEEGUU_EMB_API_CONN_STRING: "http://embedding_api:3654"
 
       # TODO: remove these two envvars and simply use the $ZEEGUU_DATA_FOLDER
       FOLDER_FOR_REPORT_OUTPUT: /zeeguu-data/crawl-reports
@@ -124,8 +121,6 @@ services:
 
   zapi_dev: &zapi_dev
     <<: *zapi_default
-    ports:
-      - "127.0.0.1:8080:9001"
     command: python /Zeeguu-API/start.py
 
   zapi_dev_translations:
@@ -137,4 +132,3 @@ services:
 
 networks:
   zeeguu_backend:
-

--- a/tools/evaluate_infer_topics.py
+++ b/tools/evaluate_infer_topics.py
@@ -1,5 +1,5 @@
 from zeeguu.core.semantic_search import (
-    add_topics_based_on_semantic_hood_search,
+    get_article_w_topics_based_on_text_similarity,
 )
 
 from zeeguu.core.model import Article, Language, ArticleTopicMap
@@ -46,8 +46,8 @@ sampled_ids = np.random.choice(list(set(ALL_IDS)), TOTAL_EXAMPLES)
 for i, doc_to_search in enumerate(sampled_ids):
     article_to_search = Article.find_by_id(doc_to_search)
     k_to_use = 9
-    a_found_t, hits_t = add_topics_based_on_semantic_hood_search(
-        article_to_search, k_to_use
+    a_found_t, hits_t = get_article_w_topics_based_on_text_similarity(
+        article_to_search, k_to_use, filter_ids=[article_to_search.id]
     )
 
     neighbouring_topics = [t.topic for a in a_found_t for t in a.topics]

--- a/tools/run_knn_classification_with_text.py
+++ b/tools/run_knn_classification_with_text.py
@@ -1,0 +1,22 @@
+from zeeguu.core.semantic_search import (
+    get_topic_classification_based_on_similar_content,
+)
+
+
+from zeeguu.api.app import create_app
+
+app = create_app()
+app.app_context().push()
+
+# https://en.wikipedia.org/wiki/Computer
+text_to_classify = """A computer is a machine that can be programmed to automatically carry out sequences of arithmetic or logical operations (computation). Modern digital electronic computers can perform generic sets of operations known as programs. These programs enable computers to perform a wide range of tasks. The term computer system may refer to a nominally complete computer that includes the hardware, operating system, software, and peripheral equipment needed and used for full operation; or to a group of computers that are linked and function together, such as a computer network or computer cluster. It is sometimes named general purpose computer to distinguish it from a computer appliance.
+
+A broad range of industrial and consumer products use computers as control systems, including simple special-purpose devices like microwave ovens and remote controls, and factory devices like industrial robots. Computers are at the core of general-purpose devices such as personal computers and mobile devices such as smartphones. Computers power the Internet, which links billions of computers and users.
+
+Early computers were meant to be used only for calculations. Simple manual instruments like the abacus have aided people in doing calculations since ancient times. Early in the Industrial Revolution, some mechanical devices were built to automate long, tedious tasks, such as guiding patterns for looms. More sophisticated electrical machines did specialized analog calculations in the early 20th century. The first digital electronic calculating machines were developed during World War II, both electromechanical and using thermionic valves. The first semiconductor transistors in the late 1940s were followed by the silicon-based MOSFET (MOS transistor) and monolithic integrated circuit chip technologies in the late 1950s, leading to the microprocessor and the microcomputer revolution in the 1970s. The speed, power, and versatility of computers have been increasing dramatically ever since then, with transistor counts increasing at a rapid pace (Moore's law noted that counts doubled every two years), leading to the Digital Revolution during the late 20th and early 21st centuries."""
+
+topic_classification = get_topic_classification_based_on_similar_content(
+    text_to_classify, verbose=True
+)
+
+print(f"The topic classification for the text is: {topic_classification}")

--- a/tools/run_knn_similarity_search.py
+++ b/tools/run_knn_similarity_search.py
@@ -1,15 +1,12 @@
 from zeeguu.core.semantic_search import (
     articles_like_this_semantic,
-    add_topics_based_on_semantic_hood_search,
     articles_like_this_tfidf,
+    get_article_w_topics_based_on_text_similarity,
     find_articles_based_on_text,
 )
 
 from zeeguu.core.model.article import Article
 from zeeguu.core.model.url_keyword import UrlKeyword
-
-from zeeguu.core.elastic.settings import ES_CONN_STRING
-from elasticsearch import Elasticsearch
 from collections import Counter
 
 from zeeguu.api.app import create_app
@@ -36,7 +33,9 @@ def search_similar_to_article(article_id):
 
     a_found, hits = articles_like_this_semantic(article_to_search)
     print("------------------------------------------------")
-    a_found_t, hits_t = add_topics_based_on_semantic_hood_search(article_to_search)
+    a_found_t, hits_t = get_article_w_topics_based_on_text_similarity(
+        article_to_search.get_content(), filter_ids=[article_to_search.id]
+    )
     a_found_lt, hits_lt = articles_like_this_tfidf(article_to_search)
 
     print("Doc Searched: ", doc_to_search)

--- a/zeeguu/core/elastic/elastic_query_builder.py
+++ b/zeeguu/core/elastic/elastic_query_builder.py
@@ -233,7 +233,7 @@ def build_elastic_semantic_sim_query(
     language,
     article_sem_vec,
     article,
-    n_candidates=100,
+    n_candidates=1000,
 ):
     """
     Builds an elastic search based on the KNN semantic embeddings, the filter can be a query object.
@@ -300,7 +300,7 @@ def build_elastic_semantic_sim_query(
 def build_elastic_semantic_sim_query_for_text(
     count,
     text_embedding,
-    n_candidates=100,
+    n_candidates=1000,
     language=None,
 ):
     """
@@ -330,18 +330,18 @@ def build_elastic_semantic_sim_query_for_text(
 
 def build_elastic_semantic_sim_query_for_topic_cls(
     k_count,
-    article,
-    article_sem_vec,
-    n_candidates=10000,
+    sem_vec,
+    filter_ids: list[int] = [],
+    n_candidates=3000,
 ):
     s = Search()
     s = s.knn(
         field="sem_vec",
         k=k_count,
         num_candidates=n_candidates,
-        query_vector=article_sem_vec,
+        query_vector=sem_vec,
         filter=(
-            ~Q("ids", values=[article.id])
+            ~Q("ids", values=filter_ids)
             # & ~Q("match", **{"url_keywords.keyword": ""})
             # & ~Q("match", **{"topics.keyword": ""})
             & Q(

--- a/zeeguu/core/elastic/elastic_query_builder.py
+++ b/zeeguu/core/elastic/elastic_query_builder.py
@@ -331,9 +331,13 @@ def build_elastic_semantic_sim_query_for_text(
 def build_elastic_semantic_sim_query_for_topic_cls(
     k_count,
     sem_vec,
-    filter_ids: list[int] = [],
+    filter_ids: list[int] = None,
     n_candidates=3000,
 ):
+
+    if filter_ids is None:
+        filter_ids = []
+
     s = Search()
     s = s.knn(
         field="sem_vec",

--- a/zeeguu/core/model/new_text.py
+++ b/zeeguu/core/model/new_text.py
@@ -1,19 +1,18 @@
 import sqlalchemy.orm
 import time
 
+from sqlalchemy import UnicodeText
+
 from zeeguu.core.util import long_hash
 from zeeguu.core.model import db
-
-
-# Enough to model Proust's longest paragraph
-TWENTY_FIVE_KB = 24 * 10**3
 
 
 class NewText(db.Model):
     __table_args__ = {"mysql_collate": "utf8_bin"}
 
     id = db.Column(db.Integer, primary_key=True)
-    content = db.Column(db.String(TWENTY_FIVE_KB))
+
+    content = db.Column(UnicodeText)
     content_hash = db.Column(db.String(64))
 
     def __init__(

--- a/zeeguu/core/model/source.py
+++ b/zeeguu/core/model/source.py
@@ -5,7 +5,6 @@ from zeeguu.core.model.language import Language
 from zeeguu.core.model.source_text import SourceText
 from zeeguu.core.model.source_type import SourceType
 from zeeguu.core.model import db
-from zeeguu.core.util import compute_fk_and_wordcount
 
 
 class Source(db.Model):
@@ -32,6 +31,8 @@ class Source(db.Model):
     broken = Column(Integer)
 
     def __init__(self, source_text, source_type, language: Language, broken=0):
+        from zeeguu.core.util import compute_fk_and_wordcount
+
         self.source_text = source_text
         self.source_type = source_type
         self.language = language

--- a/zeeguu/core/model/source_text.py
+++ b/zeeguu/core/model/source_text.py
@@ -1,6 +1,8 @@
 import sqlalchemy.orm
 import time
 
+from sqlalchemy import UnicodeText
+
 from zeeguu.core.util import text_hash
 from zeeguu.core.model import db
 
@@ -12,7 +14,8 @@ class SourceText(db.Model):
     __table_args__ = {"mysql_collate": "utf8_bin"}
 
     id = db.Column(db.Integer, primary_key=True)
-    content = db.Column(db.String(TWO_MB))
+    # this mapes to TEXT in the mysql which can hold about 15K words
+    content = db.Column(UnicodeText)
     content_hash = db.Column(db.String(64))
 
     def __init__(

--- a/zeeguu/core/semantic_search/__init__.py
+++ b/zeeguu/core/semantic_search/__init__.py
@@ -1,6 +1,7 @@
 from .elastic_semantic_search import (
     articles_like_this_semantic,
-    add_topics_based_on_semantic_hood_search,
+    get_topic_classification_based_on_similar_content,
+    get_article_w_topics_based_on_text_similarity,
     articles_like_this_tfidf,
     find_articles_based_on_text,
 )

--- a/zeeguu/core/semantic_search/elastic_semantic_search.py
+++ b/zeeguu/core/semantic_search/elastic_semantic_search.py
@@ -64,7 +64,11 @@ def articles_like_this_semantic(article: Article):
     return [], []
 
 
-def get_article_w_topics_based_on_text_similarity(text, k: int = 9, filter_ids=[]):
+def get_article_w_topics_based_on_text_similarity(text, k: int = 9, filter_ids=None):
+
+    if filter_ids is None:
+        filter_ids = []
+
     query_body = build_elastic_semantic_sim_query_for_topic_cls(
         k, get_embedding_from_text(text), filter_ids=filter_ids
     )
@@ -90,10 +94,13 @@ def get_article_w_topics_based_on_text_similarity(text, k: int = 9, filter_ids=[
 def get_topic_classification_based_on_similar_content(
     text,
     k: int = 9,
-    filter_ids: list[int] = [],
+    filter_ids: list[int] = None,
     verbose=False,
 ):
     from collections import Counter
+
+    if filter_ids is None:
+        filter_ids = []
 
     found_articles, _ = get_article_w_topics_based_on_text_similarity(
         text, k, filter_ids=filter_ids


### PR DESCRIPTION
- Updated docker compose to use the Zeeguu data + the Zeeguu resources to download the models/store ES data.
- Simplified the pipeline to be more generic and easier to use. This is to easily support the fact that we are going to have multiple sources in ES and not just articles.
- Now when calling the `build_elastic_semantic_sim_query_for_topic_cls`, we pass a text + ids we do not want to be used.
- I also simplified the call to get the Topic Object by creating the method  `get_topic_classification_based_on_similar_content`. This makes it more easily to re-use the same logic used for article inferance.
- Created a simple demo where a text is classified using the KNN classifier.
- Increased the number of candidates when retrieving the neighbours.

@mircealungu I realized I reverted this change:

```
 ports:
      - "127.0.0.1:8080:9001"
```

Did we decide if we wanted to use the mapping or update the configuration for the api.config? 