### PR TITLE
fix-caption-downloader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -68,7 +68,5 @@ pydantic>=1.10.8
 stanza==1.10.1
 
 # For videos
-webvtt-py
-yt-dlp
-ffmpeg
 emoji
+youtube_transcript_api

--- a/tools/migrations/25-04-16--remove-vtt-from-video.sql
+++ b/tools/migrations/25-04-16--remove-vtt-from-video.sql
@@ -1,0 +1,5 @@
+
+/*
+    VTT is no longer needed with the new caption downloader
+*/
+ALTER TABLE `video` DROP COLUMN `vtt`;

--- a/zeeguu/core/model/video.py
+++ b/zeeguu/core/model/video.py
@@ -37,7 +37,6 @@ class Video(db.Model):
 
     duration = db.Column(db.Integer)
     language_id = db.Column(db.Integer, db.ForeignKey("language.id"))
-    vtt = db.Column(db.Text)
 
     source_id = db.Column(db.Integer, db.ForeignKey(Source.id), unique=True)
     source = db.relationship(Source, foreign_keys="Video.source_id")
@@ -62,7 +61,6 @@ class Video(db.Model):
         thumbnail_url,
         duration,
         language,
-        vtt,
         broken=0,
         crawled_at=datetime.now(),
     ):
@@ -75,7 +73,6 @@ class Video(db.Model):
         self.thumbnail_url = thumbnail_url
         self.duration = duration
         self.language = language
-        self.vtt = vtt
         self.broken = broken
         self.crawled_at = crawled_at
 
@@ -123,11 +120,6 @@ class Video(db.Model):
             session, video_info["channelId"], channel_info, thumbnail_url, language
         )
 
-        # TODO: Remove this right? This prevents us from saving videos with no text (e.g. )
-        # if video_info["text"] == "":
-        #     print(f"Couldn't parse any text for the video '{video_unique_key}'")
-        #     return None
-
         url_object = Url.find_or_create(session, video_info["thumbnail"])
 
         # TODO: Remove this temporary workaround (this is because source_id is unique in video table)
@@ -153,7 +145,6 @@ class Video(db.Model):
             thumbnail_url=url_object,
             duration=video_info["duration"],
             language=language,
-            vtt=video_info["vtt"],
             broken=video_info["broken"],
         )
         session.add(new_video)
@@ -198,8 +189,7 @@ class Video(db.Model):
         # add topic
         print("Adding topic")
         try:
-            # new_video.assign_inferred_topics(session)
-            print("Pretend topic")
+            new_video.assign_inferred_topics(session)
         except Exception as e:
             print(
                 f"Error adding topic to video ({video_unique_key}) with elastic search: {e}"

--- a/zeeguu/core/youtube_api/youtube_api.py
+++ b/zeeguu/core/youtube_api/youtube_api.py
@@ -1,13 +1,17 @@
 import html
-from io import StringIO
 import os
 import re
 import isodate
 import requests
-import webvtt
-import yt_dlp
 from zeeguu.core.util.text import remove_emojis
 from langdetect import detect, LangDetectException
+from youtube_transcript_api import YouTubeTranscriptApi
+from youtube_transcript_api._errors import (
+    TranscriptsDisabled,
+    NoTranscriptFound,
+    VideoUnavailable,
+    CouldNotRetrieveTranscript,
+)
 
 YOUTUBE_API_KEY = os.getenv("YOUTUBE_API_KEY")
 if not YOUTUBE_API_KEY:
@@ -58,7 +62,7 @@ def get_video_unique_keys(lang, category_id=None, topic_id=None, max_results=50)
         )
 
     # see https://developers.google.com/youtube/v3/docs/search/list
