### PR TITLE
Added url to feedback email

### DIFF
--- a/zeeguu/api/endpoints/user.py
+++ b/zeeguu/api/endpoints/user.py
@@ -204,7 +204,11 @@ def send_feedback():
     user_feedback = UserFeedback.create(session, user, feedback_component, message, url)
     session.commit()
     ZeeguuMailer.send_feedback(
-        "Feedback", feedback_component.component_type, message, user
+        "Feedback",
+        feedback_component.component_type,
+        message,
+        user,
+        str(url) if url else None,
     )
     return "OK"
 

--- a/zeeguu/core/emailer/zeeguu_mailer.py
+++ b/zeeguu/core/emailer/zeeguu_mailer.py
@@ -44,19 +44,19 @@ class ZeeguuMailer(object):
         return message.as_string()
 
     @classmethod
-    def send_feedback(cls, subject, context, message, user):
+    def send_feedback(cls, subject, context, message, user, url=None):
 
         print("sending feedback...")
         mailer = ZeeguuMailer(
             subject,
             f"Dear Zeeguu Team,\n\nWrt. **{context}** I'd like to report that: \n\n"
             + message
+            + f"\n@url ({url})"
             + "\n\n"
             + "Cheers,\n"
             + f"{user.name} ({user.id}, {user.email})",
             zeeguu.core.app.config.get("SMTP_EMAIL"),
         )
-
         mailer.send()
 
     @classmethod


### PR DESCRIPTION
- When we get an email there is no URL which means we have to log into the DB to check.
- Added a string so the URL is present in the email sent