### PR TITLE
Fixed Source Broken Update

### DIFF
--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -406,7 +406,7 @@ class Article(db.Model):
         article_broken_map = ArticleBrokenMap.find_or_create(session, self, broken_code)
         self.broken = MARKED_BROKEN_DUE_TO_LOW_QUALITY
         if self.source:
-            self.source.broken = broken_code
+            self.source.broken = MARKED_BROKEN_DUE_TO_LOW_QUALITY
         session.add(article_broken_map)
         session.add(self)
         session.commit()


### PR DESCRIPTION
- Fix error spotted in Sentry.

This led me to find an interesting point we should consider. Now, spammy articles that have a text we have encountered before are all linked to the same source, and there might be a case where in the past, they weren't considered as broken, but now they are. This will make it easier to spot these ocurrences.