### PR TITLE
Fix migration script

### DIFF
--- a/zeeguu/core/model/source.py
+++ b/zeeguu/core/model/source.py
@@ -46,9 +46,9 @@ class Source(db.Model):
         return self.source_text.content
 
     @classmethod
-    def find(cls, id: int):
+    def find_by_id(cls, id: int):
         try:
-            return cls.query.filter_by(id=id).order_by(cls.date.desc()).first()
+            return cls.query.filter_by(id=id).first()
         except NoResultFound:
             return None
 
@@ -64,9 +64,21 @@ class Source(db.Model):
     ):
         source_text = SourceText.find_or_create(session, text, commit=commit)
         try:
-            return cls.query.filter_by(
+            source = cls.query.filter_by(
                 source_text=source_text, source_type=source_type, language=language
             ).one()
+
+            if source.broken == 0 and broken > 0:
+                # If we find the source, and passed a broken flag, then update the
+                # source to be broken. This is relevant for when we have multiple articles
+                # and in the past, we weren't as good at filtering "broken" documents.
+                # In this way, if any have been marked as broken, all others will also be
+                # marked as broken.
+                source.broken = broken
+                session.add(source)
+                if commit:
+                    session.commit()
+            return source
 
         except NoResultFound:
             new = cls(


### PR DESCRIPTION
- Since the query was based off source_id being none, the offset was "skipping" articles as the starting article will always be the first article in the DB without a source id.
- Added an extra condition when finding a source that isn't broken but it's being attempted to be found with a broken flag. If this is the case, then we make it broken.