### PR TITLE
Add feed-health monitor: alert when a segment's feed is empty/stale

### DIFF
--- a/tools/feed_delivery_health_check.py
+++ b/tools/feed_delivery_health_check.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python
+"""
+Feed DELIVERY health check — does a real user in each segment actually SEE a
+fresh feed?
+
+Why this exists (the motivating incident)
+-----------------------------------------
+We already have supply-side checks: crawler_liveness_check.py ("is the crawler
+alive at all?") and feed_health_check.py ("which individual RSS feeds went
+quiet?"). Both watch the DOWNLOAD side. But in Aug 2026 a real user's feed was
+silently EMPTY for ~5 days while downloads were perfectly fine: the
+simplification pipeline had broken, and that user's segment (Danish, B2+) is
+filtered toward simplified content — of which, suddenly, there was none. A
+supply/download check cannot see that: articles WERE arriving, they just never
+reached that user's feed after CEFR + feature-flag filtering.
+
+So this check runs on the DELIVERY side. It sweeps the segment matrix — the
+dimension that matters is (learned_language, CEFR_level), because feed inventory
+and filters vary along it and the incident hit one specific corner — and per
+segment asks: is there fresh, recommendable content, and does a real active
+user in that segment actually get a non-empty, fresh feed?
+
+Two signals per segment
+------------------------
+1. INVENTORY (primary alert trigger): re-run the app's OWN recommender query
+   builder (build_elastic_recommender_query) parameterized by the segment's
+   language + CEFR level, with NO per-user seen-exclusion and NO topic
+   narrowing. This is "does fresh content that this segment COULD be shown even
+   exist in the index?" It replicates the exact CEFR filtering
+   (available_cefr_levels) that starved the incident's segment, without being
+   confounded by one user's reading history.
+
+2. PER-USER CANARY (corroboration): pick a real, recently-active user in the
+   segment and call the REAL feed function article_recommendations_for_user().
+   This exercises the full path the app uses — CEFR filtering, the feature flags
+   (simplified-only vs originals-first, "show easier"), the disturbing filter,
+   the ES index, seen-exclusion, teacher-upload filtering.
+
+INVENTORY is the primary trigger because a single power-user can legitimately
+have an empty PERSONAL feed (they already opened everything fresh) — that's a
+false positive for "the segment is broken." Segment-wide inventory has no such
+per-user history, so an empty/stale inventory is the trustworthy alarm; the
+per-user run is reported alongside as corroboration and as a reality check on
+the flags.
+
+Alerting mirrors the other monitors: on failure we email a per-segment summary
+via ZeeguuMailer (the app's own SMTP — cron stdout goes to an unread log), log a
+structured summary, and exit non-zero so cron surfaces it.
+
+NOTE: not wired into cron here. Propose the crontab line in the PR; the crontab
+source of truth is the OPS repo.
+
+Usage:
+    python -m tools.feed_delivery_health_check [--verbose] [--dry-run]
+        [--active-days N] [--fresh-days N] [--min-articles K]
+        [--min-fresh K] [--stale-days N] [--count N]
+        [--languages da,de,...]
+"""
+
+import argparse
+import os
+import sys
+from collections import defaultdict, namedtuple
+from datetime import datetime, timedelta
+
+from zeeguu.core.model import User, Language
+from zeeguu.core.emailer.zeeguu_mailer import ZeeguuMailer
+
+# NOTE: the Flask app + app context are created inside main(), NOT at module
+# import time. The DB-touching functions below need an app context at CALL time,
+# but the pure classification helpers (freshness_summary, classify_segment) do
+# not — keeping app creation out of import lets the unit tests import this module
+# without a DB / config, and keeps `python -m tools...` behavior unchanged.
+
+
+# --- Thresholds ---------------------------------------------------------------
+# These are STARTING GUESSES to tune once we have a few weeks of real numbers per
+# segment (see OPEN QUESTIONS in the PR). Each is env-overridable so cron can
+# adjust without a code change.
+def _env_int(name, default):
+    try:
+        return int(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+# Consider a user "active" if last_seen within this window.
+ACTIVE_DAYS = _env_int("FEED_HEALTH_ACTIVE_DAYS", 30)
+# An article/video counts as FRESH if published within this window.
+FRESH_DAYS = _env_int("FEED_HEALTH_FRESH_DAYS", 7)
+# A segment needs at least this many recommendable items total...
+MIN_ARTICLES = _env_int("FEED_HEALTH_MIN_ARTICLES", 3)
+# ...and at least this many of them FRESH.
+MIN_FRESH = _env_int("FEED_HEALTH_MIN_FRESH", 3)
+# Flag a segment if even its FRESHEST recommendable item is older than this.
+STALE_DAYS = _env_int("FEED_HEALTH_STALE_DAYS", 4)
+# How many items to request from the recommender / inventory query.
+COUNT = _env_int("FEED_HEALTH_COUNT", 10)
+
+
+# --- Pure classification logic (unit-tested) ----------------------------------
+# Kept free of ES/DB so the freshness + status logic can be tested with plain
+# datetimes and a small fixture (see tools/test/test_feed_delivery_health_check.py).
+
+FreshnessSummary = namedtuple(
+    "FreshnessSummary", ["total", "fresh_count", "freshest_age_days"]
+)
+
+
+def freshness_summary(published_times, now, fresh_days=FRESH_DAYS):
+    """Summarize a list of publication datetimes.
+
+    Returns total count, how many are fresh (published within fresh_days), and
+    the age in days of the FRESHEST (newest) item — None when the list is empty.
+    """
+    times = [t for t in published_times if t is not None]
+    total = len(times)
+    if total == 0:
+        return FreshnessSummary(0, 0, None)
+
+    cutoff = now - timedelta(days=fresh_days)
+    fresh_count = sum(1 for t in times if t > cutoff)
+    freshest = max(times)
+    freshest_age_days = (now - freshest).total_seconds() / 86400.0
+    return FreshnessSummary(total, fresh_count, freshest_age_days)
+
+
+# Segment status values.
+STATUS_OK = "OK"
+STATUS_EMPTY = "EMPTY"  # nothing (or too little) recommendable at all
+STATUS_NO_FRESH = "NO_FRESH"  # inventory exists but not enough of it fresh
+STATUS_STALE = "STALE"  # freshest item is older than STALE_DAYS
+
+FAILING_STATUSES = {STATUS_EMPTY, STATUS_NO_FRESH, STATUS_STALE}
+
+
+def classify_segment(
+    summary,
+    min_articles=MIN_ARTICLES,
+    min_fresh=MIN_FRESH,
+    stale_days=STALE_DAYS,
+):
+    """Turn a FreshnessSummary into a segment status + human reason.
+
+    Precedence: EMPTY (not enough content at all) > NO_FRESH (enough content but
+    too little of it fresh) > STALE (freshest item too old) > OK. Pure function.
+    """
+    if summary.total < min_articles:
+        return STATUS_EMPTY, (
+            f"only {summary.total} recommendable item(s) "
+            f"(need >= {min_articles})"
+        )
+    if summary.fresh_count < min_fresh:
+        return STATUS_NO_FRESH, (
+            f"only {summary.fresh_count} fresh item(s) "
+            f"(need >= {min_fresh}); freshest is "
+            f"{_fmt_age(summary.freshest_age_days)} old"
+        )
+    if summary.freshest_age_days is not None and summary.freshest_age_days > stale_days:
+        return STATUS_STALE, (
+            f"freshest recommendable item is "
+            f"{_fmt_age(summary.freshest_age_days)} old "
+            f"(> {stale_days}d)"
+        )
+    return STATUS_OK, (
+        f"{summary.total} items, {summary.fresh_count} fresh, "
+        f"freshest {_fmt_age(summary.freshest_age_days)} old"
+    )
+
+
+def _fmt_age(age_days):
+    if age_days is None:
+        return "n/a"
+    return f"{age_days:.1f}d"
+
+
+# --- Segment matrix -----------------------------------------------------------
+Segment = namedtuple("Segment", ["language_code", "cefr_level"])
+
+SegmentResult = namedtuple(
+    "SegmentResult",
+    [
+        "segment",
+        "status",
+        "reason",
+        "inventory_summary",
+        "canary_user_id",
+        "canary_total",
+        "canary_fresh",
+        "canary_note",
+    ],
+)
+
+
+def active_users_by_segment(active_days, language_codes=None):
+    """Group recently-active users into (language, cefr_level) segments.
+
+    Returns dict[Segment] -> list of (user, last_seen), each list sorted with the
+    most-recently-seen user first (that's the canary we pick). Users whose CEFR
+    level can't be resolved (no UserLanguage row / null level) are skipped — they
+    can't define a CEFR segment.
+    """
+    cutoff = datetime.now() - timedelta(days=active_days)
+    q = User.query.filter(User.last_seen != None).filter(User.last_seen >= cutoff)  # noqa: E711
+
+    segments = defaultdict(list)
+    for user in q.all():
+        lang = user.learned_language
+        if lang is None:
+            continue
+        if language_codes and lang.code not in language_codes:
+            continue
+        try:
+            cefr = user.cefr_level_for_learned_language()
+        except Exception:
+            # No UserLanguage row, null cefr_level, etc. — can't segment.
+            continue
+        if not cefr:
+            continue
+        segments[Segment(lang.code, cefr)].append((user, user.last_seen))
+
+    for seg in segments:
+        segments[seg].sort(key=lambda pair: pair[1], reverse=True)
+    return segments
+
+
+# --- ES inventory (primary signal) --------------------------------------------
+def segment_inventory_published_times(segment, count):
+    """Fresh-inventory probe for a segment, independent of any one user.
+
+    Reuses the app's OWN query builder (build_elastic_recommender_query) with the
+    segment's language + CEFR level and NO per-user filters (no seen-exclusion,
+    no topic narrowing, no disturbing filter). include_lower=False on purpose:
+    the incident hit users who see ONLY their exact level, so the strict same-
+    level query is the worst-case signal we want to alarm on.
+
+    Returns a list of publication datetimes for the returned hits (articles AND
+    videos), or raises on ES failure (caller treats that as its own alert).
+    """
+    from elasticsearch import Elasticsearch
+    from zeeguu.core.elastic.elastic_query_builder import (
+        build_elastic_recommender_query,
+    )
+    from zeeguu.core.elastic.settings import ES_CONN_STRING, ES_ZINDEX
+
+    language = Language.find(segment.language_code)
+
+    query_body = build_elastic_recommender_query(
+        count,
+        user_topics="",
+        unwanted_user_topics="",
+        language=language,
+        user_cefr_level=segment.cefr_level,
+        es_scale="1d",
+        es_offset="1d",
+        es_decay=0.6,
+        topics_to_include="",
+        topics_to_exclude="",
+        user_ignored_sources=[],
+        articles_to_exclude=None,
+        filter_disturbing=False,
+        include_lower=False,
+        page=0,
+    )
+
+    es = Elasticsearch(ES_CONN_STRING)
+    res = es.search(index=ES_ZINDEX, body=query_body)
+    hits = res["hits"].get("hits", [])
+    return [_hit_published_time(h) for h in hits]
+
+
+def _hit_published_time(hit):
+    """Parse published_time out of an ES hit's _source into a naive datetime."""
+    raw = hit.get("_source", {}).get("published_time")
+    if raw is None:
+        return None
+    if isinstance(raw, datetime):
+        return raw.replace(tzinfo=None)
+    from dateutil import parser as date_parser
+
+    try:
+        dt = date_parser.parse(raw)
+        return dt.replace(tzinfo=None)
+    except (ValueError, TypeError):
+        return None
+
+
+# --- Per-user canary (corroboration) ------------------------------------------
+def canary_published_times(user, count):
+    """Run the REAL feed function for a user and return the publication datetimes
+    of what it would show them. Exercises the full delivery path (flags, seen-
+    exclusion, everything)."""
+    from zeeguu.core.content_recommender.elastic_recommender import (
+        article_recommendations_for_user,
+    )
+
+    content = article_recommendations_for_user(user, count)
+    return [getattr(c, "published_time", None) for c in content]
+
+
+# --- Orchestration ------------------------------------------------------------
+def evaluate_segment(segment, users, count, now, thresholds):
+    """Evaluate one segment: inventory (primary) + canary (corroboration)."""
+    min_articles, min_fresh, stale_days, fresh_days = thresholds
+
+    # Primary: segment inventory.
+    try:
+        inv_times = segment_inventory_published_times(segment, count)
+        inv_summary = freshness_summary(inv_times, now, fresh_days)
+        status, reason = classify_segment(
+            inv_summary, min_articles, min_fresh, stale_days
+        )
+    except Exception as e:
+        # An ES failure is itself alert-worthy for this segment.
+        empty = FreshnessSummary(0, 0, None)
+        return SegmentResult(
+            segment, STATUS_EMPTY, f"inventory query failed: {e}", empty,
+            None, None, None, "inventory query raised",
+        )
+
+    # Corroboration: per-user canary (most-recently-active user in the segment).
+    canary_user_id = canary_total = canary_fresh = None
+    canary_note = ""
+    if users:
+        canary_user = users[0][0]
+        canary_user_id = canary_user.id
+        try:
+            can_times = canary_published_times(canary_user, count)
+            can_summary = freshness_summary(can_times, now, fresh_days)
+            canary_total = can_summary.total
+            canary_fresh = can_summary.fresh_count
+            if can_summary.total == 0:
+                # Could be a real power-user who exhausted the fresh feed — that's
+                # exactly why the canary is corroboration, not the trigger.
+                canary_note = (
+                    "canary feed EMPTY (may be a power-user who already opened "
+                    "everything fresh — inventory is the authoritative signal)"
+                )
+            else:
+                canary_note = (
+                    f"canary sees {can_summary.total} item(s), "
+                    f"{can_summary.fresh_count} fresh"
+                )
+        except Exception as e:
+            canary_note = f"canary run failed: {e}"
+    else:
+        canary_note = "no active user available as canary"
+
+    return SegmentResult(
+        segment, status, reason, inv_summary,
+        canary_user_id, canary_total, canary_fresh, canary_note,
+    )
+
+
+def build_report(results):
+    """Human-readable, structured per-segment summary lines."""
+    lines = []
+    failing = [r for r in results if r.status in FAILING_STATUSES]
+
+    lines.append("=== FEED DELIVERY HEALTH — per-segment summary ===")
+    lines.append(f"Checked at {datetime.now():%Y-%m-%d %H:%M}")
+    lines.append(
+        f"Segments checked: {len(results)}  |  failing: {len(failing)}"
+    )
+    lines.append("")
+
+    if failing:
+        lines.append("--- FAILING SEGMENTS ---")
+        for r in sorted(failing, key=lambda r: (r.segment.language_code, r.segment.cefr_level)):
+            lines.extend(_segment_lines(r))
+        lines.append("")
+
+    lines.append("--- ALL SEGMENTS ---")
+    for r in sorted(results, key=lambda r: (r.segment.language_code, r.segment.cefr_level)):
+        s = r.segment
+        lines.append(
+            f"  [{s.language_code} {s.cefr_level}] {r.status}: {r.reason}"
+        )
+    return lines
+
+
+def _segment_lines(r):
+    s = r.segment
+    inv = r.inventory_summary
+    out = [
+        f"  [{s.language_code} {s.cefr_level}] {r.status}",
+        f"      inventory: {inv.total} items, {inv.fresh_count} fresh, "
+        f"freshest {_fmt_age(inv.freshest_age_days)} old — {r.reason}",
+    ]
+    if r.canary_user_id is not None:
+        out.append(f"      canary (user {r.canary_user_id}): {r.canary_note}")
+    else:
+        out.append(f"      canary: {r.canary_note}")
+    return out
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Feed delivery health check")
+    parser.add_argument("--active-days", type=int, default=ACTIVE_DAYS)
+    parser.add_argument("--fresh-days", type=int, default=FRESH_DAYS)
+    parser.add_argument("--min-articles", type=int, default=MIN_ARTICLES)
+    parser.add_argument("--min-fresh", type=int, default=MIN_FRESH)
+    parser.add_argument("--stale-days", type=int, default=STALE_DAYS)
+    parser.add_argument("--count", type=int, default=COUNT)
+    parser.add_argument(
+        "--languages",
+        type=str,
+        default=None,
+        help="Comma-separated language codes to restrict to (e.g. da,de).",
+    )
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Do everything except send the alert email.",
+    )
+    args = parser.parse_args()
+
+    # Create the app + push context here (see module note): tools that query the
+    # DB must run under an app context (per the worktree CLAUDE.md), but doing it
+    # lazily here keeps the module import-safe for unit tests.
+    from zeeguu.api.app import create_app_for_scripts
+
+    app = create_app_for_scripts()
+    app.app_context().push()
+
+    language_codes = (
+        {c.strip() for c in args.languages.split(",") if c.strip()}
+        if args.languages
+        else None
+    )
+    thresholds = (args.min_articles, args.min_fresh, args.stale_days, args.fresh_days)
+    now = datetime.now()
+
+    segments = active_users_by_segment(args.active_days, language_codes)
+    if not segments:
+        print("No active users found in any segment — nothing to check.")
+        return 0
+
+    results = []
+    for segment in sorted(segments, key=lambda s: (s.language_code, s.cefr_level)):
+        users = segments[segment]
+        result = evaluate_segment(segment, users, args.count, now, thresholds)
+        results.append(result)
+        if args.verbose:
+            for line in _segment_lines(result):
+                print(line)
+
+    report = build_report(results)
+    print("\n".join(report))
+
+    failing = [r for r in results if r.status in FAILING_STATUSES]
+    if not failing:
+        print(f"\nOK: all {len(results)} segment(s) deliver a fresh feed.")
+        return 0
+
+    subject = (
+        f"⚠️ Zeeguu feed delivery: {len(failing)} segment(s) empty/stale"
+    )
+    if args.dry_run:
+        print(f"\n[dry-run] would email: {subject}")
+    else:
+        ZeeguuMailer.send_mail(subject, report)
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/feed_delivery_health_check.py
+++ b/tools/feed_delivery_health_check.py
@@ -84,6 +84,11 @@ def _env_int(name, default):
         return default
 
 