-    # Quota: 100 units per 50 results
+    # Quota: 100 units per call. Up to 50 videos per call
 
     search_params = {
         "part": "id",
@@ -139,19 +143,17 @@ def fetch_video_info(video_unique_key, lang):
         print(f"Video {video_unique_key} is not in the expected language {lang}.")
         video_info["broken"] = NOT_IN_EXPECTED_LANGUAGE
 
-    if has_dubbed_audio(video_unique_key):
-        print(f"Video {video_unique_key} has dubbed audio.")
-        video_info["broken"] = DUBBED_AUDIO
+    # if has_dubbed_audio(video_unique_key):
+    #     print(f"Video {video_unique_key} has dubbed audio.")
+    #     video_info["broken"] = DUBBED_AUDIO
 
     captions = get_captions(video_unique_key, lang)
     if captions is None:
         print(f"Could not fetch captions for video {video_unique_key} in {lang}")
-        video_info["vtt"] = ""
         video_info["text"] = ""
         video_info["captions"] = []
         video_info["broken"] = NO_CAPTIONS_AVAILABLE
     else:
-        video_info["vtt"] = captions["vtt"]
         video_info["text"] = captions["text"]
         video_info["captions"] = captions["captions"]
         video_info["broken"] = 0
@@ -160,67 +162,54 @@ def fetch_video_info(video_unique_key, lang):
 
 
 def get_captions(video_unique_key, lang):
-    ydl_opts = {
-        "quiet": True,
-        "skip_download": True,
-        "writesubtitles": True,
-        "subtitleslangs": [lang],
-        "subtitlesformat": "vtt",
-    }
+    try:
+        transcript_list = YouTubeTranscriptApi.list_transcripts(video_unique_key)
+        transcript = transcript_list.find_manually_created_transcript([lang])
 
-    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-        try:
-            info = ydl.extract_info(
-                f"https://www.youtube.com/watch?v={video_unique_key}",
-                download=False,
+        transcript_data = transcript.fetch()
+
+        caption_list = []
+        full_text = []
+
+        for caption in transcript_data:
+            clean_text = text_cleaner(caption.text)
+            caption_list.append(
+                {
+                    "time_start": caption.start * 1000,
+                    "time_end": (caption.start + caption.duration) * 1000,
+                    "text": clean_text,
+                }
             )
-            subtitles = info.get("subtitles", {})
+            full_text.append(clean_text)
 
-            if lang in subtitles:
-                url = subtitles[lang][-1]["url"]
+        return {
+            "text": "\n".join(full_text),
+            "captions": caption_list,
+        }
 
-                response = requests.get(url)
-                if response.status_code == 200:
-                    vtt_content = clean_vtt(response.text)
-                    return parse_vtt(vtt_content)
-            return None
-        except Exception as e:
-            print(f"Error fetching subtitles for {video_unique_key}: {e}")
-            return None
-
-
-def parse_vtt(vtt_content):
-    def _timestamp_to_milliseconds(timestamp):
-        h, m, s = timestamp.replace(",", ".").split(":")
-        return (float(h) * 3600 + float(m) * 60 + float(s)) * 1000
-
-    captions_list = []
-    full_text = []
-
-    vtt_file = StringIO(vtt_content)
-    captions = webvtt.read_buffer(vtt_file)
-
-    for caption in captions:
-        captions_list.append(
-            {
-                "time_start": _timestamp_to_milliseconds(caption.start),
-                "time_end": _timestamp_to_milliseconds(caption.end),
-                "text": caption.text,
-            }
+    except TranscriptsDisabled:
+        print("Transcript is disabled for this video.")
+        return None
+    except NoTranscriptFound:
+        print(
+            "No manually added transcript was found for this video in the specified language."
         )
-        full_text.append(caption.text)
+        return None
+    except VideoUnavailable:
+        print("Video is unavailable.")
+        return None
+    except CouldNotRetrieveTranscript:
+        print("Could not retrieve transcript.")
+        return None
+    except Exception as e:
+        print(f"Error fetching captions for {video_unique_key}: {e}")
+        return None
 
-    return {
-        "vtt": vtt_content,
-        "text": "\n".join(full_text),
-        "captions": captions_list,
-    }
 
-
-def clean_vtt(vtt_content):
-    vtt_content = html.unescape(vtt_content)
-    vtt_content = remove_emojis(vtt_content)
-    return vtt_content
+def text_cleaner(text):
+    text = html.unescape(text)
+    text = remove_emojis(text)
+    return text
 
 
 def is_video_language_correct(title, description, language):
@@ -258,28 +247,29 @@ def is_video_language_correct(title, description, language):
     return False
 
 
-def has_dubbed_audio(video_unique_key):
-    try:
-        ydl_opts = {
-            "quiet": True,
-            "extract_flat": True,
-            "force_generic_extractor": True,
-        }
+# TODO: figure out a way to check if the video has dubbed audio without using yt-dlp
+# def has_dubbed_audio(video_unique_key):
+#     try:
+#         ydl_opts = {
+#             "quiet": True,
+#             "extract_flat": True,
+#             "force_generic_extractor": True,
+#         }
 
-        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-            info = ydl.extract_info(
-                f"https://www.youtube.com/watch?v={video_unique_key}",
-                download=False,
-            )
+#         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+#             info = ydl.extract_info(
+#                 f"https://www.youtube.com/watch?v={video_unique_key}",
+#                 download=False,
+#             )
 
-            for format in info.get("formats", []):
-                if "dubbed-auto" in format.get("format_note", "").lower():
-                    return True
-            return False
+#             for format in info.get("formats", []):
+#                 if "dubbed-auto" in format.get("format_note", "").lower():
+#                     return True
+#             return False
 
-    except Exception as e:
-        print(f"Error checking for dubbed audio: {e}")
-        return False
+#     except Exception as e:
+#         print(f"Error checking for dubbed audio: {e}")
+#         return False
 
 
 def fetch_channel_info(channel_id):

--- a/zeeguu/core/youtube_api/youtube_api.py
+++ b/zeeguu/core/youtube_api/youtube_api.py
@@ -247,31 +247,6 @@ def is_video_language_correct(title, description, language):
     return False
 
 
-# TODO: figure out a way to check if the video has dubbed audio without using yt-dlp
-# def has_dubbed_audio(video_unique_key):
-#     try:
-#         ydl_opts = {
-#             "quiet": True,
-#             "extract_flat": True,
-#             "force_generic_extractor": True,
-#         }
-
-#         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-#             info = ydl.extract_info(
-#                 f"https://www.youtube.com/watch?v={video_unique_key}",
-#                 download=False,
-#             )
-
-#             for format in info.get("formats", []):
-#                 if "dubbed-auto" in format.get("format_note", "").lower():
-#                     return True
-#             return False
-
-#     except Exception as e:
-#         print(f"Error checking for dubbed audio: {e}")
-#         return False
-
-
 def fetch_channel_info(channel_id):
     def _get_thumbnail(snippet):
         return (


### PR DESCRIPTION
Change caption downloader to youtube-transcript-api instead of yt-dlp. This should not require login, and it seems to be faster as well.
https://github.com/jdepoix/youtube-transcript-api

TODO:
- Make sure all tables where text is stored have characterset utf8mb4 and collate utf8mb4_bin (I think this was done Monday)
- If this is working, the video_downloader.py needs to uncomment the rest of the topics. And the video_crawler should set the number of videos to 50.