### PR TITLE
remove wrong videos

### DIFF
--- a/tools/remove_wrong_language_videos.py
+++ b/tools/remove_wrong_language_videos.py
@@ -1,0 +1,27 @@
+from zeeguu.api.app import create_app
+from zeeguu.core.model import db
+from zeeguu.core.model.video import Video
+from zeeguu.core.model.language import Language
+
+from zeeguu.core.youtube_api.youtube_api import is_video_language_correct
+
+app = create_app()
+app.app_context().push()
+
+videos = Video.query.all()
+
+print("removing videos with wrong language videos")
+for video in videos:
+    if video.broken == 0:
+        video_language = video.language.code
+
+        if not is_video_language_correct(
+            video.title, video.description, video_language
+        ):
+            print(
+                f"Video {video} has wrong language: {video_language}, setting to broken"
+            )
+            video.broken = 2
+
+print("done")
+db.session.commit()

--- a/tools/remove_wrong_videos.py
+++ b/tools/remove_wrong_videos.py
@@ -30,9 +30,7 @@ print("removing videos with too short captions")
 for video in videos:
     if video.broken == 0:
         if is_captions_too_short(video.get_content(), video.duration):
-            print(
-                f"Video {video} has too short captions: {video_language}, setting to broken"
-            )
+            print(f"Video {video} has too short captions setting to broken")
             video.broken = 4
 
 print("done")

--- a/tools/remove_wrong_videos.py
+++ b/tools/remove_wrong_videos.py
@@ -6,7 +6,8 @@ from zeeguu.core.model.language import Language
 from zeeguu.core.youtube_api.youtube_api import (
     is_video_language_correct,
     is_captions_too_short,
-    NOT_IN_EXPECTED_LANGUAGE
+    NOT_IN_EXPECTED_LANGUAGE,
+    CAPTIONS_TOO_SHORT,
 )
 
 app = create_app()
@@ -29,10 +30,10 @@ for video in videos:
 
 print("removing videos with too short captions")
 for video in videos:
-    if video.broken == 0:
+    if not video.broken:
         if is_captions_too_short(video.get_content(), video.duration):
             print(f"Video {video} has too short captions setting to broken")
-            video.broken = 4
+            video.broken = CAPTIONS_TOO_SHORT
 
 print("done")
 db.session.commit()

--- a/tools/remove_wrong_videos.py
+++ b/tools/remove_wrong_videos.py
@@ -6,6 +6,7 @@ from zeeguu.core.model.language import Language
 from zeeguu.core.youtube_api.youtube_api import (
     is_video_language_correct,
     is_captions_too_short,
+    NOT_IN_EXPECTED_LANGUAGE
 )
 
 app = create_app()
@@ -24,7 +25,7 @@ for video in videos:
             print(
                 f"Video {video} has wrong language: {video_language}, setting to broken"
             )
-            video.broken = 2
+            video.broken = NOT_IN_EXPECTED_LANGUAGE
 
 print("removing videos with too short captions")
 for video in videos:

--- a/tools/remove_wrong_videos.py
+++ b/tools/remove_wrong_videos.py
@@ -15,7 +15,7 @@ videos = Video.query.all()
 
 print("removing videos with wrong language")
 for video in videos:
-    if video.broken == 0:
+    if not video.broken:
         video_language = video.language.code
 
         if not is_video_language_correct(

--- a/tools/remove_wrong_videos.py
+++ b/tools/remove_wrong_videos.py
@@ -3,14 +3,17 @@ from zeeguu.core.model import db
 from zeeguu.core.model.video import Video
 from zeeguu.core.model.language import Language
 
-from zeeguu.core.youtube_api.youtube_api import is_video_language_correct
+from zeeguu.core.youtube_api.youtube_api import (
+    is_video_language_correct,
+    is_captions_too_short,
+)
 
 app = create_app()
 app.app_context().push()
 
 videos = Video.query.all()
 
-print("removing videos with wrong language videos")
+print("removing videos with wrong language")
 for video in videos:
     if video.broken == 0:
         video_language = video.language.code
@@ -22,6 +25,15 @@ for video in videos:
                 f"Video {video} has wrong language: {video_language}, setting to broken"
             )
             video.broken = 2
+
+print("removing videos with too short captions")
+for video in videos:
+    if video.broken == 0:
+        if is_captions_too_short(video.get_content(), video.duration):
+            print(
+                f"Video {video} has too short captions: {video_language}, setting to broken"
+            )
+            video.broken = 4
 
 print("done")
 db.session.commit()

--- a/zeeguu/core/youtube_api/youtube_api.py
+++ b/zeeguu/core/youtube_api/youtube_api.py
@@ -361,7 +361,4 @@ def fetch_channel_info(channel_id):
 
 def is_captions_too_short(caption_text: str, video_duration_in_seconds: int) -> bool:
     # After consolidating different videos and captions, we have found that 1 word per second is a good threshold
-    if len(caption_text.split()) < video_duration_in_seconds:
-        return True
-    else:
-        return False
+    return len(caption_text.split()) < video_duration_in_seconds

--- a/zeeguu/core/youtube_api/youtube_api.py
+++ b/zeeguu/core/youtube_api/youtube_api.py
@@ -162,7 +162,6 @@ def fetch_video_info(video_unique_key, lang):
         video_info["broken"] = NOT_IN_EXPECTED_LANGUAGE
         return video_info
 
-    # Fetch captions
     captions = get_captions_from_json(video_unique_key, lang)
     if captions is None:
         print(f"Could not fetch captions for video {video_unique_key} in {lang}")
@@ -360,9 +359,9 @@ def fetch_channel_info(channel_id):
     return channel_info
 
 
-def is_captions_too_short(captions: str, video_duration_in_seconds: int) -> bool:
+def is_captions_too_short(caption_text: str, video_duration_in_seconds: int) -> bool:
     # After consolidating different videos and captions, we have found that 1 word per second is a good threshold
-    if len(captions) < video_duration_in_seconds:
+    if len(caption_text.split()) < video_duration_in_seconds:
         return True
     else:
         return False


### PR DESCRIPTION
Created a script that removes all the videos that are: 
- detected to be in the wrong language based on title and description.
- detected to have too few words for the duration of the video. (We have set the cutoff to one word per second based on average talking speed and looking through videos)

run the 'remove_wrong_videos.py' in the tools folder.