+def _env_level_set(name, default):
+    raw = os.environ.get(name, default)
+    return {tok.strip().upper() for tok in raw.split(",") if tok.strip()}
+
+
 # Consider a user "active" if last_seen within this window.
 ACTIVE_DAYS = _env_int("FEED_HEALTH_ACTIVE_DAYS", 30)
 # An article/video counts as FRESH if published within this window.
@@ -93,7 +98,17 @@ MIN_ARTICLES = _env_int("FEED_HEALTH_MIN_ARTICLES", 3)
 # ...and at least this many of them FRESH.
 MIN_FRESH = _env_int("FEED_HEALTH_MIN_FRESH", 3)
 # Flag a segment if even its FRESHEST recommendable item is older than this.
-STALE_DAYS = _env_int("FEED_HEALTH_STALE_DAYS", 4)
+# We crawl several times a day, so for an alerting segment "nothing fresh in ~a
+# day" already means new content stopped landing — that's the alarm, not a
+# multi-day grace. Kept at 1 (≈ nothing new today); this assumes the check runs
+# AFTER the day's crawl so it doesn't fire on a not-yet-crawled today.
+STALE_DAYS = _env_int("FEED_HEALTH_STALE_DAYS", 1)
+# CEFR levels whose failures actually ALERT (email + non-zero exit). Other levels
+# are still evaluated and shown in the report, but don't trigger alerts. C1/C2
+# are report-only by default: we don't complexify (generate above-level content)
+# yet, so almost all crawled news sits at A1–B2 and C1/C2 are empty by design —
+# alerting on them would be pure noise. Revisit when complexification ships.
+ALERT_LEVELS = _env_level_set("FEED_HEALTH_ALERT_LEVELS", "A1,A2,B1,B2")
 # How many items to request from the recommender / inventory query.
 COUNT = _env_int("FEED_HEALTH_COUNT", 10)
 
