### PR TITLE
On-demand simplification: assess-only crawl + per-level preview summaries

### DIFF
--- a/tools/migrations/26-08-12--add_article_level_summary.sql
+++ b/tools/migrations/26-08-12--add_article_level_summary.sql
@@ -31,7 +31,11 @@ CREATE TABLE article_level_summary_context (
     bookmark_id INT NOT NULL,
     article_level_summary_id INT,
     CONSTRAINT fk_alsc_bookmark FOREIGN KEY (bookmark_id) REFERENCES bookmark (id),
-    CONSTRAINT fk_alsc_summary FOREIGN KEY (article_level_summary_id) REFERENCES article_level_summary (id) ON DELETE CASCADE
+    CONSTRAINT fk_alsc_summary FOREIGN KEY (article_level_summary_id) REFERENCES article_level_summary (id) ON DELETE CASCADE,
+    -- One context row per (bookmark, level summary): makes a concurrent-insert
+    -- race fail with IntegrityError (which find_or_create catches + re-queries)
+    -- instead of silently creating a duplicate that later breaks .one().
+    UNIQUE KEY uq_alsc_bookmark_summary (bookmark_id, article_level_summary_id)
 );
 
 -- New context type so the bookmark/context pipeline can dispatch to the join above.

--- a/tools/migrations/26-08-12--add_article_level_summary.sql
+++ b/tools/migrations/26-08-12--add_article_level_summary.sql
@@ -1,0 +1,37 @@
+-- Per-level preview summaries for the on-demand simplification flow.
+--
+-- Simplification is now on-demand: the crawl no longer pre-generates full
+-- simplified article bodies for every CEFR level. But the feed card still wants
+-- a LEVEL-APPROPRIATE, tappable summary for each learner. Previously that came
+-- for free from the per-level simplified child articles (each carried its own
+-- summary + tokenization + tap-context, keyed by the child's article_id). With
+-- no children, we store the per-level summaries directly, cheaply.
+--
+-- article_level_summary: one short summary per (article, level-below-original).
+-- The original-level summary stays in article.summary as the fallback.
+CREATE TABLE article_level_summary (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    article_id INT NOT NULL,
+    cefr_level ENUM('A1', 'A2', 'B1', 'B2', 'C1', 'C2') NOT NULL,
+    summary TEXT,
+    tokenized_summary JSON,
+    ai_model VARCHAR(255),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_als_article FOREIGN KEY (article_id) REFERENCES article (id) ON DELETE CASCADE,
+    UNIQUE KEY uq_article_level (article_id, cefr_level)
+);
+
+-- article_level_summary_context: the tap-to-translate context join, mirroring
+-- article_fragment_context. Anchors a bookmark to a SPECIFIC level's summary so
+-- past-bookmark highlighting lands on the right tokens (summaries differ by
+-- level, so token coordinates are not shared across levels).
+CREATE TABLE article_level_summary_context (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    bookmark_id INT NOT NULL,
+    article_level_summary_id INT,
+    CONSTRAINT fk_alsc_bookmark FOREIGN KEY (bookmark_id) REFERENCES bookmark (id),
+    CONSTRAINT fk_alsc_summary FOREIGN KEY (article_level_summary_id) REFERENCES article_level_summary (id) ON DELETE CASCADE
+);
+
+-- New context type so the bookmark/context pipeline can dispatch to the join above.
+INSERT INTO context_type (type) VALUES ('ArticleLevelSummary');

--- a/tools/migrations/26-08-12--add_article_level_summary.sql
+++ b/tools/migrations/26-08-12--add_article_level_summary.sql
@@ -15,9 +15,10 @@ CREATE TABLE article_level_summary (
     cefr_level ENUM('A1', 'A2', 'B1', 'B2', 'C1', 'C2') NOT NULL,
     summary TEXT,
     tokenized_summary JSON,
-    ai_model VARCHAR(255),
+    ai_generator_id INT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT fk_als_article FOREIGN KEY (article_id) REFERENCES article (id) ON DELETE CASCADE,
+    CONSTRAINT fk_als_ai_generator FOREIGN KEY (ai_generator_id) REFERENCES ai_generator (id),
     UNIQUE KEY uq_article_level (article_id, cefr_level)
 );
 

--- a/zeeguu/core/account_management/user_account_deletion.py
+++ b/zeeguu/core/account_management/user_account_deletion.py
@@ -39,6 +39,7 @@ from zeeguu.core.model.audio_lesson_generation_progress import AudioLessonGenera
 from zeeguu.core.model.user_word_interaction_history import UserWordInteractionHistory
 from zeeguu.core.model.example_sentence_context import ExampleSentenceContext
 from zeeguu.core.model.article_summary_context import ArticleSummaryContext
+from zeeguu.core.model.article_level_summary_context import ArticleLevelSummaryContext
 from zeeguu.core.model.article_fragment_context import ArticleFragmentContext
 from zeeguu.core.model.article_title_context import ArticleTitleContext
 from zeeguu.core.model.video_caption_context import VideoCaptionContext
@@ -67,6 +68,7 @@ from zeeguu.core.model.example_sentence import ExampleSentence
 bookmark_context_tables = [
     ExampleSentenceContext,
     ArticleSummaryContext,
+    ArticleLevelSummaryContext,
     ArticleFragmentContext,
     ArticleTitleContext,
     VideoCaptionContext,

--- a/zeeguu/core/content_recommender/elastic_recommender.py
+++ b/zeeguu/core/content_recommender/elastic_recommender.py
@@ -552,42 +552,36 @@ def get_user_info_from_content_recommendations(user, content_list):
 
 def _apply_simplified_display_overlay(user, results):
     """
-    Overlay the simplified *title* and *summary* onto result dicts that
-    point at an original article, when a CEFR-matched simplified child
-    exists. The publisher's headline is reachable via the article's
-    source/url at the publisher itself — no need to surface it on the
-    card.
+    Overlay a CEFR-level-matched preview *summary* onto feed-card result dicts
+    that point at an original article, using the per-level ArticleLevelSummary
+    rows (on-demand simplification means there are no simplified child articles
+    to borrow a summary from anymore).
 
-    Result ids, urls, and parent linkage are untouched, so the
-    "Simplified" badge, save state, and external-open routing in
-    ArticlePreview are unchanged. Falls back silently to the original
-    title/summary when no level match exists.
+    Sets both the plain ``summary`` teaser (Preview mode) and the tappable
+    ``interactiveSummary`` payload (Interactive mode), the latter anchored to the
+    specific level-summary row so tap-to-translate and past-bookmark highlighting
+    land on the right tokens. Titles are left as the original — we don't produce
+    per-level titles. Falls back silently to the article's own summary when the
+    learner's level has no simpler summary.
 
-    Batched: one IN-query for simplified children (+ joined CEFR
-    assessments), one for their tokenization caches. past_bookmarks
-    are populated against the simplified article's id — the card lives
-    over the simplified content (title/summary come from there), so
-    the bookmarks the user made while reading that simplified article
-    are the right ones to highlight.
+    Batched: one IN-query for all candidate articles' level summaries.
     """
-    import json
-    from sqlalchemy.orm import joinedload
-    from zeeguu.core.model import db
-    from zeeguu.core.model.article import (
-        strip_trailing_ellipsis,
-        strip_trailing_ellipsis_tokens_json,
+    from zeeguu.core.model.article_level_summary import (
+        ArticleLevelSummary,
+        CEFR_ORDER,
     )
-    from zeeguu.core.model.article_tokenization_cache import ArticleTokenizationCache
-    from zeeguu.core.model.article_title_context import ArticleTitleContext
-    from zeeguu.core.model.article_summary_context import ArticleSummaryContext
+    from zeeguu.core.model.article_level_summary_context import (
+        ArticleLevelSummaryContext,
+    )
     from zeeguu.core.model.context_identifier import ContextIdentifier
     from zeeguu.core.model.context_type import ContextType
+    from sqlalchemy.orm.exc import NoResultFound
 
     try:
         user_cefr_level = user.cefr_level_for_learned_language()
-    except (AttributeError, IndexError, TypeError):
+    except (AttributeError, IndexError, TypeError, NoResultFound):
         return
-    if not user_cefr_level:
+    if not user_cefr_level or user_cefr_level not in CEFR_ORDER:
         return
 
     candidate_ids = [
@@ -597,104 +591,45 @@ def _apply_simplified_display_overlay(user, results):
     if not candidate_ids:
         return
 
-    # Only same-language children may overlay an original. A child is normally a
-    # simplification (same language), but a friend-share can now create a
-    # *translated* child (different language) hanging off the same original —
-    # that must NOT be shown as the original's "simplified version" to speakers
-    # of the original's language. (No-op on pre-existing data: today's children
-    # are all same-language.)
-    from sqlalchemy.orm import aliased
-
-    ParentArticle = aliased(Article)
-    children = (
-        Article.query
-        .options(joinedload(Article.cefr_assessment))
-        .join(ParentArticle, Article.parent_article_id == ParentArticle.id)
-        .filter(Article.parent_article_id.in_(candidate_ids))
-        .filter(Article.language_id == ParentArticle.language_id)
+    allowed = set(CEFR_ORDER[: CEFR_ORDER.index(user_cefr_level) + 1])
+    rows = (
+        ArticleLevelSummary.query
+        .filter(ArticleLevelSummary.article_id.in_(candidate_ids))
         .all()
     )
-    if not children:
-        return
-
-    def matches(child):
-        level = (
-            child.cefr_assessment.effective_cefr_level
-            if child.cefr_assessment and child.cefr_assessment.effective_cefr_level
-            else child.cefr_level
-        )
-        if not level:
-            return False
-        if level == user_cefr_level:
-            return True
-        if "/" in level:
-            lo, hi = level.split("/")
-            return user_cefr_level in (lo, hi)
-        return False
-
-    # First level-matching child wins, mirroring get_appropriate_version_for_user_level
-    overlays = {}  # original_id -> simplified Article
-    for child in children:
-        if child.parent_article_id in overlays:
+    # Best level summary per article: highest level at or below the learner's.
+    best = {}  # article_id -> ArticleLevelSummary
+    for row in rows:
+        if row.cefr_level not in allowed:
             continue
-        if matches(child):
-            overlays[child.parent_article_id] = child
+        current = best.get(row.article_id)
+        if current is None or CEFR_ORDER.index(row.cefr_level) > CEFR_ORDER.index(
+            current.cefr_level
+        ):
+            best[row.article_id] = row
 
-    if not overlays:
+    if not best:
         return
-
-    display_articles = list(overlays.values())
-    display_ids = [a.id for a in display_articles]
-    caches = {
-        c.article_id: c
-        for c in db.session.query(ArticleTokenizationCache)
-        .filter(ArticleTokenizationCache.article_id.in_(display_ids))
-        .all()
-    }
-    for article in display_articles:
-        if article.id not in caches:
-            cache, _ = ArticleTokenizationCache.ensure_populated(db.session, article)
-            caches[article.id] = cache
-    db.session.commit()
 
     for result in results:
-        display = overlays.get(result["id"])
+        display = best.get(result["id"])
         if not display:
             continue
 
-        result["title"] = display.title
-
         if display.summary and len(display.summary.strip()) > 10:
-            result["summary"] = strip_trailing_ellipsis(display.summary)
+            result["summary"] = display.summary.strip()
 
-        cache = caches.get(display.id)
-        if not cache:
+        tokens = display.get_tokenized_summary()
+        if not tokens:
             continue
-        if cache.tokenized_title:
-            try:
-                tokens = json.loads(cache.tokenized_title)
-                ctx = ContextIdentifier(ContextType.ARTICLE_TITLE, article_id=display.id)
-                result["interactiveTitle"] = {
-                    "tokens": tokens,
-                    "context_identifier": ctx.as_dictionary(),
-                    "past_bookmarks": ArticleTitleContext.get_all_user_bookmarks_for_article_title(
-                        user.id, display.id
-                    ),
-                }
-            except (json.JSONDecodeError, TypeError):
-                pass
-        if display.summary and cache.tokenized_summary:
-            try:
-                tokens = json.loads(
-                    strip_trailing_ellipsis_tokens_json(cache.tokenized_summary)
-                )
-                ctx = ContextIdentifier(ContextType.ARTICLE_SUMMARY, article_id=display.id)
-                result["interactiveSummary"] = {
-                    "tokens": tokens,
-                    "context_identifier": ctx.as_dictionary(),
-                    "past_bookmarks": ArticleSummaryContext.get_all_user_bookmarks_for_article_summary(
-                        user.id, display.id
-                    ),
-                }
-            except (json.JSONDecodeError, TypeError):
-                pass
+        ctx = ContextIdentifier(
+            ContextType.ARTICLE_LEVEL_SUMMARY,
+            article_level_summary_id=display.id,
+        )
+        result["interactiveSummary"] = {
+            "tokens": tokens,
+            "context_identifier": ctx.as_dictionary(),
+            "past_bookmarks": ArticleLevelSummaryContext.get_all_user_bookmarks_for_article_level_summary(
+                user.id, display.id
+            ),
+        }

--- a/zeeguu/core/content_recommender/elastic_recommender.py
+++ b/zeeguu/core/content_recommender/elastic_recommender.py
@@ -564,7 +564,9 @@ def _apply_simplified_display_overlay(user, results):
     per-level titles. Falls back silently to the article's own summary when the
     learner's level has no simpler summary.
 
-    Batched: one IN-query for all candidate articles' level summaries.
+    Batched in two queries: a columns-only pick of the best level per article,
+    then a load of just those chosen rows (so the heavy tokenized_summary JSON is
+    deserialized once per article, not once per level).
     """
     from zeeguu.core.model.article_level_summary import (
         ArticleLevelSummary,
@@ -591,28 +593,49 @@ def _apply_simplified_display_overlay(user, results):
     if not candidate_ids:
         return
 
-    allowed = set(CEFR_ORDER[: CEFR_ORDER.index(user_cefr_level) + 1])
-    rows = (
+    allowed = ArticleLevelSummary.allowed_levels(user_cefr_level)
+
+    # Two steps so we deserialize the heavy tokenized_summary JSON for only the ONE
+    # best row per article, never every level: first a columns-only query to pick
+    # the best-matching level per article, then load just those chosen rows.
+    lightweight = (
         ArticleLevelSummary.query
-        .filter(ArticleLevelSummary.article_id.in_(candidate_ids))
+        .with_entities(
+            ArticleLevelSummary.id,
+            ArticleLevelSummary.article_id,
+            ArticleLevelSummary.cefr_level,
+        )
+        .filter(
+            ArticleLevelSummary.article_id.in_(candidate_ids),
+            ArticleLevelSummary.cefr_level.in_(allowed),
+        )
         .all()
     )
-    # Best level summary per article: highest level at or below the learner's.
-    best = {}  # article_id -> ArticleLevelSummary
-    for row in rows:
-        if row.cefr_level not in allowed:
-            continue
-        current = best.get(row.article_id)
-        if current is None or CEFR_ORDER.index(row.cefr_level) > CEFR_ORDER.index(
-            current.cefr_level
-        ):
-            best[row.article_id] = row
-
-    if not best:
+    if not lightweight:
         return
 
+    by_article = {}
+    for row in lightweight:
+        by_article.setdefault(row.article_id, []).append(row)
+
+    chosen_id_by_article = {}
+    for article_id, rows in by_article.items():
+        best_row = ArticleLevelSummary.pick_best(rows, user_cefr_level)
+        if best_row:
+            chosen_id_by_article[article_id] = best_row.id
+    if not chosen_id_by_article:
+        return
+
+    full_by_id = {
+        als.id: als
+        for als in ArticleLevelSummary.query.filter(
+            ArticleLevelSummary.id.in_(chosen_id_by_article.values())
+        ).all()
+    }
+
     for result in results:
-        display = best.get(result["id"])
+        chosen_id = chosen_id_by_article.get(result["id"])
+        display = full_by_id.get(chosen_id) if chosen_id else None
         if not display:
             continue
 

--- a/zeeguu/core/content_retriever/article_downloader.py
+++ b/zeeguu/core/content_retriever/article_downloader.py
@@ -41,6 +41,7 @@ from zeeguu.core.content_retriever import (
 )
 from zeeguu.core.llm_services.simplification_and_classification import (
     simplify_and_classify,
+    assess_summarize_and_classify,
 )
 from zeeguu.core.content_quality.advertorial_detection import is_advertorial
 from zeeguu.core.content_quality.disturbing_content_detection import (
@@ -50,6 +51,15 @@ from zeeguu.core.model.article_broken_code_map import LowQualityTypes
 
 TIMEOUT_SECONDS = 10
 MAX_WORD_FOR_BROKEN_ARTICLE = 10000
+# On-demand simplification: at crawl time we only assess + summarize + classify;
+# full simplification to each CEFR level happens lazily when a learner opens an
+# article (POST /simplify_article/<id>). Set SIMPLIFY_AT_CRAWL=true to restore the
+# legacy behavior of pre-generating every sub-level at crawl time.
+SIMPLIFY_AT_CRAWL = os.environ.get("SIMPLIFY_AT_CRAWL", "false").strip().lower() in (
+    "1",
+    "true",
+    "yes",
+)
 # Max time per feed (safety valve for sequential crawls) - configurable via env var
 MAX_FEED_PROCESSING_TIME_SECONDS = int(os.environ.get("MAX_FEED_PROCESSING_TIME_SECONDS", "300"))
 
@@ -757,34 +767,43 @@ def download_feed_item(session, feed, feed_item, url, crawl_report, simplificati
         )
         _save_classifications(session, new_article, [("DISTURBING", "KEYWORD")])
 
-    # Check topic simplification cap - skip simplification if all topics are "full" for this language today
-    # topic_simplification_counts is keyed by (language_id, topic_id) tuple
-    # Note: article_topic_ids and article_topic_names were captured earlier before potential rollback
-    skip_simplification_due_to_cap = False
-    language_id = feed.language_id
-    lang_code = feed.language.code
-    max_for_lang = get_max_simplified_for_language(lang_code)
+    # The per-(language, topic) daily simplification cap only exists to bound the
+    # cost of pre-generating simplified versions at crawl time. In on-demand mode
+    # no simplified children are created here, so the cap does not apply — every
+    # article still gets the cheap assess+summarize+classify pass.
+    if SIMPLIFY_AT_CRAWL:
+        # topic_simplification_counts is keyed by (language_id, topic_id) tuple
+        # Note: article_topic_ids/names were captured earlier before potential rollback
+        language_id = feed.language_id
+        lang_code = feed.language.code
+        max_for_lang = get_max_simplified_for_language(lang_code)
 
-    if topic_simplification_counts is not None and article_topic_ids:
-        # Check if ANY topic still needs simplified articles today for this language
-        needs_simplification = False
-        for topic_id in article_topic_ids:
-            key = (language_id, topic_id)
-            current_count = topic_simplification_counts.get(key, 0)
-            if current_count < max_for_lang:
-                needs_simplification = True
-                break
+        if topic_simplification_counts is not None and article_topic_ids:
+            # Check if ANY topic still needs simplified articles today for this language
+            needs_simplification = False
+            for topic_id in article_topic_ids:
+                key = (language_id, topic_id)
+                current_count = topic_simplification_counts.get(key, 0)
+                if current_count < max_for_lang:
+                    needs_simplification = True
+                    break
 
-        if not needs_simplification:
-            skip_simplification_due_to_cap = True
-            log(f"   ⏭ Skipping simplification - daily cap ({max_for_lang}/topic) reached for: {article_topic_names}")
-            return new_article
+            if not needs_simplification:
+                log(f"   ⏭ Skipping simplification - daily cap ({max_for_lang}/topic) reached for: {article_topic_names}")
+                return new_article
 
-    # Auto-create simplified versions and classify content
-    log(f"   Calling LLM for simplification and classification...")
+    # On-demand mode: assess + summarize + classify only (no simplified children).
+    # Legacy mode: also pre-generate simplified versions for every sub-level.
+    if SIMPLIFY_AT_CRAWL:
+        log(f"   Calling LLM for simplification and classification...")
+    else:
+        log(f"   Calling LLM for assessment and summary (on-demand simplification)...")
     llm_start_time = time()
     try:
-        simplified_articles, llm_classifications = simplify_and_classify(
+        classify_fn = (
+            simplify_and_classify if SIMPLIFY_AT_CRAWL else assess_summarize_and_classify
+        )
+        simplified_articles, llm_classifications = classify_fn(
             session, new_article, simplification_provider=simplification_provider
         )
         llm_duration = time() - llm_start_time

--- a/zeeguu/core/llm_services/prompts/article_simplification.py
+++ b/zeeguu/core/llm_services/prompts/article_simplification.py
@@ -113,3 +113,86 @@ Original article to simplify:
 TITLE: {{title}}
 
 CONTENT: {{content}}"""
+
+
+def get_assessment_and_summary_prompt(language: str) -> str:
+    """
+    Prompt for the on-demand pipeline's crawl step: assess + summarize + classify
+    ONLY, with no simplified versions generated.
+
+    Simplification has moved to on-demand (a learner requests a level when they
+    open an article), so at crawl time we no longer pre-generate every sub-level.
+    We still need the cheap-to-produce metadata the feed relies on: the original
+    CEFR level (feed ranking + the reader's simplify-offer gate), an abstractive
+    summary (preferred over copyright-risky RSS blurbs), the article type, the
+    disturbing-content flag, and the same paywall/advertorial rejection signals
+    the crawler uses to drop junk. The output is a handful of short fields rather
+    than several full article bodies, so this call costs a fraction of the old
+    all-levels simplification.
+    """
+    language_name = Language.LANGUAGE_NAMES.get(language, language)
+
+    return f"""You are an expert <<LANGUAGE_NAME>> language teacher. Your task is to assess an article's CEFR level and write a short summary. Do NOT rewrite or simplify the article — only assess and summarize it.
+
+CEFR Level Guidelines:
+- A1: Very basic vocabulary (1000 most common words), simple present tense, basic sentence structures
+- A2: Expanded vocabulary (2000 words), past/future tenses, simple connectors
+- B1: Intermediate vocabulary (3000 words), complex sentences, opinion expressions
+- B2: Advanced vocabulary, subjunctive mood, nuanced expressions
+- C1: Sophisticated vocabulary, complex grammar, idiomatic expressions
+- C2: Near-native level, literary devices, specialized terminology
+
+IMPORTANT: If the article appears to be incomplete due to a paywall, simply respond with: "unfinished". This includes:
+- Articles with fewer than 3 paragraphs (very likely incomplete)
+- Articles that end abruptly without a proper conclusion
+- Articles that appear to be only the first paragraph(s) of a longer piece
+- Articles with "subscribe to read more" or similar paywall messages
+- Articles that seem to cut off mid-story or mid-explanation
+- Articles that lack the depth/detail expected from the headline
+- Articles that end with incomplete sentences (like ending with "«." or mid-quote)
+- Articles that introduce a topic but don't provide substantial content about it
+- Articles that have audio elements mentioned ("Lyt til artiklen", "Læst op af") but very little text content
+- Articles that appear to be just a teaser or introduction without the main content
+
+IMPORTANT: If the article appears to be promotional/advertorial content rather than genuine news, simply respond with: "advertorial". This includes:
+- Articles primarily promoting specific products with pricing/discounts ("Ne laissez pas passer cette offre", "à -30%", "en promotion")
+- Articles with affiliate marketing language ("meilleure offre", "bon plan", "code promo")
+- Articles focused on shopping recommendations rather than journalistic news content
+- Articles with repeated brand/retailer mentions (Rakuten, Amazon, etc.) in a promotional context
+- Articles that are essentially product advertisements disguised as news
+- Articles with strong call-to-action language for purchasing ("profitez", "achetez maintenant")
+- Articles that read like shopping guides or product catalogs rather than news reporting
+
+LEVELS TO SUMMARIZE:
+- Also write a level-appropriate summary for EVERY CEFR level simpler than the original.
+- If original is A1, write no extra summaries.
+- If original is A2, write A1.
+- If original is B1, write A1 and A2.
+- If original is B2, write A1, A2, and B1.
+- If original is C1, write A1, A2, B1, and B2.
+- If original is C2, write A1, A2, B1, B2, and C1.
+- Each level's summary conveys the SAME facts as ORIGINAL_SUMMARY but using vocabulary and sentence structure appropriate for that level. Do NOT drop information at lower levels — say the same things more simply.
+
+You must respond in the exact format shown below. Do NOT include any explanations, comments, or meta-text. Do NOT produce full simplified versions of the article — summaries only.
+
+DISTURBING_CONTENT: [YES or NO - would a reader who has asked to avoid disturbing material be upset by this article? Answer YES if EITHER (a) the article's focus is violence, death, or disaster AS AN EVENT - violent crimes, war, terrorism, accidents with casualties, tragic deaths, or graphic violence; OR (b) the article dwells on death/burial imagery and themes even when nobody was harmed - corpses, coffins, being buried (alive or dead), funerary, mortuary, or embalming practices, graphic bodily harm or medical gore. A lifestyle, wellness, or novelty piece whose SUBJECT is death or burial (e.g. "coffin therapy", being buried alive for relaxation) is YES. Note: brief incidental mentions in an otherwise neutral article do NOT count, and purely historical or educational treatment of a difficult topic is acceptable (NO).]
+
+ARTICLE_TYPE: [NEWS or GENERAL - NEWS = current events tied to a specific time (politics, breaking news, weather, sports results, someone visiting somewhere today, elections, daily events). GENERAL = evergreen content you could read months later (science explainers, cultural topics, how-to guides, historical articles, general knowledge, health/lifestyle advice).]
+
+ORIGINAL_LEVEL: [assess the CEFR level of the original article: A1, A2, B1, B2, C1, or C2]
+
+ORIGINAL_SUMMARY: [plain text summary (NO markdown formatting, no bold/italic) in <<LANGUAGE_NAME>>, 2-4 sentences scaled to the article (short items 1-2 sentences; longer or denser articles up to 4; hard cap ~70 words). It MUST ADD information the title does not already contain — the specific names, numbers, reasons, consequences, or context the headline implies but does not state; if the title assumes a referent (a person, event, acronym, "a swap with X"), briefly say what it is IF the article explains it. NEVER restate or paraphrase the title: if a reader could guess the summary from the title alone, rewrite it. Use ONLY facts stated in the article — do not add details from your own knowledge. Lead with the concrete facts (who/what/how many/outcome). Paraphrase in your own words: no verbatim sentences or phrases lifted from the article, and no direct quotes. DO NOT use meta-preambles like "The article tells about...", "This article is about...", "Artiklen fortæller om...", "L'article parle de...", "Der Artikel handelt von...", "El artículo trata de...". Just state the content as if reporting it yourself.]
+
+SIMPLIFIED_LEVELS: [comma-separated list of the levels simpler than the original for which you wrote a summary below, e.g. "A1,A2" — leave empty if original is A1]
+
+[For each level in SIMPLIFIED_LEVELS, include this section:]
+
+[LEVEL]_SUMMARY: [plain text summary (NO markdown formatting, no bold/italic) in <<LANGUAGE_NAME>> using vocabulary appropriate for this level, same length limits and same content/no-meta-preamble rules as ORIGINAL_SUMMARY above.]
+
+<<LANGUAGE_NAME>> = {language_name}
+
+Original article to assess:
+
+TITLE: {{title}}
+
+CONTENT: {{content}}"""

--- a/zeeguu/core/llm_services/simplification_and_classification.py
+++ b/zeeguu/core/llm_services/simplification_and_classification.py
@@ -16,7 +16,10 @@ from zeeguu.logging import log
 from zeeguu.core.model.article import Article
 from zeeguu.core.model.url import Url
 from .haiku_client import HAIKU_MODEL, haiku_completion_or_raise
-from .prompts.article_simplification import get_adaptive_simplification_prompt
+from .prompts.article_simplification import (
+    get_adaptive_simplification_prompt,
+    get_assessment_and_summary_prompt,
+)
 from zeeguu.core.llm_services import models
 
 
@@ -36,6 +39,261 @@ def _get_next_simplification_provider() -> str:
         return "deepseek"
     else:
         return "anthropic"
+
+
+def assess_and_summarize(
+    title: str,
+    content: str,
+    target_language: str,
+    simplification_provider: str = None,
+) -> dict:
+    """
+    On-demand-pipeline crawl step: assess CEFR level, summarize, and classify an
+    article in a single LLM call WITHOUT generating any simplified versions.
+
+    This is the cheap replacement for ``simplify_article_adaptive_levels`` on the
+    crawl path now that simplification is on-demand. It returns the same metadata
+    fields the feed relies on and raises the same PAYWALL/ADVERTORIAL exceptions
+    so the crawler's junk-rejection keeps working unchanged.
+
+    Returns:
+        {
+            'original_cefr_level': str,
+            'original_summary': str,
+            'article_type': str | None,   # 'NEWS' | 'GENERAL'
+            'is_disturbing': bool,
+            'provider': str,
+            'model_name': str,
+        }
+
+    Raises:
+        Exception: "PAYWALL: ..." or "ADVERTORIAL: ..." when the LLM flags the
+        article, or on API failure.
+    """
+    prompt_template = get_assessment_and_summary_prompt(target_language)
+    prompt = prompt_template.format(title=title, content=content)
+
+    if simplification_provider:
+        provider = simplification_provider
+    else:
+        provider = _get_next_simplification_provider()
+    log(f"Using {provider.upper()} provider for assessment+summary")
+
+    if provider == "deepseek":
+        api_key = os.environ.get("DEEPSEEK_API_SIMPLIFICATIONS")
+        fallback_api_key = os.environ.get("ANTHROPIC_TEXT_SIMPLIFICATION_KEY")
+    else:
+        api_key = os.environ.get("ANTHROPIC_TEXT_SIMPLIFICATION_KEY")
+        fallback_api_key = os.environ.get("DEEPSEEK_API_SIMPLIFICATIONS")
+
+    if not api_key:
+        log(f"WARNING: {provider.upper()} API key not set, trying fallback")
+        provider = "anthropic" if provider == "deepseek" else "deepseek"
+        api_key = fallback_api_key
+        if not api_key:
+            raise Exception(
+                "Neither DEEPSEEK_API_SIMPLIFICATIONS nor ANTHROPIC_TEXT_SIMPLIFICATION_KEY environment variable set"
+            )
+
+    log(f"Assessing+summarizing article '{title[:50]}...' in {target_language}")
+
+    if provider == "deepseek":
+        model_name = models.DEEPSEEK_GENERAL
+        response = requests.post(
+            "https://api.deepseek.com/v1/chat/completions",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": model_name,
+                "messages": [{"role": "user", "content": prompt}],
+                # Assessment + a ~70-word summary is a handful of short fields, so
+                # a small cap is plenty (vs. 6000 for full multi-level bodies).
+                "max_tokens": 800,
+                "temperature": 0.1,
+            },
+            timeout=120,
+        )
+        if response.status_code != 200:
+            raise Exception(
+                f"DEEPSEEK API error: {response.status_code} - {response.text}"
+            )
+        result = response.json()["choices"][0]["message"]["content"].strip()
+    else:  # anthropic
+        model_name = HAIKU_MODEL
+        result = haiku_completion_or_raise(
+            prompt, max_tokens=800, temperature=0.1, timeout=120
+        ).strip()
+
+    # Same paywall/advertorial rejection contract as the full simplifier.
+    if result.lower().strip() == "unfinished":
+        raise Exception("PAYWALL: Article appears to be incomplete due to paywall")
+    if result.lower().strip() == "advertorial":
+        raise Exception(
+            "ADVERTORIAL: Article appears to be advertorial/promotional content"
+        )
+
+    # Parse the small set of labelled fields, plus any per-level [LEVEL]_SUMMARY
+    # sections (e.g. "A1_SUMMARY:", "B1_SUMMARY:").
+    sections = {}
+    current_section = None
+    current_content = []
+    for line in result.split("\n"):
+        line = line.strip()
+        is_field = ":" in line and any(
+            line.startswith(prefix)
+            for prefix in [
+                "DISTURBING_CONTENT",
+                "ARTICLE_TYPE",
+                "ORIGINAL_LEVEL",
+                "ORIGINAL_SUMMARY",
+                "SIMPLIFIED_LEVELS",
+            ]
+        )
+        is_level_summary = "_SUMMARY:" in line and line.split("_SUMMARY:")[0] in [
+            "A1",
+            "A2",
+            "B1",
+            "B2",
+            "C1",
+            "C2",
+        ]
+        if is_field or is_level_summary:
+            if current_section:
+                sections[current_section] = "\n".join(current_content).strip()
+            current_section = line.split(":")[0]
+            current_content = [line.split(":", 1)[1].strip()]
+        elif current_section:
+            current_content.append(line)
+    if current_section:
+        sections[current_section] = "\n".join(current_content).strip()
+
+    def clean_text(text):
+        return text.strip("[](){}\"'")
+
+    def strip_markdown_from_summary(text):
+        import re
+
+        text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
+        text = re.sub(r"__(.+?)__", r"\1", text)
+        text = re.sub(r"\*(.+?)\*", r"\1", text)
+        text = re.sub(r"(?<!\w)_(.+?)_(?!\w)", r"\1", text)
+        return text
+
+    is_disturbing = clean_text(sections.get("DISTURBING_CONTENT", "NO")).upper() == "YES"
+    article_type_raw = clean_text(sections.get("ARTICLE_TYPE", "")).upper()
+    article_type = article_type_raw if article_type_raw in ["NEWS", "GENERAL"] else None
+    original_level = clean_text(sections.get("ORIGINAL_LEVEL", ""))
+    original_summary = strip_markdown_from_summary(
+        clean_text(sections.get("ORIGINAL_SUMMARY", ""))
+    )
+
+    # Per-level preview summaries (one per level simpler than the original).
+    level_summaries = {}
+    for level in ["A1", "A2", "B1", "B2", "C1", "C2"]:
+        raw = sections.get(f"{level}_SUMMARY")
+        if raw:
+            text = strip_markdown_from_summary(clean_text(raw))
+            if text:
+                level_summaries[level] = text
+
+    return {
+        "original_cefr_level": original_level,
+        "original_summary": original_summary,
+        "article_type": article_type,
+        "is_disturbing": is_disturbing,
+        "level_summaries": level_summaries,
+        "provider": provider,
+        "model_name": model_name,
+    }
+
+
+def assess_summarize_and_classify(
+    session, original_article: Article, simplification_provider: str = None
+) -> tuple[list, list]:
+    """
+    Crawl-time entry point for the on-demand pipeline. Mirrors the return
+    contract of ``simplify_and_classify`` — ``(simplified_articles, classifications)``
+    — but NEVER creates simplified children: it only assesses the original's
+    CEFR level, writes an abstractive summary, and detects article type and
+    disturbing content. Simplification happens later, on demand, when a learner
+    opens the article (POST /simplify_article/<id>).
+
+    The empty ``simplified_articles`` list keeps the caller in
+    ``article_downloader.py`` working with no branch changes, and PAYWALL/
+    ADVERTORIAL exceptions propagate so junk rejection is unchanged.
+    """
+    if original_article.parent_article_id:
+        log(
+            f"SKIP: Article {original_article.id} is already a simplified version (parent: {original_article.parent_article_id})"
+        )
+        return [], []
+
+    word_count = original_article.get_word_count()
+    if word_count < 100:
+        log(
+            f"SKIP: Article {original_article.id} is too short to assess - {word_count} words (minimum: 100 words)"
+        )
+        return [], []
+
+    log(f"STARTING: Assess+summarize (on-demand mode) for article {original_article.id}")
+
+    result = assess_and_summarize(
+        original_article.title,
+        original_article.get_content(),
+        original_article.language.code,
+        simplification_provider=simplification_provider,
+    )
+
+    original_article.cefr_level = result["original_cefr_level"]
+    if result["article_type"]:
+        original_article.article_type = result["article_type"]
+    # Prefer the LLM's abstractive summary over the feed's RSS blurb, which is
+    # often just the headline reworded (and can be verbatim publisher text).
+    if result["original_summary"]:
+        original_article.summary = result["original_summary"]
+    session.commit()
+
+    # Persist the per-level preview summaries (tokenized so the tappable feed-card
+    # preview renders without re-tokenizing on the request path).
+    _store_level_summaries(
+        session,
+        original_article,
+        result.get("level_summaries", {}),
+        result.get("model_name"),
+    )
+
+    classifications = []
+    if result["is_disturbing"]:
+        classifications.append(("DISTURBING", "LLM"))
+    return [], classifications
+
+
+def _store_level_summaries(session, article, level_summaries, model_name):
+    """Create/refresh ArticleLevelSummary rows for an article, tokenizing each."""
+    if not level_summaries:
+        return
+    from zeeguu.core.model.article_level_summary import ArticleLevelSummary
+    from zeeguu.core.mwe import tokenize_for_reading
+
+    for level, summary_text in level_summaries.items():
+        try:
+            tokenized = tokenize_for_reading(summary_text, article.language, mode="stanza")
+        except Exception as e:
+            log(f"  Could not tokenize {level} summary for article {article.id}: {e}")
+            tokenized = None
+        ArticleLevelSummary.find_or_create(
+            session,
+            article,
+            cefr_level=level,
+            summary=summary_text,
+            tokenized_summary=tokenized,
+            ai_model=model_name,
+            commit=False,
+        )
+    session.commit()
+    log(f"  Stored {len(level_summaries)} per-level preview summaries for article {article.id}")
 
 
 def get_target_levels_for_original_level(original_level: str) -> list[str]:

--- a/zeeguu/core/llm_services/simplification_and_classification.py
+++ b/zeeguu/core/llm_services/simplification_and_classification.py
@@ -108,9 +108,11 @@ def assess_and_summarize(
             json={
                 "model": model_name,
                 "messages": [{"role": "user", "content": prompt}],
-                # Assessment + a ~70-word summary is a handful of short fields, so
-                # a small cap is plenty (vs. 6000 for full multi-level bodies).
-                "max_tokens": 800,
+                # Assessment + one ~70-word summary PER level below the original
+                # (up to 5 for a C2 article) plus the original summary. Sized with
+                # headroom so the last-emitted levels aren't truncated — still a
+                # fraction of the 6000 the full multi-level bodies needed.
+                "max_tokens": 2000,
                 "temperature": 0.1,
             },
             timeout=120,
@@ -123,7 +125,7 @@ def assess_and_summarize(
     else:  # anthropic
         model_name = HAIKU_MODEL
         result = haiku_completion_or_raise(
-            prompt, max_tokens=800, temperature=0.1, timeout=120
+            prompt, max_tokens=2000, temperature=0.1, timeout=120
         ).strip()
 
     # Same paywall/advertorial rejection contract as the full simplifier.
@@ -270,12 +272,25 @@ def assess_summarize_and_classify(
     return [], classifications
 
 
+# Prompt-version tag so the first-class AIGenerator entity records which prompt
+# produced these summaries (bump when the assess+summarize prompt changes).
+ASSESS_SUMMARY_PROMPT_VERSION = "assess_summary_v1"
+
+
 def _store_level_summaries(session, article, level_summaries, model_name):
     """Create/refresh ArticleLevelSummary rows for an article, tokenizing each."""
     if not level_summaries:
         return
     from zeeguu.core.model.article_level_summary import ArticleLevelSummary
+    from zeeguu.core.model.ai_generator import AIGenerator
     from zeeguu.core.mwe import tokenize_for_reading
+
+    ai_generator_id = None
+    if model_name:
+        ai_generator = AIGenerator.find_or_create(
+            session, model_name, prompt_version=ASSESS_SUMMARY_PROMPT_VERSION
+        )
+        ai_generator_id = ai_generator.id
 
     for level, summary_text in level_summaries.items():
         try:
@@ -289,7 +304,7 @@ def _store_level_summaries(session, article, level_summaries, model_name):
             cefr_level=level,
             summary=summary_text,
             tokenized_summary=tokenized,
-            ai_model=model_name,
+            ai_generator_id=ai_generator_id,
             commit=False,
         )
     session.commit()

--- a/zeeguu/core/llm_services/simplification_and_classification.py
+++ b/zeeguu/core/llm_services/simplification_and_classification.py
@@ -41,6 +41,97 @@ def _get_next_simplification_provider() -> str:
         return "anthropic"
 
 
+def _select_provider_and_key(simplification_provider: str = None):
+    """
+    Resolve the provider (round-robin unless one is given) and its API key,
+    falling back to the other provider when the primary key is unset.
+    Returns (provider, api_key). Shared by the assess-only and full-simplify paths.
+    """
+    if simplification_provider:
+        provider = simplification_provider
+    else:
+        provider = _get_next_simplification_provider()
+    log(f"Using {provider.upper()} provider for simplification")
+
+    if provider == "deepseek":
+        api_key = os.environ.get("DEEPSEEK_API_SIMPLIFICATIONS")
+        fallback_api_key = os.environ.get("ANTHROPIC_TEXT_SIMPLIFICATION_KEY")
+    else:
+        api_key = os.environ.get("ANTHROPIC_TEXT_SIMPLIFICATION_KEY")
+        fallback_api_key = os.environ.get("DEEPSEEK_API_SIMPLIFICATIONS")
+
+    if not api_key:
+        log(f"WARNING: {provider.upper()} API key not set, trying fallback")
+        provider = "anthropic" if provider == "deepseek" else "deepseek"
+        api_key = fallback_api_key
+        if not api_key:
+            raise Exception(
+                "Neither DEEPSEEK_API_SIMPLIFICATIONS nor ANTHROPIC_TEXT_SIMPLIFICATION_KEY environment variable set"
+            )
+    return provider, api_key
+
+
+def _call_simplification_llm(prompt, provider, api_key, max_tokens, timeout=180):
+    """
+    Send `prompt` to the chosen provider and return (result_text, model_name).
+    Raises on a non-200 DeepSeek response or an Anthropic error.
+    """
+    api_start_time = time.time()
+    if provider == "deepseek":
+        model_name = models.DEEPSEEK_GENERAL
+        response = requests.post(
+            "https://api.deepseek.com/v1/chat/completions",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": model_name,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": max_tokens,
+                "temperature": 0.1,
+            },
+            timeout=timeout,
+        )
+        if response.status_code != 200:
+            raise Exception(
+                f"DEEPSEEK API error: {response.status_code} - {response.text}"
+            )
+        result = response.json()["choices"][0]["message"]["content"].strip()
+    else:  # anthropic
+        model_name = HAIKU_MODEL
+        result = haiku_completion_or_raise(
+            prompt, max_tokens=max_tokens, temperature=0.1, timeout=timeout
+        ).strip()
+    log(f"  {provider.upper()} responded in {time.time() - api_start_time:.2f}s ({len(result)} chars)")
+    return result, model_name
+
+
+def _raise_if_paywall_or_advertorial(result):
+    """Both prompts answer with a bare token when the article is junk — reject it."""
+    if result.lower().strip() == "unfinished":
+        raise Exception("PAYWALL: Article appears to be incomplete due to paywall")
+    if result.lower().strip() == "advertorial":
+        raise Exception(
+            "ADVERTORIAL: Article appears to be advertorial/promotional content"
+        )
+
+
+def _clean_text(text):
+    return text.strip("[](){}\"'")
+
+
+def _strip_markdown_from_summary(text):
+    """Remove markdown bold/italic formatting from summary text."""
+    import re
+
+    text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
+    text = re.sub(r"__(.+?)__", r"\1", text)
+    text = re.sub(r"\*(.+?)\*", r"\1", text)
+    text = re.sub(r"(?<!\w)_(.+?)_(?!\w)", r"\1", text)
+    return text
+
+
 def assess_and_summarize(
     title: str,
     content: str,
@@ -73,68 +164,17 @@ def assess_and_summarize(
     prompt_template = get_assessment_and_summary_prompt(target_language)
     prompt = prompt_template.format(title=title, content=content)
 
-    if simplification_provider:
-        provider = simplification_provider
-    else:
-        provider = _get_next_simplification_provider()
-    log(f"Using {provider.upper()} provider for assessment+summary")
-
-    if provider == "deepseek":
-        api_key = os.environ.get("DEEPSEEK_API_SIMPLIFICATIONS")
-        fallback_api_key = os.environ.get("ANTHROPIC_TEXT_SIMPLIFICATION_KEY")
-    else:
-        api_key = os.environ.get("ANTHROPIC_TEXT_SIMPLIFICATION_KEY")
-        fallback_api_key = os.environ.get("DEEPSEEK_API_SIMPLIFICATIONS")
-
-    if not api_key:
-        log(f"WARNING: {provider.upper()} API key not set, trying fallback")
-        provider = "anthropic" if provider == "deepseek" else "deepseek"
-        api_key = fallback_api_key
-        if not api_key:
-            raise Exception(
-                "Neither DEEPSEEK_API_SIMPLIFICATIONS nor ANTHROPIC_TEXT_SIMPLIFICATION_KEY environment variable set"
-            )
-
+    provider, api_key = _select_provider_and_key(simplification_provider)
     log(f"Assessing+summarizing article '{title[:50]}...' in {target_language}")
 
-    if provider == "deepseek":
-        model_name = models.DEEPSEEK_GENERAL
-        response = requests.post(
-            "https://api.deepseek.com/v1/chat/completions",
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            },
-            json={
-                "model": model_name,
-                "messages": [{"role": "user", "content": prompt}],
-                # Assessment + one ~70-word summary PER level below the original
-                # (up to 5 for a C2 article) plus the original summary. Sized with
-                # headroom so the last-emitted levels aren't truncated — still a
-                # fraction of the 6000 the full multi-level bodies needed.
-                "max_tokens": 2000,
-                "temperature": 0.1,
-            },
-            timeout=120,
-        )
-        if response.status_code != 200:
-            raise Exception(
-                f"DEEPSEEK API error: {response.status_code} - {response.text}"
-            )
-        result = response.json()["choices"][0]["message"]["content"].strip()
-    else:  # anthropic
-        model_name = HAIKU_MODEL
-        result = haiku_completion_or_raise(
-            prompt, max_tokens=2000, temperature=0.1, timeout=120
-        ).strip()
-
-    # Same paywall/advertorial rejection contract as the full simplifier.
-    if result.lower().strip() == "unfinished":
-        raise Exception("PAYWALL: Article appears to be incomplete due to paywall")
-    if result.lower().strip() == "advertorial":
-        raise Exception(
-            "ADVERTORIAL: Article appears to be advertorial/promotional content"
-        )
+    # Assessment + one ~70-word summary PER level below the original (up to 5 for a
+    # C2 article) plus the original summary. 2000 gives headroom over the single-
+    # summary sizing so the last-emitted levels aren't truncated — still a fraction
+    # of the 6000 the full multi-level bodies needed.
+    result, model_name = _call_simplification_llm(
+        prompt, provider, api_key, max_tokens=2000, timeout=120
+    )
+    _raise_if_paywall_or_advertorial(result)
 
     # Parse the small set of labelled fields, plus any per-level [LEVEL]_SUMMARY
     # sections (e.g. "A1_SUMMARY:", "B1_SUMMARY:").
@@ -171,24 +211,12 @@ def assess_and_summarize(
     if current_section:
         sections[current_section] = "\n".join(current_content).strip()
 
-    def clean_text(text):
-        return text.strip("[](){}\"'")
-
-    def strip_markdown_from_summary(text):
-        import re
-
-        text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
-        text = re.sub(r"__(.+?)__", r"\1", text)
-        text = re.sub(r"\*(.+?)\*", r"\1", text)
-        text = re.sub(r"(?<!\w)_(.+?)_(?!\w)", r"\1", text)
-        return text
-
-    is_disturbing = clean_text(sections.get("DISTURBING_CONTENT", "NO")).upper() == "YES"
-    article_type_raw = clean_text(sections.get("ARTICLE_TYPE", "")).upper()
+    is_disturbing = _clean_text(sections.get("DISTURBING_CONTENT", "NO")).upper() == "YES"
+    article_type_raw = _clean_text(sections.get("ARTICLE_TYPE", "")).upper()
     article_type = article_type_raw if article_type_raw in ["NEWS", "GENERAL"] else None
-    original_level = clean_text(sections.get("ORIGINAL_LEVEL", ""))
-    original_summary = strip_markdown_from_summary(
-        clean_text(sections.get("ORIGINAL_SUMMARY", ""))
+    original_level = _clean_text(sections.get("ORIGINAL_LEVEL", ""))
+    original_summary = _strip_markdown_from_summary(
+        _clean_text(sections.get("ORIGINAL_SUMMARY", ""))
     )
 
     # Per-level preview summaries (one per level simpler than the original).
@@ -196,7 +224,7 @@ def assess_and_summarize(
     for level in ["A1", "A2", "B1", "B2", "C1", "C2"]:
         raw = sections.get(f"{level}_SUMMARY")
         if raw:
-            text = strip_markdown_from_summary(clean_text(raw))
+            text = _strip_markdown_from_summary(_clean_text(raw))
             if text:
                 level_summaries[level] = text
 
@@ -392,85 +420,17 @@ def simplify_article_adaptive_levels(
     prompt_template = get_adaptive_simplification_prompt(target_language)
     prompt = prompt_template.format(title=title, content=content)
 
-    # Choose provider: use specified, or round-robin between deepseek and anthropic
-    if simplification_provider:
-        provider = simplification_provider
-    else:
-        # Round-robin based on a simple counter
-        provider = _get_next_simplification_provider()
-    log(f"Using {provider.upper()} provider for simplification")
-
-    # Try the chosen provider first, fallback to the other if it fails
-    if provider == "deepseek":
-        api_key = os.environ.get("DEEPSEEK_API_SIMPLIFICATIONS")
-        fallback_api_key = os.environ.get("ANTHROPIC_TEXT_SIMPLIFICATION_KEY")
-    else:
-        api_key = os.environ.get("ANTHROPIC_TEXT_SIMPLIFICATION_KEY")
-        fallback_api_key = os.environ.get("DEEPSEEK_API_SIMPLIFICATIONS")
-
-    if not api_key:
-        log(f"WARNING: {provider.upper()} API key not set, trying fallback")
-        provider = "anthropic" if provider == "deepseek" else "deepseek"
-        api_key = fallback_api_key
-        if not api_key:
-            raise Exception(
-                "Neither DEEPSEEK_API_SIMPLIFICATIONS nor ANTHROPIC_TEXT_SIMPLIFICATION_KEY environment variable set"
-            )
+    provider, api_key = _select_provider_and_key(simplification_provider)
 
     try:
         log(f"Adaptively simplifying article '{title[:50]}...' in {target_language}")
         log(f"  Article length: {len(content)} characters")
         log(f"  Prompt length: {len(prompt)} characters")
 
-        # Make API call based on provider
-        api_start_time = time.time()
-
-        if provider == "deepseek":
-            model_name = models.DEEPSEEK_GENERAL
-            log(f"  Sending request to DeepSeek API...")
-            response = requests.post(
-                "https://api.deepseek.com/v1/chat/completions",
-                headers={
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                },
-                json={
-                    "model": model_name,
-                    "messages": [{"role": "user", "content": prompt}],
-                    "max_tokens": 6000,
-                    "temperature": 0.1,
-                },
-                timeout=180,
-            )
-            api_duration = time.time() - api_start_time
-            log(
-                f"  DEEPSEEK API responded with status: {response.status_code} (took {api_duration:.2f} seconds)"
-            )
-            if response.status_code != 200:
-                raise Exception(
-                    f"DEEPSEEK API error: {response.status_code} - {response.text}"
-                )
-            result = response.json()["choices"][0]["message"]["content"].strip()
-        else:  # anthropic
-            model_name = HAIKU_MODEL
-            log(f"  Sending request to Anthropic API...")
-            result = haiku_completion_or_raise(
-                prompt, max_tokens=4000, temperature=0.1, timeout=180
-            ).strip()
-            api_duration = time.time() - api_start_time
-            log(f"  ANTHROPIC API completed (took {api_duration:.2f} seconds)")
-
-        log(f"  Response length: {len(result)} characters")
-
-        # Check if article is unfinished due to paywall
-        if result.lower().strip() == "unfinished":
-            raise Exception("PAYWALL: Article appears to be incomplete due to paywall")
-
-        # Check if article is advertorial
-        if result.lower().strip() == "advertorial":
-            raise Exception(
-                "ADVERTORIAL: Article appears to be advertorial/promotional content"
-            )
+        result, model_name = _call_simplification_llm(
+            prompt, provider, api_key, max_tokens=6000, timeout=180
+        )
+        _raise_if_paywall_or_advertorial(result)
 
         log(f"  Parsing response sections...")
         # Parse the response
@@ -517,33 +477,18 @@ def simplify_article_adaptive_levels(
         log(f"  Section keys: {list(sections.keys())}")
 
         # Extract basic info
-        def clean_text(text):
-            return text.strip("[](){}\"'")
-
-        def strip_markdown_from_summary(text):
-            """Remove markdown bold/italic formatting from summary text."""
-            import re
-
-            # Remove bold (**text** or __text__)
-            text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
-            text = re.sub(r"__(.+?)__", r"\1", text)
-            # Remove italic (*text* or _text_)
-            text = re.sub(r"\*(.+?)\*", r"\1", text)
-            text = re.sub(r"(?<!\w)_(.+?)_(?!\w)", r"\1", text)
-            return text
-
         is_disturbing = (
-            clean_text(sections.get("DISTURBING_CONTENT", "NO")).upper() == "YES"
+            _clean_text(sections.get("DISTURBING_CONTENT", "NO")).upper() == "YES"
         )
-        article_type_raw = clean_text(sections.get("ARTICLE_TYPE", "")).upper()
+        article_type_raw = _clean_text(sections.get("ARTICLE_TYPE", "")).upper()
         article_type = (
             article_type_raw if article_type_raw in ["NEWS", "GENERAL"] else None
         )
-        original_level = clean_text(sections.get("ORIGINAL_LEVEL", ""))
-        original_summary = strip_markdown_from_summary(
-            clean_text(sections.get("ORIGINAL_SUMMARY", ""))
+        original_level = _clean_text(sections.get("ORIGINAL_LEVEL", ""))
+        original_summary = _strip_markdown_from_summary(
+            _clean_text(sections.get("ORIGINAL_SUMMARY", ""))
         )
-        simplified_levels_str = clean_text(sections.get("SIMPLIFIED_LEVELS", ""))
+        simplified_levels_str = _clean_text(sections.get("SIMPLIFIED_LEVELS", ""))
 
         # Parse simplified levels
         if simplified_levels_str:
@@ -576,10 +521,10 @@ def simplify_article_adaptive_levels(
 
             if all(key in sections for key in [title_key, content_key, summary_key]):
                 versions[level] = {
-                    "title": clean_text(sections[title_key]),
-                    "content": clean_text(sections[content_key]),
-                    "summary": strip_markdown_from_summary(
-                        clean_text(sections[summary_key])
+                    "title": _clean_text(sections[title_key]),
+                    "content": _clean_text(sections[content_key]),
+                    "summary": _strip_markdown_from_summary(
+                        _clean_text(sections[summary_key])
                     ),
                 }
                 log(f"    Successfully extracted {level} version")

--- a/zeeguu/core/model/__init__.py
+++ b/zeeguu/core/model/__init__.py
@@ -32,6 +32,8 @@ from .bookmark_context import BookmarkContext
 from .article_fragment_context import ArticleFragmentContext
 from .article_title_context import ArticleTitleContext
 from .article_summary_context import ArticleSummaryContext
+from .article_level_summary import ArticleLevelSummary
+from .article_level_summary_context import ArticleLevelSummaryContext
 from .example_sentence import ExampleSentence
 from .example_sentence_context import ExampleSentenceContext
 

--- a/zeeguu/core/model/article_level_summary.py
+++ b/zeeguu/core/model/article_level_summary.py
@@ -1,0 +1,114 @@
+import json
+
+import sqlalchemy
+
+from zeeguu.core.model.article import Article
+from zeeguu.core.model.db import db
+
+# CEFR levels, simplest → most complex. Used to pick the best available summary
+# for a learner's level.
+CEFR_ORDER = ["A1", "A2", "B1", "B2", "C1", "C2"]
+
+
+class ArticleLevelSummary(db.Model):
+    """
+    A short, CEFR-level-specific summary of an Article, used as the tappable
+    preview blurb on feed cards.
+
+    On-demand simplification means the crawl no longer creates a simplified child
+    article per level, so the level-appropriate summaries live here directly
+    instead of on child-article rows. There is at most one row per
+    (article, cefr_level), for levels simpler than the article's own level; the
+    article's own-level summary stays on ``Article.summary``.
+    """
+
+    __table_args__ = {"mysql_collate": "utf8_bin"}
+
+    id = db.Column(db.Integer, primary_key=True)
+
+    article_id = db.Column(db.Integer, db.ForeignKey(Article.id), nullable=False)
+    article = db.relationship(Article)
+
+    cefr_level = db.Column(db.String(2), nullable=False)
+    summary = db.Column(db.UnicodeText)
+    # Cached token stream (same shape as ArticleTokenizationCache.tokenized_summary)
+    # so the tappable preview renders without re-tokenizing on the request path.
+    tokenized_summary = db.Column(db.JSON)
+    ai_model = db.Column(db.String(255))
+    created_at = db.Column(db.DateTime)
+
+    def __init__(self, article, cefr_level, summary, tokenized_summary=None, ai_model=None):
+        self.article = article
+        self.cefr_level = cefr_level
+        self.summary = summary
+        self.tokenized_summary = tokenized_summary
+        self.ai_model = ai_model
+
+    def __repr__(self):
+        return f"<ArticleLevelSummary a:{self.article_id} {self.cefr_level}>"
+
+    @classmethod
+    def find_by_id(cls, id: int):
+        try:
+            return cls.query.filter(cls.id == id).one()
+        except sqlalchemy.orm.exc.NoResultFound:
+            return None
+
+    @classmethod
+    def find_or_create(
+        cls,
+        session,
+        article,
+        cefr_level,
+        summary,
+        tokenized_summary=None,
+        ai_model=None,
+        commit=True,
+    ):
+        try:
+            existing = cls.query.filter(
+                cls.article_id == article.id,
+                cls.cefr_level == cefr_level,
+            ).one()
+            existing.summary = summary
+            existing.tokenized_summary = tokenized_summary
+            existing.ai_model = ai_model
+            session.add(existing)
+            if commit:
+                session.commit()
+            return existing
+        except sqlalchemy.orm.exc.NoResultFound:
+            new = cls(article, cefr_level, summary, tokenized_summary, ai_model)
+            session.add(new)
+            if commit:
+                session.commit()
+            return new
+
+    @classmethod
+    def best_for_user_level(cls, article_id: int, user_level: str):
+        """
+        Return the ArticleLevelSummary best matching a learner's CEFR level: the
+        highest stored level that is still at or below ``user_level`` (rows only
+        exist for levels below the article's own, so a learner at or above the
+        article level gets None and the caller falls back to Article.summary).
+        Returns None when there's no suitable per-level summary.
+        """
+        if user_level not in CEFR_ORDER:
+            return None
+        allowed = set(CEFR_ORDER[: CEFR_ORDER.index(user_level) + 1])
+        rows = cls.query.filter(cls.article_id == article_id).all()
+        candidates = [r for r in rows if r.cefr_level in allowed]
+        if not candidates:
+            return None
+        return max(candidates, key=lambda r: CEFR_ORDER.index(r.cefr_level))
+
+    def get_tokenized_summary(self):
+        """Parse the cached token stream, tolerating either JSON text or a dict."""
+        if not self.tokenized_summary:
+            return None
+        if isinstance(self.tokenized_summary, str):
+            try:
+                return json.loads(self.tokenized_summary)
+            except (ValueError, TypeError):
+                return None
+        return self.tokenized_summary

--- a/zeeguu/core/model/article_level_summary.py
+++ b/zeeguu/core/model/article_level_summary.py
@@ -89,6 +89,30 @@ class ArticleLevelSummary(db.Model):
                 session.commit()
             return new
 
+    @staticmethod
+    def allowed_levels(user_level: str):
+        """CEFR levels at or below ``user_level`` (the levels a learner can read),
+        or None if the level is unknown."""
+        if user_level not in CEFR_ORDER:
+            return None
+        return set(CEFR_ORDER[: CEFR_ORDER.index(user_level) + 1])
+
+    @staticmethod
+    def pick_best(candidates, user_level: str):
+        """
+        From ``candidates`` (any objects with a ``.cefr_level``), return the one at
+        the highest level still at or below ``user_level``, or None. This is the
+        single source of truth for level selection, shared by the single-article
+        lookup and the batched feed overlay so they can't drift apart.
+        """
+        allowed = ArticleLevelSummary.allowed_levels(user_level)
+        if not allowed:
+            return None
+        eligible = [c for c in candidates if c.cefr_level in allowed]
+        if not eligible:
+            return None
+        return max(eligible, key=lambda c: CEFR_ORDER.index(c.cefr_level))
+
     @classmethod
     def best_for_user_level(cls, article_id: int, user_level: str):
         """
@@ -98,14 +122,13 @@ class ArticleLevelSummary(db.Model):
         article level gets None and the caller falls back to Article.summary).
         Returns None when there's no suitable per-level summary.
         """
-        if user_level not in CEFR_ORDER:
+        allowed = cls.allowed_levels(user_level)
+        if not allowed:
             return None
-        allowed = set(CEFR_ORDER[: CEFR_ORDER.index(user_level) + 1])
-        rows = cls.query.filter(cls.article_id == article_id).all()
-        candidates = [r for r in rows if r.cefr_level in allowed]
-        if not candidates:
-            return None
-        return max(candidates, key=lambda r: CEFR_ORDER.index(r.cefr_level))
+        rows = cls.query.filter(
+            cls.article_id == article_id, cls.cefr_level.in_(allowed)
+        ).all()
+        return cls.pick_best(rows, user_level)
 
     def get_tokenized_summary(self):
         """Parse the cached token stream, tolerating either JSON text or a dict."""

--- a/zeeguu/core/model/article_level_summary.py
+++ b/zeeguu/core/model/article_level_summary.py
@@ -34,15 +34,20 @@ class ArticleLevelSummary(db.Model):
     # Cached token stream (same shape as ArticleTokenizationCache.tokenized_summary)
     # so the tappable preview renders without re-tokenizing on the request path.
     tokenized_summary = db.Column(db.JSON)
-    ai_model = db.Column(db.String(255))
-    created_at = db.Column(db.DateTime)
+    # First-class generator entity (model_name + prompt_version), same as
+    # Article.simplification_ai_generator_id — not a raw model-name string.
+    ai_generator_id = db.Column(db.Integer, db.ForeignKey("ai_generator.id"))
+    ai_generator = db.relationship("AIGenerator", foreign_keys=[ai_generator_id])
+    created_at = db.Column(db.DateTime, server_default=db.func.now())
 
-    def __init__(self, article, cefr_level, summary, tokenized_summary=None, ai_model=None):
+    def __init__(
+        self, article, cefr_level, summary, tokenized_summary=None, ai_generator_id=None
+    ):
         self.article = article
         self.cefr_level = cefr_level
         self.summary = summary
         self.tokenized_summary = tokenized_summary
-        self.ai_model = ai_model
+        self.ai_generator_id = ai_generator_id
 
     def __repr__(self):
         return f"<ArticleLevelSummary a:{self.article_id} {self.cefr_level}>"
@@ -62,7 +67,7 @@ class ArticleLevelSummary(db.Model):
         cefr_level,
         summary,
         tokenized_summary=None,
-        ai_model=None,
+        ai_generator_id=None,
         commit=True,
     ):
         try:
@@ -72,13 +77,13 @@ class ArticleLevelSummary(db.Model):
             ).one()
             existing.summary = summary
             existing.tokenized_summary = tokenized_summary
-            existing.ai_model = ai_model
+            existing.ai_generator_id = ai_generator_id
             session.add(existing)
             if commit:
                 session.commit()
             return existing
         except sqlalchemy.orm.exc.NoResultFound:
-            new = cls(article, cefr_level, summary, tokenized_summary, ai_model)
+            new = cls(article, cefr_level, summary, tokenized_summary, ai_generator_id)
             session.add(new)
             if commit:
                 session.commit()

--- a/zeeguu/core/model/article_level_summary_context.py
+++ b/zeeguu/core/model/article_level_summary_context.py
@@ -12,7 +12,15 @@ class ArticleLevelSummaryContext(db.Model):
     Mirrors ArticleFragmentContext (keyed on a granular id, not article_id).
     """
 
-    __table_args__ = {"mysql_collate": "utf8_bin"}
+    __table_args__ = (
+        # At most one context row per (bookmark, level summary) — see find_or_create.
+        db.UniqueConstraint(
+            "bookmark_id",
+            "article_level_summary_id",
+            name="uq_alsc_bookmark_summary",
+        ),
+        {"mysql_collate": "utf8_bin"},
+    )
 
     id = db.Column(db.Integer, primary_key=True)
 
@@ -44,17 +52,31 @@ class ArticleLevelSummaryContext(db.Model):
 
     @classmethod
     def find_or_create(cls, session, bookmark, article_level_summary, commit=True):
+        existing = cls.query.filter(
+            cls.bookmark == bookmark,
+            cls.article_level_summary == article_level_summary,
+        ).one_or_none()
+        if existing:
+            return existing
+
+        # Insert inside a SAVEPOINT so that if a concurrent request created the
+        # same (bookmark, level summary) between our SELECT and INSERT, the unique
+        # constraint fires and we roll back just this insert (not the caller's
+        # whole transaction, which may still be uncommitted when commit=False) and
+        # return the row the other request created.
+        new = cls(bookmark, article_level_summary)
         try:
+            with session.begin_nested():
+                session.add(new)
+        except sqlalchemy.exc.IntegrityError:
             return cls.query.filter(
                 cls.bookmark == bookmark,
                 cls.article_level_summary == article_level_summary,
             ).one()
-        except sqlalchemy.orm.exc.NoResultFound or sqlalchemy.exc.InterfaceError:
-            new = cls(bookmark, article_level_summary)
-            session.add(new)
-            if commit:
-                session.commit()
-            return new
+
+        if commit:
+            session.commit()
+        return new
 
     @classmethod
     def get_all_user_bookmarks_for_article_level_summary(

--- a/zeeguu/core/model/article_level_summary_context.py
+++ b/zeeguu/core/model/article_level_summary_context.py
@@ -1,0 +1,72 @@
+from zeeguu.core.model.db import db
+import sqlalchemy
+
+
+class ArticleLevelSummaryContext(db.Model):
+    """
+    A context that is found in a per-level preview summary of an Article
+    (see ArticleLevelSummary). Anchors a bookmark to a SPECIFIC level's summary
+    so past-bookmark highlighting lands on the right tokens — summaries differ
+    by level, so token coordinates are not shared across levels.
+
+    Mirrors ArticleFragmentContext (keyed on a granular id, not article_id).
+    """
+
+    __table_args__ = {"mysql_collate": "utf8_bin"}
+
+    id = db.Column(db.Integer, primary_key=True)
+
+    from zeeguu.core.model.bookmark import Bookmark
+
+    bookmark_id = db.Column(db.Integer, db.ForeignKey(Bookmark.id), nullable=False)
+    bookmark = db.relationship(Bookmark)
+
+    from zeeguu.core.model.article_level_summary import ArticleLevelSummary
+
+    article_level_summary_id = db.Column(
+        db.Integer, db.ForeignKey(ArticleLevelSummary.id)
+    )
+    article_level_summary = db.relationship(ArticleLevelSummary)
+
+    def __init__(self, bookmark, article_level_summary):
+        self.bookmark = bookmark
+        self.article_level_summary = article_level_summary
+
+    def __repr__(self):
+        return f"<ArticleLevelSummaryContext als:{self.article_level_summary_id}, b:{self.bookmark_id}>"
+
+    @classmethod
+    def find_by_bookmark(cls, bookmark):
+        try:
+            return cls.query.filter(cls.bookmark == bookmark).one()
+        except sqlalchemy.orm.exc.NoResultFound:
+            return None
+
+    @classmethod
+    def find_or_create(cls, session, bookmark, article_level_summary, commit=True):
+        try:
+            return cls.query.filter(
+                cls.bookmark == bookmark,
+                cls.article_level_summary == article_level_summary,
+            ).one()
+        except sqlalchemy.orm.exc.NoResultFound or sqlalchemy.exc.InterfaceError:
+            new = cls(bookmark, article_level_summary)
+            session.add(new)
+            if commit:
+                session.commit()
+            return new
+
+    @classmethod
+    def get_all_user_bookmarks_for_article_level_summary(
+        cls, user_id: int, article_level_summary_id: int, as_json_serializable: bool = True
+    ):
+        from zeeguu.core.model import Bookmark, UserWord
+
+        result = (
+            Bookmark.query.join(cls)
+            .join(UserWord, Bookmark.user_word_id == UserWord.id)
+            .filter(cls.article_level_summary_id == article_level_summary_id)
+            .filter(UserWord.user_id == user_id)
+        ).all()
+
+        return [each.to_json(True) if as_json_serializable else each for each in result]

--- a/zeeguu/core/model/bookmark.py
+++ b/zeeguu/core/model/bookmark.py
@@ -152,6 +152,19 @@ class Bookmark(db.Model):
             else:
                 # Fallback: context mapping is missing
                 return "[Title not available]"
+        if self.context.context_type.type == ContextType.ARTICLE_LEVEL_SUMMARY:
+            from zeeguu.core.model.article_level_summary_context import (
+                ArticleLevelSummaryContext,
+            )
+
+            level_summary_context = ArticleLevelSummaryContext.find_by_bookmark(self)
+            if level_summary_context and level_summary_context.article_level_summary:
+                return Article.find_by_id(
+                    level_summary_context.article_level_summary.article_id
+                ).title
+            else:
+                # Fallback: context mapping is missing
+                return "[Title not available]"
         if self.context.context_type.type == ContextType.VIDEO_TITLE:
             from zeeguu.core.model.video_title_context import VideoTitleContext
 
@@ -429,6 +442,10 @@ class Bookmark(db.Model):
                 case ContextType.ARTICLE_SUMMARY:
                     context_identifier.article_id = (
                         result.article_id if result else None
+                    )
+                case ContextType.ARTICLE_LEVEL_SUMMARY:
+                    context_identifier.article_level_summary_id = (
+                        result.article_level_summary_id if result else None
                     )
                 case ContextType.VIDEO_TITLE:
                     context_identifier.video_id = result.video_id if result else None

--- a/zeeguu/core/model/context_identifier.py
+++ b/zeeguu/core/model/context_identifier.py
@@ -10,6 +10,7 @@ class ContextIdentifier:
         video_id=None,
         video_caption_id=None,
         example_sentence_id=None,
+        article_level_summary_id=None,
     ):
         self.context_type = context_type
         self.article_fragment_id = article_fragment_id
@@ -17,6 +18,7 @@ class ContextIdentifier:
         self.video_id = video_id
         self.video_caption_id = video_caption_id
         self.example_sentence_id = example_sentence_id
+        self.article_level_summary_id = article_level_summary_id
 
     def __repr__(self):
         return f"<ContextIdentifier context_type={self.context_type}>"
@@ -33,6 +35,7 @@ class ContextIdentifier:
             video_id=dictionary.get("video_id", None),
             video_caption_id=dictionary.get("video_caption_id", None),
             example_sentence_id=dictionary.get("example_sentence_id", None),
+            article_level_summary_id=dictionary.get("article_level_summary_id", None),
         )
 
     @classmethod
@@ -47,6 +50,7 @@ class ContextIdentifier:
             "video_id": self.video_id,
             "video_caption_id": self.video_caption_id,
             "example_sentence_id": self.example_sentence_id,
+            "article_level_summary_id": self.article_level_summary_id,
         }
 
     def create_context_mapping(self, session, bookmark, commit=False):
@@ -93,7 +97,21 @@ class ContextIdentifier:
                     session, bookmark, article, commit=commit
                 )
                 session.add(mapped_context)
-                
+
+            case ContextType.ARTICLE_LEVEL_SUMMARY:
+                if self.article_level_summary_id is None:
+                    return None
+                from zeeguu.core.model.article_level_summary import ArticleLevelSummary
+                level_summary = ArticleLevelSummary.find_by_id(
+                    self.article_level_summary_id
+                )
+                if level_summary is None:
+                    return None
+                mapped_context = context_specific_table.find_or_create(
+                    session, bookmark, level_summary, commit=commit
+                )
+                session.add(mapped_context)
+
             case ContextType.VIDEO_TITLE:
                 if self.video_id is None:
                     return None

--- a/zeeguu/core/model/context_type.py
+++ b/zeeguu/core/model/context_type.py
@@ -14,6 +14,7 @@ class ContextType(db.Model):
     ARTICLE_FRAGMENT = "ArticleFragment"
     ARTICLE_TITLE = "ArticleTitle"
     ARTICLE_SUMMARY = "ArticleSummary"
+    ARTICLE_LEVEL_SUMMARY = "ArticleLevelSummary"
     VIDEO_TITLE = "VideoTitle"
     VIDEO_CAPTION = "VideoCaption"
     WEB_FRAGMENT = "WebFragment"
@@ -25,6 +26,7 @@ class ContextType(db.Model):
         ARTICLE_FRAGMENT,
         ARTICLE_TITLE,
         ARTICLE_SUMMARY,
+        ARTICLE_LEVEL_SUMMARY,
         VIDEO_TITLE,
         VIDEO_CAPTION,
         WEB_FRAGMENT,
@@ -71,6 +73,9 @@ class ContextType(db.Model):
         from zeeguu.core.model.article_fragment_context import ArticleFragmentContext
         from zeeguu.core.model.article_title_context import ArticleTitleContext
         from zeeguu.core.model.article_summary_context import ArticleSummaryContext
+        from zeeguu.core.model.article_level_summary_context import (
+            ArticleLevelSummaryContext,
+        )
         from zeeguu.core.model.video_title_context import VideoTitleContext
         from zeeguu.core.model.video_caption_context import VideoCaptionContext
         from zeeguu.core.model.example_sentence_context import ExampleSentenceContext
@@ -82,6 +87,8 @@ class ContextType(db.Model):
                 return ArticleTitleContext
             case cls.ARTICLE_SUMMARY:
                 return ArticleSummaryContext
+            case cls.ARTICLE_LEVEL_SUMMARY:
+                return ArticleLevelSummaryContext
             case cls.VIDEO_TITLE:
                 return VideoTitleContext
             case cls.VIDEO_CAPTION:

--- a/zeeguu/core/model/user_article.py
+++ b/zeeguu/core/model/user_article.py
@@ -691,6 +691,47 @@ class UserArticle(db.Model):
                     token.pop("mwe_partner_indices", None)
 
     @classmethod
+    def _level_matched_summary_payload(cls, user, article):
+        """
+        Return the tappable-summary payload for the ArticleLevelSummary matching
+        this learner's CEFR level, or None if there's no suitable per-level
+        summary (caller falls back to the article's own-level summary).
+        """
+        from sqlalchemy.orm.exc import NoResultFound
+        from zeeguu.core.model.article_level_summary import ArticleLevelSummary
+        from zeeguu.core.model.article_level_summary_context import (
+            ArticleLevelSummaryContext,
+        )
+        from zeeguu.core.model.context_identifier import ContextIdentifier
+        from zeeguu.core.model.context_type import ContextType
+
+        try:
+            user_level = user.cefr_level_for_learned_language()
+        except (AttributeError, IndexError, TypeError, NoResultFound):
+            return None
+        if not user_level:
+            return None
+
+        level_summary = ArticleLevelSummary.best_for_user_level(article.id, user_level)
+        if not level_summary:
+            return None
+        tokens = level_summary.get_tokenized_summary()
+        if not tokens:
+            return None
+
+        context_id = ContextIdentifier(
+            ContextType.ARTICLE_LEVEL_SUMMARY,
+            article_level_summary_id=level_summary.id,
+        )
+        return {
+            "tokens": tokens,
+            "context_identifier": context_id.as_dictionary(),
+            "past_bookmarks": ArticleLevelSummaryContext.get_all_user_bookmarks_for_article_level_summary(
+                user.id, level_summary.id
+            ),
+        }
+
+    @classmethod
     def user_article_summary_info(cls, user: User, article: Article, tokenization_cache=None):
         """
         Returns tokenized summary and title for an article with user bookmarks.
@@ -723,8 +764,13 @@ class UserArticle(db.Model):
         if not cache:
             cache, _ = ArticleTokenizationCache.ensure_populated(db.session, article)
 
-        # Build summary response
-        if article.summary and cache.tokenized_summary:
+        # Build summary response — prefer a CEFR-level-matched preview summary if
+        # one exists for this learner's level; otherwise fall back to the article's
+        # own-level summary.
+        level_summary = cls._level_matched_summary_payload(user, article)
+        if level_summary:
+            result["tokenized_summary"] = level_summary
+        elif article.summary and cache.tokenized_summary:
             try:
                 from zeeguu.core.model.article import strip_trailing_ellipsis_tokens_json
                 tokenized_summary = json.loads(

--- a/zeeguu/core/test/test_article_level_summary.py
+++ b/zeeguu/core/test/test_article_level_summary.py
@@ -1,0 +1,103 @@
+"""Per-level preview summaries (on-demand simplification flow).
+
+Covers the level-selection logic and that the feed's summary payload anchors to
+the CEFR-matched ArticleLevelSummary (with the ArticleLevelSummary context type)
+so the tappable preview / bookmark highlighting targets the right level.
+"""
+from unittest import TestCase
+
+import zeeguu.core
+from zeeguu.core.test.model_test_mixin import ModelTestMixIn
+from zeeguu.core.test.rules.article_rule import ArticleRule
+from zeeguu.core.test.rules.user_rule import UserRule
+
+from zeeguu.core.model.article_level_summary import ArticleLevelSummary
+from zeeguu.core.model.context_type import ContextType
+from zeeguu.core.model.user_article import UserArticle
+from zeeguu.core.model.user_language import UserLanguage
+
+session = zeeguu.core.model.db.session
+
+# A minimal non-empty token stream (shape is opaque to our code — we only check
+# truthiness and round-tripping).
+DUMMY_TOKENS = [[{"text": "hej", "sentence_i": 0, "token_i": 0}]]
+
+CEFR_TO_INT = {"A1": 1, "A2": 2, "B1": 3, "B2": 4, "C1": 5, "C2": 6}
+
+
+class ArticleLevelSummaryTest(ModelTestMixIn, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = UserRule().user
+        self.article = ArticleRule().article
+        # Align the article's language with the user's learned language so the
+        # summary path is exercised in the same language.
+        self.article.language = self.user.learned_language
+        session.add(self.article)
+        session.commit()
+
+    def _add_level_summary(self, level):
+        return ArticleLevelSummary.find_or_create(
+            session,
+            self.article,
+            cefr_level=level,
+            summary=f"summary at {level}",
+            tokenized_summary=DUMMY_TOKENS,
+        )
+
+    def _set_user_level(self, level):
+        ul = UserLanguage.find_or_create(session, self.user, self.user.learned_language)
+        ul.cefr_level = CEFR_TO_INT[level]
+        session.add(ul)
+        session.commit()
+
+    def test_best_for_user_level_picks_highest_at_or_below(self):
+        self._add_level_summary("A1")
+        b1 = self._add_level_summary("B1")
+
+        # B2 learner → highest available at/below is B1
+        assert ArticleLevelSummary.best_for_user_level(self.article.id, "B2").id == b1.id
+        # C1 learner → still B1 (nothing higher stored)
+        assert ArticleLevelSummary.best_for_user_level(self.article.id, "C1").id == b1.id
+        # A2 learner → only A1 qualifies
+        assert (
+            ArticleLevelSummary.best_for_user_level(self.article.id, "A2").cefr_level
+            == "A1"
+        )
+        # A1 learner → A1
+        assert (
+            ArticleLevelSummary.best_for_user_level(self.article.id, "A1").cefr_level
+            == "A1"
+        )
+
+    def test_no_summary_at_or_below_returns_none(self):
+        self._add_level_summary("B1")
+        # An A1 learner has nothing at/below B1... wait, B1 > A1, so None.
+        assert ArticleLevelSummary.best_for_user_level(self.article.id, "A1") is None
+
+    def test_summary_info_anchors_to_level_summary(self):
+        self._add_level_summary("A1")
+        b1 = self._add_level_summary("B1")
+        self._set_user_level("B2")
+
+        info = UserArticle.user_article_summary_info(self.user, self.article)
+        payload = info.get("tokenized_summary")
+        assert payload is not None
+        ctx = payload["context_identifier"]
+        assert ctx["context_type"] == ContextType.ARTICLE_LEVEL_SUMMARY
+        assert ctx["article_level_summary_id"] == b1.id
+        assert payload["tokens"] == DUMMY_TOKENS
+
+    def test_summary_info_falls_back_to_original_when_no_level_match(self):
+        # Learner at A1 with only a B1 summary → no per-level match → falls back
+        # to the article's own summary (ArticleSummary context, keyed by article).
+        self._add_level_summary("B1")
+        self._set_user_level("A1")
+
+        info = UserArticle.user_article_summary_info(self.user, self.article)
+        payload = info.get("tokenized_summary")
+        if payload is not None:  # only asserted when the article has an own summary
+            assert (
+                payload["context_identifier"]["context_type"]
+                == ContextType.ARTICLE_SUMMARY
+            )

--- a/zeeguu/core/test/test_article_level_summary.py
+++ b/zeeguu/core/test/test_article_level_summary.py
@@ -12,9 +12,11 @@ from zeeguu.core.test.rules.article_rule import ArticleRule
 from zeeguu.core.test.rules.user_rule import UserRule
 
 from zeeguu.core.model.article_level_summary import ArticleLevelSummary
+from zeeguu.core.model.article_level_summary_context import ArticleLevelSummaryContext
 from zeeguu.core.model.context_type import ContextType
 from zeeguu.core.model.user_article import UserArticle
 from zeeguu.core.model.user_language import UserLanguage
+from zeeguu.core.test.rules.bookmark_rule import BookmarkRule
 
 session = zeeguu.core.model.db.session
 
@@ -101,3 +103,29 @@ class ArticleLevelSummaryTest(ModelTestMixIn, TestCase):
                 payload["context_identifier"]["context_type"]
                 == ContextType.ARTICLE_SUMMARY
             )
+
+    def test_context_find_or_create_is_idempotent(self):
+        als = self._add_level_summary("B1")
+        bookmark = BookmarkRule(self.user).bookmark
+
+        c1 = ArticleLevelSummaryContext.find_or_create(session, bookmark, als)
+        c2 = ArticleLevelSummaryContext.find_or_create(session, bookmark, als)
+
+        assert c1.id == c2.id
+        count = ArticleLevelSummaryContext.query.filter_by(
+            bookmark_id=bookmark.id, article_level_summary_id=als.id
+        ).count()
+        assert count == 1
+
+    def test_duplicate_context_rejected_by_unique_constraint(self):
+        from sqlalchemy.exc import IntegrityError
+
+        als = self._add_level_summary("B1")
+        bookmark = BookmarkRule(self.user).bookmark
+
+        # Two raw rows for the same (bookmark, level summary) must not coexist.
+        session.add(ArticleLevelSummaryContext(bookmark, als))
+        session.add(ArticleLevelSummaryContext(bookmark, als))
+        with self.assertRaises(IntegrityError):
+            session.flush()
+        session.rollback()

--- a/zeeguu/core/user_feature_toggles.py
+++ b/zeeguu/core/user_feature_toggles.py
@@ -88,37 +88,29 @@ def _extension_experiment_1(user):
 
 
 def _show_non_simplified_articles(user):
-    """Show non-simplified (original) articles.
+    """Show non-simplified (original) articles in the feed.
 
-    Transitional allowlist: the product direction is flipping so that
-    full articles (opened externally) become the default. This set holds
-    the pilots on the new flow while we validate it; eventually this will
-    be the behavior for everyone and the flag can go away.
+    Now on for everyone: simplification has moved on-demand, so the crawl no
+    longer pre-generates simplified children and the feed is originals-first for
+    all users (a level-matched simplified version is created lazily when a learner
+    opens an article). Previously a transitional allowlist ({4607, 4626, 6083,
+    6250}); the rollout is complete, so this is the default.
     """
-    LEGACY_USER_IDS = {4607, 4626, 6083, 6250}
-    return user.id in LEGACY_USER_IDS
+    return True
 
 
 def _always_open_externally(user):
-    """Article cards in the feed always render the "Open Externally"
-    button for these users — except for saved articles, which still
-    open in the Zeeguu reader.
+    """Article cards in the feed always render the "Open Externally" button
+    (except saved articles, which still open in the Zeeguu reader).
 
-    Click-through behavior is unchanged: the redirect-notification modal
-    still appears unless the user has dismissed it with "don't show again".
+    Click-through behavior is unchanged: the redirect-notification modal still
+    appears unless the user dismissed it with "don't show again".
 
-    Rollout: the original pilot users, every user signed up from id 6367
-    onwards (i.e., all new users going forward), and all dev accounts so
-    the team dogfoods the on-demand flow. Existing non-dev users keep the
-    in-reader flow until we flip the default for them too.
+    Now on for everyone as part of the on-demand simplification flip. Previously
+    a staged rollout (pilot users {4607, 6083, 6250}, new signups from id 6367,
+    and all dev accounts); the rollout is complete, so this is the default.
     """
-    BETA_USER_IDS = {4607, 6083, 6250}
-    NEW_USER_THRESHOLD = 6367
-    return (
-        user.is_dev
-        or user.id in BETA_USER_IDS
-        or user.id >= NEW_USER_THRESHOLD
-    )
+    return True
 
 
 def _hide_recommendations(user):


### PR DESCRIPTION
## What & why

Moves article **simplification off the crawl path** (copyright + cost) and keeps learners' feeds fair with **per-CEFR-level preview summaries**. Full simplification stays **on-demand** (`POST /simplify_article/<id>`).

Motivation: the crawl was pre-generating simplified bodies for every level of every article (the recent Anthropic monthly-cap exhaustion was this burn), while most crawled articles are never opened.

## Changes (API only — no web/iOS changes needed)

**1. Crawl → assess-only.** The crawler now only assesses CEFR level, writes an abstractive summary, and classifies (article type + disturbing + paywall/advertorial rejection preserved) — **no simplified children**. Behind `SIMPLIFY_AT_CRAWL` (default **off**); set it to restore the legacy all-levels behavior.

**2. Originals-first for everyone.** `show_non_simplified_articles` and `always_open_externally` flipped to all users, so feeds no longer depend on pre-simplified inventory (also resolves the empty-feed class of bug for B2+/Danish).

**3. Per-level tappable preview summaries.** So each learner still sees a level-appropriate, tappable summary on feed cards without simplified child articles:
- New `article_level_summary` + `article_level_summary_context` tables (migration `26-08-12`), models, and a new `ArticleLevelSummary` context type threaded through `ContextIdentifier` + `Bookmark` reverse lookups.
- The single crawl LLM call now also returns a summary per level below the original; each is tokenized and stored.
- `user_article_summary_info` and the feed overlay serve the learner's-level summary (correct tap-context / highlighting), falling back to `article.summary`.

**Why zero client changes:** the app fetches summary tokens from `/user_article_summary` (now level-aware) and treats `context_identifier` as opaque.

## Tests
19 passing incl. new `test_article_level_summary.py` (level selection + context anchoring/fallback).

## ⚠️ Before merge/deploy
- **Not yet validated on device/prod.** (Draft.)
- Run migration `tools/migrations/26-08-12--add_article_level_summary.sql` **before** deploying the code.
- Deploy the crawl flip + toggle flip together (feeds go originals-first for everyone).

## Not included (intentional / follow-ups)
- Per-level **titles** (titles stay original).
- Wiring the client `interactiveSummary` preload slot (perf only; endpoint path already works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
