### PR TITLE
MWE ungroup: apply user MWE overrides to preview summaries

### DIFF
--- a/zeeguu/core/content_recommender/elastic_recommender.py
+++ b/zeeguu/core/content_recommender/elastic_recommender.py
@@ -577,6 +577,8 @@ def _apply_simplified_display_overlay(user, results):
     )
     from zeeguu.core.model.context_identifier import ContextIdentifier
     from zeeguu.core.model.context_type import ContextType
+    from zeeguu.core.model.user_article import UserArticle
+    from zeeguu.core.model.user_mwe_override import UserMweOverride
     from sqlalchemy.orm.exc import NoResultFound
 
     try:
@@ -633,6 +635,13 @@ def _apply_simplified_display_overlay(user, results):
         ).all()
     }
 
+    # Batch-fetch the user's MWE ungroup overrides for every candidate article in
+    # one query (overrides are stored keyed by the parent article id), so we can
+    # clear disabled MWE metadata from each overlaid summary without an N+1.
+    overrides_by_article = UserMweOverride.get_disabled_mwes_for_user_articles(
+        user.id, list(chosen_id_by_article.keys())
+    )
+
     for result in results:
         chosen_id = chosen_id_by_article.get(result["id"])
         display = full_by_id.get(chosen_id) if chosen_id else None
@@ -645,8 +654,15 @@ def _apply_simplified_display_overlay(user, results):
         tokens = display.get_tokenized_summary()
         if not tokens:
             continue