@@ -132,6 +147,17 @@ STATUS_NO_FRESH = "NO_FRESH"  # inventory exists but not enough of it fresh
 STATUS_STALE = "STALE"  # freshest item is older than STALE_DAYS
 
 FAILING_STATUSES = {STATUS_EMPTY, STATUS_NO_FRESH, STATUS_STALE}
+
+
+def is_alerting(result, alert_levels=ALERT_LEVELS):
+    """Whether a failing segment should actually raise an alert (email + non-zero
+    exit). A segment alerts only if it's failing AND its CEFR level is in the
+    alerting set; report-only levels (e.g. C1/C2) are still shown but never
+    alarm — see ALERT_LEVELS."""
+    return (
+        result.status in FAILING_STATUSES
+        and result.segment.cefr_level in alert_levels
+    )
 
 
 def classify_segment(
@@ -352,21 +378,33 @@ def evaluate_segment(segment, users, count, now, thresholds):
     )
 
 
-def build_report(results):
+def build_report(results, alert_levels=ALERT_LEVELS):
     """Human-readable, structured per-segment summary lines."""
     lines = []
-    failing = [r for r in results if r.status in FAILING_STATUSES]
+    alerting = [r for r in results if is_alerting(r, alert_levels)]
+    report_only = [
+        r
+        for r in results
+        if r.status in FAILING_STATUSES and not is_alerting(r, alert_levels)
+    ]
 
     lines.append("=== FEED DELIVERY HEALTH — per-segment summary ===")
     lines.append(f"Checked at {datetime.now():%Y-%m-%d %H:%M}")
     lines.append(
-        f"Segments checked: {len(results)}  |  failing: {len(failing)}"
+        f"Segments checked: {len(results)}  |  alerting: {len(alerting)}"
+        f"  |  report-only issues: {len(report_only)}"
     )
     lines.append("")
 
