### PR TITLE
Fix video language detection

### DIFF
--- a/zeeguu/core/youtube_api/youtube_api.py
+++ b/zeeguu/core/youtube_api/youtube_api.py
@@ -155,10 +155,6 @@ def fetch_video_info(video_unique_key, lang):
         video_info["broken"] = NOT_IN_EXPECTED_LANGUAGE
         return video_info
 
-    # if has_dubbed_audio(video_unique_key):
-    #     print(f"Video {video_unique_key} has dubbed audio.")
-    #     video_info["broken"] = DUBBED_AUDIO
-
     captions = get_captions_from_json(video_unique_key, lang)
     if captions is None:
         print(f"Could not fetch captions for video {video_unique_key} in {lang}")
@@ -209,28 +205,7 @@ def get_captions_with_yttapi(video_unique_key, lang):
             "text": "\n".join(full_text),
             "captions": caption_list,
         }
-        return {
-            "text": "\n".join(full_text),
-            "captions": caption_list,
-        }
 
-    except TranscriptsDisabled:
-        print("Transcript is disabled for this video.")
-        return None
-    except NoTranscriptFound:
-        print(
-            "No manually added transcript was found for this video in the specified language."
-        )
-        return None
-    except VideoUnavailable:
-        print("Video is unavailable.")
-        return None
-    except CouldNotRetrieveTranscript as e:
-        print(f"Could not retrieve transcript: {e}")
-        return None
-    except Exception as e:
-        print(f"Error fetching captions for {video_unique_key}: {e}")
-        return None
     except TranscriptsDisabled:
         print("Transcript is disabled for this video.")
         return None

--- a/zeeguu/core/youtube_api/youtube_api.py
+++ b/zeeguu/core/youtube_api/youtube_api.py
@@ -135,13 +135,18 @@ def fetch_video_info(video_unique_key, lang):
         "channelId": item["snippet"]["channelId"],
         "thumbnail": _get_thumbnail(item),
         "tags": item["snippet"].get("tags", []),
-        "duration": int(
-            isodate.parse_duration(item["contentDetails"]["duration"]).total_seconds()
-        ),
         "text": "",
         "captions": [],
         "broken": 0,
     }
+
+    try:
+        video_info["duration"] = int(
+            isodate.parse_duration(item["contentDetails"]["duration"]).total_seconds()
+        )
+    except KeyError:
+        print(f"Duration not found for video {video_unique_key}. Setting to 0.")
+        video_info["duration"] = 0
 
     if not is_video_language_correct(
         video_info["title"], video_info["description"], lang

--- a/zeeguu/core/youtube_api/youtube_api.py
+++ b/zeeguu/core/youtube_api/youtube_api.py
@@ -138,6 +138,9 @@ def fetch_video_info(video_unique_key, lang):
         "duration": int(
             isodate.parse_duration(item["contentDetails"]["duration"]).total_seconds()
         ),
+        "text": "",
+        "captions": [],
+        "broken": 0,
     }
 
     if not is_video_language_correct(
@@ -145,6 +148,7 @@ def fetch_video_info(video_unique_key, lang):
     ):
         print(f"Video {video_unique_key} is not in the expected language {lang}.")
         video_info["broken"] = NOT_IN_EXPECTED_LANGUAGE
+        return video_info
 
     # if has_dubbed_audio(video_unique_key):
     #     print(f"Video {video_unique_key} has dubbed audio.")
@@ -153,13 +157,10 @@ def fetch_video_info(video_unique_key, lang):
     captions = get_captions_from_json(video_unique_key, lang)
     if captions is None:
         print(f"Could not fetch captions for video {video_unique_key} in {lang}")
-        video_info["text"] = ""
-        video_info["captions"] = []
         video_info["broken"] = NO_CAPTIONS_AVAILABLE
     else:
         video_info["text"] = captions["text"]
         video_info["captions"] = captions["captions"]
-        video_info["broken"] = 0
 
     return video_info
 


### PR DESCRIPTION
- Fix the bug where videos in the wrong language are not set as broken. The problem was that we didn't return after finding the video broken. Before we would still try to find captions for videos in the target language, and sometimes they would be available. Now we save the video as broken as soon as the wrong language is detected.

- Fix another bug where some videos dont have a duration value.

- Clean up some duplicated code.