+        # Apply the user's MWE ungroup overrides to the overlaid summary tokens.
+        overrides_by_hash = overrides_by_article.get(display.article_id)
+        if overrides_by_hash:
+            UserArticle._apply_mwe_overrides_to_summary_tokens(tokens, overrides_by_hash)
+        # The bookmark mapping keys on article_level_summary_id; article_id is
+        # carried only for the client's MWE-ungroup path (parent article id).
         ctx = ContextIdentifier(
             ContextType.ARTICLE_LEVEL_SUMMARY,
+            article_id=display.article_id,
             article_level_summary_id=display.id,
         )
         result["interactiveSummary"] = {

--- a/zeeguu/core/model/user_article.py
+++ b/zeeguu/core/model/user_article.py
@@ -690,6 +690,34 @@ class UserArticle(db.Model):
                     token.pop("mwe_is_separated", None)
                     token.pop("mwe_partner_indices", None)
 
+    @staticmethod
+    def _apply_mwe_overrides_to_summary_tokens(summary_tokens, overrides_by_hash):
+        """
+        Clear MWE metadata from summary tokens for expressions the user disabled.
+
+        A summary's token stream nests paragraphs -> sentences -> tokens (the
+        direct output of tokenize_for_reading, same as a body fragment's tokens
+        but without the outer fragment wrapper), so this has one fewer loop than
+        the body version in user_article_info. Mutates summary_tokens in place.
+
+        Args:
+            summary_tokens: list of paragraphs, each a list of sentences,
+                each a list of token dicts
+            overrides_by_hash: dict of {sentence_hash: [disabled mwe expressions]}
+        """
+        if not overrides_by_hash or not summary_tokens:
+            return
+        for paragraph in summary_tokens:
+            for sentence in paragraph:
+                if not sentence:
+                    continue
+                sentence_text = " ".join(t.get("text", "") for t in sentence)
+                sentence_hash = UserMweOverride.compute_sentence_hash(sentence_text)
+                if sentence_hash in overrides_by_hash:
+                    UserArticle._clear_mwe_metadata_for_expressions(
+                        sentence, overrides_by_hash[sentence_hash]
+                    )
+
     @classmethod
     def _level_matched_summary_payload(cls, user, article):
         """
@@ -719,8 +747,13 @@ class UserArticle(db.Model):
         if not tokens:
             return None
 
+        # The bookmark mapping still keys on article_level_summary_id
+        # (create_context_mapping switches on context_type); article_id is carried
+        # only so the client's MWE-ungroup path can address the override by
+        # parent article id.
         context_id = ContextIdentifier(
             ContextType.ARTICLE_LEVEL_SUMMARY,
+            article_id=article.id,
             article_level_summary_id=level_summary.id,
         )
         return {
@@ -788,6 +821,21 @@ class UserArticle(db.Model):
                 }
             except (json.JSONDecodeError, TypeError):
                 log(f"[SUMMARY] Article {article.id} - Cache corrupt, skipping summary")
+
+        # Apply the user's MWE ungroup overrides to whichever summary branch
+        # produced the payload (per-level OR the fallback own-summary). The lookup
+        # keys on the PARENT article.id: for level summaries that's how overrides
+        # are stored (see ContextIdentifier.article_id on ARTICLE_LEVEL_SUMMARY),
+        # and the summary sentence text differs from body sentences so the
+        # sentence hash still scopes the override to the summary. Mutates in place.
+        if "tokenized_summary" in result:
+            overrides_by_hash = UserMweOverride.get_disabled_mwes_for_user_article(
+                user.id, article.id
+            )
+            if overrides_by_hash:
+                cls._apply_mwe_overrides_to_summary_tokens(
+                    result["tokenized_summary"].get("tokens"), overrides_by_hash
+                )
 
         # Build title response
         if cache.tokenized_title:

--- a/zeeguu/core/model/user_mwe_override.py
+++ b/zeeguu/core/model/user_mwe_override.py
@@ -87,3 +87,26 @@ class UserMweOverride(db.Model):
                 result[o.sentence_hash] = []
             result[o.sentence_hash].append(o.mwe_expression)
         return result
+
+    @classmethod
+    def get_disabled_mwes_for_user_articles(cls, user_id, article_ids):
+        """Batched variant of get_disabled_mwes_for_user_article.
+
+        Returns dict mapping article_id -> {sentence_hash -> [mwe_expressions]}
+        for the given user across many articles, in a single query. Articles with
+        no overrides are simply absent from the returned dict.
+        """
+        if not article_ids:
+            return {}
+
+        overrides = cls.query.filter(
+            cls.user_id == user_id,
+            cls.article_id.in_(article_ids),
+            cls.disabled == True,  # noqa: E712 (SQLAlchemy needs ==, not `is`)
+        ).all()
+
+        result = {}
+        for o in overrides:
+            by_hash = result.setdefault(o.article_id, {})
+            by_hash.setdefault(o.sentence_hash, []).append(o.mwe_expression)
+        return result

--- a/zeeguu/core/test/test_article_level_summary.py
+++ b/zeeguu/core/test/test_article_level_summary.py
@@ -16,6 +16,7 @@ from zeeguu.core.model.article_level_summary_context import ArticleLevelSummaryC
 from zeeguu.core.model.context_type import ContextType
 from zeeguu.core.model.user_article import UserArticle
 from zeeguu.core.model.user_language import UserLanguage
+from zeeguu.core.model.user_mwe_override import UserMweOverride
 from zeeguu.core.test.rules.bookmark_rule import BookmarkRule
 
 session = zeeguu.core.model.db.session
@@ -23,6 +24,29 @@ session = zeeguu.core.model.db.session
 # A minimal non-empty token stream (shape is opaque to our code — we only check
 # truthiness and round-tripping).
 DUMMY_TOKENS = [[{"text": "hej", "sentence_i": 0, "token_i": 0}]]
+
+# A summary token stream (paragraphs -> sentences -> tokens) whose first sentence
+# groups "har lavet" into an MWE. The metadata keys mirror what
+# UserArticle._clear_mwe_metadata_for_expressions reads and clears.
+MWE_SENTENCE_TEXT = "har lavet mad"
+MWE_EXPRESSION = "har lavet"
+
+
+def _mwe_tokens():
+    return [
+        [
+            [
+                {"text": "har", "sentence_i": 0, "token_i": 0, "mwe_group_id": 7,
+                 "mwe_role": "head", "mwe_is_separated": False,
+                 "mwe_partner_indices": [1]},
+                {"text": "lavet", "sentence_i": 0, "token_i": 1, "mwe_group_id": 7,
+                 "mwe_role": "dep", "mwe_is_separated": False,
+                 "mwe_partner_indices": [0]},
+                {"text": "mad", "sentence_i": 0, "token_i": 2},
+            ]
+        ]
+    ]
+
 
 CEFR_TO_INT = {"A1": 1, "A2": 2, "B1": 3, "B2": 4, "C1": 5, "C2": 6}
 
@@ -45,6 +69,15 @@ class ArticleLevelSummaryTest(ModelTestMixIn, TestCase):
             cefr_level=level,
             summary=f"summary at {level}",
             tokenized_summary=DUMMY_TOKENS,
+        )
+
+    def _add_mwe_level_summary(self, level):
+        return ArticleLevelSummary.find_or_create(
+            session,
+            self.article,
+            cefr_level=level,
+            summary=f"summary at {level}",
+            tokenized_summary=_mwe_tokens(),
         )
 
     def _set_user_level(self, level):
@@ -89,6 +122,57 @@ class ArticleLevelSummaryTest(ModelTestMixIn, TestCase):
         assert ctx["context_type"] == ContextType.ARTICLE_LEVEL_SUMMARY
         assert ctx["article_level_summary_id"] == b1.id
         assert payload["tokens"] == DUMMY_TOKENS
+
+    def test_level_summary_context_carries_parent_article_id(self):
+        # The served level-summary context now also carries the parent article id
+        # so the client's MWE-ungroup path can address the override.
+        self._add_level_summary("B1")
+        self._set_user_level("B2")
+
+        info = UserArticle.user_article_summary_info(self.user, self.article)
+        ctx = info["tokenized_summary"]["context_identifier"]
+        assert ctx["context_type"] == ContextType.ARTICLE_LEVEL_SUMMARY
+        assert ctx["article_id"] == self.article.id
+
+    def test_mwe_override_clears_metadata_on_level_summary(self):
+        # A B2 learner served a B1 level summary whose first sentence groups
+        # "har lavet" as an MWE. After the user ungroups it (an override keyed by
+        # the parent article id + sentence hash), the served summary tokens must
+        # have the MWE metadata stripped.
+        self._add_mwe_level_summary("B1")
+        self._set_user_level("B2")
+
+        sentence_hash = UserMweOverride.compute_sentence_hash(MWE_SENTENCE_TEXT)
+        UserMweOverride.find_or_create(
+            session,
+            user_id=self.user.id,
+            article_id=self.article.id,
+            sentence_hash=sentence_hash,
+            mwe_expression=MWE_EXPRESSION,
+        )
+        session.commit()
+
+        info = UserArticle.user_article_summary_info(self.user, self.article)
+        tokens = info["tokenized_summary"]["tokens"]
+        sentence = tokens[0][0]
+
+        # The two MWE tokens are stripped of all mwe_* metadata...
+        for tok in sentence[:2]:
+            assert "mwe_group_id" not in tok
+            assert "mwe_role" not in tok
+            assert "mwe_is_separated" not in tok
+            assert "mwe_partner_indices" not in tok
+        # ...while the untouched token keeps its plain text.
+        assert sentence[2]["text"] == "mad"
+
+    def test_mwe_override_untouched_when_expression_not_disabled(self):
+        # Sanity: with no matching override, the MWE metadata survives.
+        self._add_mwe_level_summary("B1")
+        self._set_user_level("B2")
+
+        info = UserArticle.user_article_summary_info(self.user, self.article)
+        sentence = info["tokenized_summary"]["tokens"][0][0]
+        assert sentence[0]["mwe_group_id"] == 7
 
     def test_summary_info_falls_back_to_original_when_no_level_match(self):
         # Learner at A1 with only a B1 summary → no per-level match → falls back


### PR DESCRIPTION
## Problem

PR #698 added per-level tappable preview summaries (`article_level_summary` table + `ArticleLevelSummary` context type). Tapping a word in a summary translates/bookmarks fine, but the **"ungroup a multi-word expression (MWE)"** action did nothing on summaries.

Root cause: `UserMweOverride` clearing was only applied to the article **body** (the `tokenized_fragments` block in `UserArticle.user_article_info`, guarded by `if with_content:`). Summaries — both the per-level preview summaries and the article's own `summary` — never got that treatment.

## Change

1. **Batched override fetch** — `UserMweOverride.get_disabled_mwes_for_user_articles(user_id, article_ids)` returns `{article_id: {sentence_hash: [expressions]}}` in one query (mirrors the existing single-article method).

2. **Shared apply helper** — `UserArticle._apply_mwe_overrides_to_summary_tokens(summary_tokens, overrides_by_hash)` walks a summary's `paragraphs -> sentences` (one fewer loop than the body version, which also has the outer fragment wrapper) and clears disabled MWE metadata in place. Applied in:
   - `user_article_summary_info` — for both the level-summary path and the fallback `article.summary` path (this also fixes the pre-existing gap for the original summary). Override lookup uses the **parent** `article.id`; summary sentence text differs from body sentences so the sentence hash still scopes the override to the summary.
   - `_apply_simplified_display_overlay` (feed overlay) — batch-fetches overrides for all candidate articles and applies to each `interactiveSummary`.

3. **`article_id` carry** — the `ARTICLE_LEVEL_SUMMARY` `ContextIdentifier` now also passes `article_id` (in both `_level_matched_summary_payload` and the overlay). The bookmark mapping still keys on `article_level_summary_id` (`create_context_mapping` switches on `context_type`); `article_id` is only for the client's MWE-ungroup path. This was reverted from #698 because it was inert without this task.

4. **Tests** — extended `test_article_level_summary.py`: MWE metadata cleared on a served level summary when an override exists, the untouched-token sanity case, and the `article_id` carry on the context identifier.

## Notes

- Depends on #698 (based on `wt/on-demand-simplify`, not master). Should be rebased onto master after #698 merges.
- No schema change; no migration.

## Tests

`test_article_level_summary.py` — 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