-    if failing:
-        lines.append("--- FAILING SEGMENTS ---")
-        for r in sorted(failing, key=lambda r: (r.segment.language_code, r.segment.cefr_level)):
+    if alerting:
+        lines.append("--- ALERTING SEGMENTS (empty/stale) ---")
+        for r in sorted(alerting, key=lambda r: (r.segment.language_code, r.segment.cefr_level)):
+            lines.extend(_segment_lines(r))
+        lines.append("")
+
+    if report_only:
+        lines.append("--- REPORT-ONLY ISSUES (not alerting; e.g. C1/C2) ---")
+        for r in sorted(report_only, key=lambda r: (r.segment.language_code, r.segment.cefr_level)):
             lines.extend(_segment_lines(r))
         lines.append("")
 
@@ -402,6 +440,12 @@ def main():
     parser.add_argument("--min-fresh", type=int, default=MIN_FRESH)
     parser.add_argument("--stale-days", type=int, default=STALE_DAYS)
     parser.add_argument("--count", type=int, default=COUNT)
+    parser.add_argument(
+        "--alert-levels",
+        type=str,
+        default=",".join(sorted(ALERT_LEVELS)),
+        help="Comma-separated CEFR levels whose failures alert; others are report-only.",
+    )
     parser.add_argument(
         "--languages",
         type=str,
@@ -446,16 +490,29 @@ def main():
             for line in _segment_lines(result):
                 print(line)
 
-    report = build_report(results)
+    alert_levels = {
+        t.strip().upper() for t in args.alert_levels.split(",") if t.strip()
+    }
+    report = build_report(results, alert_levels)
     print("\n".join(report))
 
-    failing = [r for r in results if r.status in FAILING_STATUSES]
-    if not failing:
-        print(f"\nOK: all {len(results)} segment(s) deliver a fresh feed.")
+    alerting_failures = [r for r in results if is_alerting(r, alert_levels)]
+    report_only_failures = [
+        r
+        for r in results
+        if r.status in FAILING_STATUSES and not is_alerting(r, alert_levels)
+    ]
+    if not alerting_failures:
+        note = (
+            f" ({len(report_only_failures)} report-only issue(s) shown above)"
+            if report_only_failures
+            else ""
+        )
+        print(f"\nOK: no alerting segment failures.{note}")
         return 0
 
     subject = (
-        f"⚠️ Zeeguu feed delivery: {len(failing)} segment(s) empty/stale"
+        f"⚠️ Zeeguu feed delivery: {len(alerting_failures)} segment(s) empty/stale"
     )
     if args.dry_run:
         print(f"\n[dry-run] would email: {subject}")

--- a/tools/test_feed_delivery_health_check.py
+++ b/tools/test_feed_delivery_health_check.py
@@ -21,12 +21,22 @@ from datetime import datetime, timedelta
 from tools.feed_delivery_health_check import (
     freshness_summary,
     classify_segment,
+    is_alerting,
+    Segment,
+    SegmentResult,
     FreshnessSummary,
     STATUS_OK,
     STATUS_EMPTY,
     STATUS_NO_FRESH,
     STATUS_STALE,
 )
+
+
+def _result(cefr_level, status):
+    return SegmentResult(
+        Segment("da", cefr_level), status, "reason",
+        FreshnessSummary(0, 0, None), None, None, None, "",
+    )
 
 NOW = datetime(2026, 8, 13, 12, 0, 0)
 
@@ -111,3 +121,21 @@ def test_classify_ok_at_stale_boundary():
     s = FreshnessSummary(total=10, fresh_count=5, freshest_age_days=4.0)
     status, _ = classify_segment(s, min_articles=3, min_fresh=3, stale_days=4)
     assert status == STATUS_OK
+
+
+# --- is_alerting (alert-level gating) -----------------------------------------
+ALERTING = {"A1", "A2", "B1", "B2"}
+
+
+def test_alerting_when_failing_and_level_in_alert_set():
+    assert is_alerting(_result("B2", STATUS_STALE), ALERTING) is True
+
+
+def test_not_alerting_for_report_only_level_even_when_empty():
+    # C1/C2 are report-only until we complexify — empty must NOT alert.
+    assert is_alerting(_result("C1", STATUS_EMPTY), ALERTING) is False
+    assert is_alerting(_result("C2", STATUS_NO_FRESH), ALERTING) is False
+
+
+def test_not_alerting_when_segment_is_ok():
+    assert is_alerting(_result("B1", STATUS_OK), ALERTING) is False

--- a/tools/test_feed_delivery_health_check.py
+++ b/tools/test_feed_delivery_health_check.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+"""
+Unit tests for the PURE classification logic of the feed delivery health check.
+
+The full ES + DB delivery path (segment_inventory_published_times,
+canary_published_times, active_users_by_segment) is hard to unit-test — it needs
+a live Elasticsearch index and a populated MySQL — so it's exercised manually /
+in staging, not here. What we CAN and do pin down below is the freshness +
+staleness classification and the segment-status decision, which is where the
+thresholds live and where a regression would silently change what alerts.
+
+These tests import the module directly; per its module note, importing does NOT
+create a Flask app or touch the DB, so no fixtures are needed.
+
+Run:
+    python -m pytest tools/test_feed_delivery_health_check.py -v
+"""
+
+from datetime import datetime, timedelta
+
+from tools.feed_delivery_health_check import (
+    freshness_summary,
+    classify_segment,
+    FreshnessSummary,
+    STATUS_OK,
+    STATUS_EMPTY,
+    STATUS_NO_FRESH,
+    STATUS_STALE,
+)
+
+NOW = datetime(2026, 8, 13, 12, 0, 0)
+
+
+def _days_ago(n):
+    return NOW - timedelta(days=n)
+
+
+# --- freshness_summary --------------------------------------------------------
+def test_freshness_summary_empty():
+    s = freshness_summary([], NOW, fresh_days=7)
+    assert s == FreshnessSummary(0, 0, None)
+
+
+def test_freshness_summary_ignores_none_entries():
+    s = freshness_summary([None, _days_ago(1), None], NOW, fresh_days=7)
+    assert s.total == 1
+    assert s.fresh_count == 1
+
+
+def test_freshness_summary_counts_fresh_within_window():
+    times = [_days_ago(1), _days_ago(3), _days_ago(6), _days_ago(10), _days_ago(30)]
+    s = freshness_summary(times, NOW, fresh_days=7)
+    assert s.total == 5
+    # 1, 3, 6 days old are < 7d; 10 and 30 are not.
+    assert s.fresh_count == 3
+
+
+def test_freshness_summary_freshest_age_is_the_newest():
+    times = [_days_ago(2), _days_ago(9), _days_ago(4)]
+    s = freshness_summary(times, NOW, fresh_days=7)
+    # freshest = 2 days old
+    assert abs(s.freshest_age_days - 2.0) < 1e-6
+
+
+def test_freshness_summary_boundary_is_strict():
+    # Exactly at the cutoff is NOT counted as fresh (> cutoff, strict).
+    s = freshness_summary([_days_ago(7)], NOW, fresh_days=7)
+    assert s.fresh_count == 0
+
+
+# --- classify_segment ---------------------------------------------------------
+def test_classify_ok():
+    s = FreshnessSummary(total=8, fresh_count=5, freshest_age_days=1.0)
+    status, _ = classify_segment(s, min_articles=3, min_fresh=3, stale_days=4)
+    assert status == STATUS_OK
+
+
+def test_classify_empty_when_too_few_items():
+    s = FreshnessSummary(total=2, fresh_count=2, freshest_age_days=0.5)
+    status, reason = classify_segment(s, min_articles=3, min_fresh=3, stale_days=4)
+    assert status == STATUS_EMPTY
+    assert "recommendable" in reason
+
+
+def test_classify_empty_takes_precedence_over_fresh_check():
+    # Zero items -> EMPTY, not NO_FRESH, even though fresh_count also < min_fresh.
+    s = FreshnessSummary(total=0, fresh_count=0, freshest_age_days=None)
+    status, _ = classify_segment(s, min_articles=3, min_fresh=3, stale_days=4)
+    assert status == STATUS_EMPTY
+
+
+def test_classify_no_fresh_when_inventory_exists_but_stale():
+    # This is the incident shape: plenty of items, but not enough FRESH ones.
+    s = FreshnessSummary(total=20, fresh_count=1, freshest_age_days=9.0)
+    status, reason = classify_segment(s, min_articles=3, min_fresh=3, stale_days=4)
+    assert status == STATUS_NO_FRESH
+    assert "fresh" in reason
+
+
+def test_classify_stale_when_fresh_enough_but_freshest_too_old():
+    # Enough "fresh" (within 7d) items to pass min_fresh, but the freshest is
+    # older than stale_days -> STALE. Uses a wider fresh window than stale window.
+    s = FreshnessSummary(total=10, fresh_count=4, freshest_age_days=5.0)
+    status, reason = classify_segment(s, min_articles=3, min_fresh=3, stale_days=4)
+    assert status == STATUS_STALE
+    assert "freshest" in reason
+
+
+def test_classify_ok_at_stale_boundary():
+    # freshest exactly == stale_days is NOT stale (strict >).
+    s = FreshnessSummary(total=10, fresh_count=5, freshest_age_days=4.0)
+    status, _ = classify_segment(s, min_articles=3, min_fresh=3, stale_days=4)
+    assert status == STATUS_OK


### PR DESCRIPTION
## Why this exists (the incident)

We already monitor the **supply/download** side: `crawler_liveness_check.py` ("is the crawler alive at all?") and `feed_health_check.py` ("which individual RSS feeds went quiet?"). Both watch whether articles get **downloaded**.

But recently a real user's feed was silently **EMPTY for ~5 days** while downloads were perfectly fine. The **simplification pipeline** had broken, and that user's segment (Danish, B2+) is filtered toward simplified content — of which there was suddenly none. A supply/download check cannot see this: articles *were* arriving, they just never survived the per-user CEFR + feature-flag filtering to reach the feed.

This adds a **delivery-side** check: does a real user in each segment actually **see** a fresh feed?

## Approach

The segment dimension that matters is **`(learned_language, CEFR_level)`** — feed inventory and filters vary along it, and the incident hit one specific corner. For each segment the tool computes **two signals**:

1. **INVENTORY (primary alert trigger).** Re-runs the app's *own* query builder `build_elastic_recommender_query` parameterized by the segment's language + CEFR level, with **no** per-user seen-exclusion and **no** topic narrowing. This is "does fresh content this segment *could* be shown even exist in the index?" It replicates the exact `available_cefr_levels` filtering that starved the incident's segment, without being confounded by any one user's reading history. Uses `include_lower=False` on purpose — the incident hit users who see only their exact level, so the strict same-level query is the worst-case signal.

2. **PER-USER CANARY (corroboration).** Picks a real, recently-active user in the segment (`last_seen` within `--active-days`, CEFR via `cefr_level_for_learned_language`) and calls the **real** feed function `article_recommendations_for_user(user, 10)`. This exercises the full delivery path: CEFR filtering, feature flags (simplified-only vs originals-first, "show easier"), disturbing filter, ES index, seen-exclusion, teacher-upload filtering. **No synthetic users are created** — only existing active users are read.

### Why inventory is the primary signal (the seen-history caveat)

A single power-user can legitimately have an **empty personal feed** — they've already opened everything fresh. That's a false positive for "the segment is broken." Segment-wide inventory has no per-user history, so an empty/stale inventory is the trustworthy alarm; the per-user canary is reported **alongside** as corroboration and as a reality check on the flags. When the canary feed is empty but inventory is healthy, the report explicitly says so rather than alerting.

### Per segment, the status is:
- **EMPTY** — fewer than `min-articles` recommendable items at all
- **NO_FRESH** — enough items exist but fewer than `min-fresh` are fresh (the incident shape)
- **STALE** — enough fresh items, but even the freshest is older than `stale-days`
- **OK** otherwise

On any failing segment it emails a per-segment summary via `ZeeguuMailer` (the app's own SMTP — cron stdout goes to an unread log, same rationale as the other monitors), prints a structured report, and **exits non-zero** so cron surfaces it.

## Thresholds (starting guesses — tune with real data)

All module constants, each **env-overridable** so cron can adjust without a code change:

| Threshold | Default | Env var |
|---|---|---|
| Active-user window | 30 days | `FEED_HEALTH_ACTIVE_DAYS` |
| Fresh window | 7 days | `FEED_HEALTH_FRESH_DAYS` |
| Min recommendable items | 3 | `FEED_HEALTH_MIN_ARTICLES` |
| Min fresh items | 3 | `FEED_HEALTH_MIN_FRESH` |
| Freshest-item stale cutoff | 4 days | `FEED_HEALTH_STALE_DAYS` |
| Items requested | 10 | `FEED_HEALTH_COUNT` |

## Files

- `tools/feed_delivery_health_check.py` — the monitor
- `tools/test_feed_delivery_health_check.py` — 11 unit tests for the pure freshness/staleness classification and segment-status decision (`python -m pytest tools/test_feed_delivery_health_check.py`, all green). The full ES+DB path needs a live index and is not unit-tested; the app context is created lazily inside `main()` so the module imports DB-free for tests.

## Proposed crontab line (for the ops repo — NOT wired here)

Once daily, after the morning crawl has had time to run:

```cron
30 6 * * *  cd $ZEEGUU_API && run_task.sh feed_delivery_health_check
```

(Adjust to match the `run_task.sh` invocation convention the other monitors use.)

## Open questions

- **Which segments are "must-never-be-empty"?** Right now every active segment is checked equally. We may want an allow-list of core `(language, CEFR)` segments that page vs. merely log, and to ignore tiny long-tail segments (one user at C2 in a thin-inventory language) that are empty by nature, not by breakage.
- **Threshold tuning.** `min-fresh=3` / `stale-days=4` are guesses. A few weeks of per-segment numbers (especially overnight/weekend low-water marks) should calibrate these; the strict `include_lower=False` inventory query may be too aggressive for genuinely thin-inventory languages.
- **Primary signal choice.** I made **inventory** the trigger and the canary corroboration. Alternative: alert only when *both* inventory is thin *and* the canary is empty (fewer false positives, but would have caught the incident a bit later). Worth revisiting once we see real alert volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
