### PR TITLE
Race-guard the six bookmark/context join tables

### DIFF
--- a/tools/migrations/26-08-13--add_unique_bookmark_context_joins.sql
+++ b/tools/migrations/26-08-13--add_unique_bookmark_context_joins.sql
@@ -1,0 +1,38 @@
+-- Add UNIQUE(bookmark_id, <anchor_id>) to the bookmark/context join tables.
+--
+-- Each of these tables backs a copy-pasted find_or_create that (a) inherited an
+-- 'except A or B' bug which only ever caught NoResultFound, and (b) had no unique
+-- key, so a concurrent first-open race (two requests INSERTing between each
+-- other's SELECT and INSERT) silently created duplicate rows -- after which
+-- find_by_bookmark / find_or_create (.one()) 500'd with MultipleResultsFound.
+--
+-- The models now insert inside a SAVEPOINT and re-query on IntegrityError, which
+-- only works once the constraint below actually exists. Mirrors the fix already
+-- applied to article_level_summary_context (PR #698, commit 01520e6b).
+--
+-- Prod was verified duplicate-free for all six (bookmark_id, anchor_id) pairs on
+-- 2026-08-13 (0 duplicate groups per table), so no de-dupe step is required and
+-- the ALTERs below will not fail on existing data. If you run this against an
+-- environment that might contain duplicates, dedupe first with the same
+-- DELETE...JOIN(keep MIN(id)) pattern as 26-05-26-a--dedupe-and-unique-user-video.sql.
+--
+-- Note on cost: each ALTER rewrites the table to add the unique key. These join
+-- tables are small, but prefer off-peak if any has grown large.
+
+ALTER TABLE article_summary_context
+    ADD UNIQUE KEY uq_asc_bookmark_article (bookmark_id, article_id);
+
+ALTER TABLE article_fragment_context
+    ADD UNIQUE KEY uq_afc_bookmark_fragment (bookmark_id, article_fragment_id);
+
+ALTER TABLE article_title_context
+    ADD UNIQUE KEY uq_atc_bookmark_article (bookmark_id, article_id);
+
+ALTER TABLE video_title_context
+    ADD UNIQUE KEY uq_vtc_bookmark_video (bookmark_id, video_id);
+
+ALTER TABLE video_caption_context
+    ADD UNIQUE KEY uq_vcc_bookmark_caption (bookmark_id, caption_id);
+
+ALTER TABLE example_sentence_context
+    ADD UNIQUE KEY uq_esc_bookmark_example (bookmark_id, example_sentence_id);

--- a/zeeguu/core/model/article_fragment_context.py
+++ b/zeeguu/core/model/article_fragment_context.py
@@ -7,7 +7,15 @@ class ArticleFragmentContext(db.Model):
     A context that is found in a fragment of an Article.
     """
 
-    __table_args__ = {"mysql_collate": "utf8_bin"}
+    __table_args__ = (
+        # At most one context row per (bookmark, article fragment) — see find_or_create.
+        db.UniqueConstraint(
+            "bookmark_id",
+            "article_fragment_id",
+            name="uq_afc_bookmark_fragment",
+        ),
+        {"mysql_collate": "utf8_bin"},
+    )
 
     id = db.Column(db.Integer, primary_key=True)
     from zeeguu.core.model.bookmark import Bookmark
@@ -40,20 +48,34 @@ class ArticleFragmentContext(db.Model):
 
     @classmethod
     def find_or_create(cls, session, bookmark, article_fragment, commit=True):
+        existing = cls.query.filter(
+            cls.bookmark == bookmark,
+            cls.article_fragment == article_fragment,
+        ).one_or_none()
+        if existing:
+            return existing
+
+        # Insert inside a SAVEPOINT so that if a concurrent request created the
+        # same (bookmark, article fragment) between our SELECT and INSERT, the
+        # unique constraint fires and we roll back just this insert (not the
+        # caller's whole transaction, which may still be uncommitted when
+        # commit=False) and return the row the other request created.
+        new = cls(
+            bookmark,
+            article_fragment,
+        )
         try:
+            with session.begin_nested():
+                session.add(new)
+        except sqlalchemy.exc.IntegrityError:
             return cls.query.filter(
                 cls.bookmark == bookmark,
                 cls.article_fragment == article_fragment,
             ).one()
-        except sqlalchemy.orm.exc.NoResultFound or sqlalchemy.exc.InterfaceError:
-            new = cls(
-                bookmark,
-                article_fragment,
-            )
-            session.add(new)
-            if commit:
-                session.commit()
-            return new
+
+        if commit:
+            session.commit()
+        return new
 
     @classmethod
     def get_all_user_bookmarks_for_article_fragment(

--- a/zeeguu/core/model/article_summary_context.py
+++ b/zeeguu/core/model/article_summary_context.py
@@ -9,7 +9,15 @@ class ArticleSummaryContext(db.Model):
     A context that is found in a summary of an Article.
     """
 
-    __table_args__ = {"mysql_collate": "utf8_bin"}
+    __table_args__ = (
+        # At most one context row per (bookmark, article) summary — see find_or_create.
+        db.UniqueConstraint(
+            "bookmark_id",
+            "article_id",
+            name="uq_asc_bookmark_article",
+        ),
+        {"mysql_collate": "utf8_bin"},
+    )
 
     id = db.Column(db.Integer, primary_key=True)
     bookmark_id = db.Column(db.Integer, db.ForeignKey(Bookmark.id), nullable=False)
@@ -44,20 +52,34 @@ class ArticleSummaryContext(db.Model):
         article,
         commit=True,
     ):
+        existing = cls.query.filter(
+            cls.bookmark == bookmark,
+            cls.article == article,
+        ).one_or_none()
+        if existing:
+            return existing
+
+        # Insert inside a SAVEPOINT so that if a concurrent request created the
+        # same (bookmark, article) between our SELECT and INSERT, the unique
+        # constraint fires and we roll back just this insert (not the caller's
+        # whole transaction, which may still be uncommitted when commit=False) and
+        # return the row the other request created.
+        new = cls(
+            bookmark,
+            article,
+        )
         try:
+            with session.begin_nested():
+                session.add(new)
+        except sqlalchemy.exc.IntegrityError:
             return cls.query.filter(
                 cls.bookmark == bookmark,
                 cls.article == article,
             ).one()
-        except sqlalchemy.orm.exc.NoResultFound or sqlalchemy.exc.InterfaceError:
-            new = cls(
-                bookmark,
-                article,
-            )
-            session.add(new)
-            if commit:
-                session.commit()
-            return new
+
+        if commit:
+            session.commit()
+        return new
 
     @classmethod
     def get_all_user_bookmarks_for_article_summary(

--- a/zeeguu/core/model/article_title_context.py
+++ b/zeeguu/core/model/article_title_context.py
@@ -9,7 +9,15 @@ class ArticleTitleContext(db.Model):
     A context that is found in a title of an Article.
     """
 
-    __table_args__ = {"mysql_collate": "utf8_bin"}
+    __table_args__ = (
+        # At most one context row per (bookmark, article) title — see find_or_create.
+        db.UniqueConstraint(
+            "bookmark_id",
+            "article_id",
+            name="uq_atc_bookmark_article",
+        ),
+        {"mysql_collate": "utf8_bin"},
+    )
 
     id = db.Column(db.Integer, primary_key=True)
     bookmark_id = db.Column(db.Integer, db.ForeignKey(Bookmark.id), nullable=False)
@@ -44,20 +52,34 @@ class ArticleTitleContext(db.Model):
         article,
         commit=True,
     ):
+        existing = cls.query.filter(
+            cls.bookmark == bookmark,
+            cls.article == article,
+        ).one_or_none()
+        if existing:
+            return existing
+
+        # Insert inside a SAVEPOINT so that if a concurrent request created the
+        # same (bookmark, article) between our SELECT and INSERT, the unique
+        # constraint fires and we roll back just this insert (not the caller's
+        # whole transaction, which may still be uncommitted when commit=False) and
+        # return the row the other request created.
+        new = cls(
+            bookmark,
+            article,
+        )
         try:
+            with session.begin_nested():
+                session.add(new)
+        except sqlalchemy.exc.IntegrityError:
             return cls.query.filter(
                 cls.bookmark == bookmark,
                 cls.article == article,
             ).one()
-        except sqlalchemy.orm.exc.NoResultFound or sqlalchemy.exc.InterfaceError:
-            new = cls(
-                bookmark,
-                article,
-            )
-            session.add(new)
-            if commit:
-                session.commit()
-            return new
+
+        if commit:
+            session.commit()
+        return new
 
     @classmethod
     def get_all_user_bookmarks_for_article_title(

--- a/zeeguu/core/model/example_sentence_context.py
+++ b/zeeguu/core/model/example_sentence_context.py
@@ -10,10 +10,18 @@ class ExampleSentenceContext(db.Model):
     This follows the same pattern as VideoTitleContext, ArticleFragmentContext, etc.
     """
 
-    __table_args__ = {"mysql_collate": "utf8_bin"}
+    __table_args__ = (
+        # At most one context row per (bookmark, example sentence) — see find_or_create.
+        db.UniqueConstraint(
+            "bookmark_id",
+            "example_sentence_id",
+            name="uq_esc_bookmark_example",
+        ),
+        {"mysql_collate": "utf8_bin"},
+    )
 
     id = db.Column(db.Integer, primary_key=True)
-    
+
     bookmark_id = db.Column(db.Integer, db.ForeignKey(Bookmark.id), nullable=False)
     bookmark = db.relationship(Bookmark)
 
@@ -46,17 +54,31 @@ class ExampleSentenceContext(db.Model):
         example_sentence,
         commit=True,
     ):
+        existing = cls.query.filter(
+            cls.bookmark == bookmark,
+            cls.example_sentence == example_sentence,
+        ).one_or_none()
+        if existing:
+            return existing
+
+        # Insert inside a SAVEPOINT so that if a concurrent request created the
+        # same (bookmark, example sentence) between our SELECT and INSERT, the
+        # unique constraint fires and we roll back just this insert (not the
+        # caller's whole transaction, which may still be uncommitted when
+        # commit=False) and return the row the other request created.
+        new = cls(bookmark, example_sentence)
         try:
+            with session.begin_nested():
+                session.add(new)
+        except sqlalchemy.exc.IntegrityError:
             return cls.query.filter(
                 cls.bookmark == bookmark,
                 cls.example_sentence == example_sentence,
             ).one()
-        except sqlalchemy.orm.exc.NoResultFound or sqlalchemy.exc.InterfaceError:
-            new = cls(bookmark, example_sentence)
-            session.add(new)
-            if commit:
-                session.commit()
-            return new
+
+        if commit:
+            session.commit()
+        return new
 
     @classmethod
     def get_all_user_bookmarks_for_example(

--- a/zeeguu/core/model/video_caption_context.py
+++ b/zeeguu/core/model/video_caption_context.py
@@ -8,7 +8,15 @@ class VideoCaptionContext(db.Model):
     A context that is found in a caption of a Video.
     """
 
-    __table_args__ = {"mysql_collate": "utf8_bin"}
+    __table_args__ = (
+        # At most one context row per (bookmark, caption) — see find_or_create.
+        db.UniqueConstraint(
+            "bookmark_id",
+            "caption_id",
+            name="uq_vcc_bookmark_caption",
+        ),
+        {"mysql_collate": "utf8_bin"},
+    )
 
     id = db.Column(db.Integer, primary_key=True)
 
@@ -46,20 +54,34 @@ class VideoCaptionContext(db.Model):
         caption,
         commit=True,
     ):
+        existing = cls.query.filter(
+            cls.bookmark == bookmark,
+            cls.caption == caption,
+        ).one_or_none()
+        if existing:
+            return existing
+
+        # Insert inside a SAVEPOINT so that if a concurrent request created the
+        # same (bookmark, caption) between our SELECT and INSERT, the unique
+        # constraint fires and we roll back just this insert (not the caller's
+        # whole transaction, which may still be uncommitted when commit=False) and
+        # return the row the other request created.
+        new = cls(
+            bookmark,
+            caption,
+        )
         try:
+            with session.begin_nested():
+                session.add(new)
+        except sqlalchemy.exc.IntegrityError:
             return cls.query.filter(
                 cls.bookmark == bookmark,
                 cls.caption == caption,
             ).one()
-        except sqlalchemy.orm.exc.NoResultFound or sqlalchemy.exc.InterfaceError:
-            new = cls(
-                bookmark,
-                caption,
-            )
-            session.add(new)
-            if commit:
-                session.commit()
-            return new
+
+        if commit:
+            session.commit()
+        return new
 
     @classmethod
     def get_all_user_bookmarks_for_caption(

--- a/zeeguu/core/model/video_title_context.py
+++ b/zeeguu/core/model/video_title_context.py
@@ -10,7 +10,15 @@ class VideoTitleContext(db.Model):
     A context that is found in a title of an Video.
     """
 
-    __table_args__ = {"mysql_collate": "utf8_bin"}
+    __table_args__ = (
+        # At most one context row per (bookmark, video) title — see find_or_create.
+        db.UniqueConstraint(
+            "bookmark_id",
+            "video_id",
+            name="uq_vtc_bookmark_video",
+        ),
+        {"mysql_collate": "utf8_bin"},
+    )
 
     id = db.Column(db.Integer, primary_key=True)
     bookmark_id = db.Column(db.Integer, db.ForeignKey(Bookmark.id), nullable=False)
@@ -45,17 +53,31 @@ class VideoTitleContext(db.Model):
         video,
         commit=True,
     ):
+        existing = cls.query.filter(
+            cls.bookmark == bookmark,
+            cls.video == video,
+        ).one_or_none()
+        if existing:
+            return existing
+
+        # Insert inside a SAVEPOINT so that if a concurrent request created the
+        # same (bookmark, video) between our SELECT and INSERT, the unique
+        # constraint fires and we roll back just this insert (not the caller's
+        # whole transaction, which may still be uncommitted when commit=False) and
+        # return the row the other request created.
+        new = cls(bookmark, video)
         try:
+            with session.begin_nested():
+                session.add(new)
+        except sqlalchemy.exc.IntegrityError:
             return cls.query.filter(
                 cls.bookmark == bookmark,
                 cls.video == video,
             ).one()
-        except sqlalchemy.orm.exc.NoResultFound or sqlalchemy.exc.InterfaceError:
-            new = cls(bookmark, video)
-            session.add(new)
-            if commit:
-                session.commit()
-            return new
+
+        if commit:
+            session.commit()
+        return new
 
     @classmethod
     def get_all_user_bookmarks_for_video_title(

--- a/zeeguu/core/test/test_bookmark_context_uniqueness.py
+++ b/zeeguu/core/test/test_bookmark_context_uniqueness.py
@@ -1,0 +1,142 @@
+"""Race-guard behaviour for the bookmark/context join tables.
+
+Every one of these join models carries a copy-pasted find_or_create that used to
+(a) swallow the wrong exception ('except A or B' only ever caught NoResultFound)
+and (b) have no unique key, so a concurrent first-open race could create two rows
+for the same (bookmark, anchor) -- which later broke find_by_bookmark/.one() with
+MultipleResultsFound.
+
+These tests mirror test_article_level_summary.py's
+test_context_find_or_create_is_idempotent / _rejected_by_unique_constraint, run
+across all six affected models at once:
+
+    ArticleSummaryContext, ArticleFragmentContext, ArticleTitleContext,
+    VideoTitleContext, VideoCaptionContext, ExampleSentenceContext
+"""
+from unittest import TestCase
+
+from sqlalchemy.exc import IntegrityError
+
+import zeeguu.core
+from zeeguu.core.test.model_test_mixin import ModelTestMixIn
+from zeeguu.core.test.rules.article_rule import ArticleRule
+from zeeguu.core.test.rules.bookmark_rule import BookmarkRule
+from zeeguu.core.test.rules.meaning_rule import MeaningRule
+from zeeguu.core.test.rules.user_rule import UserRule
+
+from zeeguu.core.model.article_fragment import ArticleFragment
+from zeeguu.core.model.article_fragment_context import ArticleFragmentContext
+from zeeguu.core.model.article_summary_context import ArticleSummaryContext
+from zeeguu.core.model.article_title_context import ArticleTitleContext
+from zeeguu.core.model.caption import Caption
+from zeeguu.core.model.example_sentence import ExampleSentence
+from zeeguu.core.model.example_sentence_context import ExampleSentenceContext
+from zeeguu.core.model.new_text import NewText
+from zeeguu.core.model.video import Video
+from zeeguu.core.model.video_caption_context import VideoCaptionContext
+from zeeguu.core.model.video_title_context import VideoTitleContext
+
+session = zeeguu.core.model.db.session
+
+
+class BookmarkContextUniquenessTest(ModelTestMixIn, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = UserRule().user
+        self.article = ArticleRule().article
+        language = self.user.learned_language
+
+        self.fragment = ArticleFragment.find_or_create(
+            session, self.article, "a fragment of text", 0
+        )
+
+        self.video = Video(
+            video_unique_key="test_video_key",
+            title="a test video",
+            source=None,
+            description="a description",
+            published_time=None,
+            channel=None,
+            thumbnail_url=None,
+            duration=0,
+            language=language,
+        )
+        session.add(self.video)
+
+        self.caption = Caption(
+            self.video, 0, 1000, NewText.find_or_create(session, "a caption line")
+        )
+        session.add(self.caption)
+
+        self.example_sentence = ExampleSentence(
+            "an example sentence", language, MeaningRule().meaning
+        )
+        session.add(self.example_sentence)
+        session.commit()
+
+    def _cases(self):
+        """(label, ContextClass, find_or_create-args, anchor filter kwargs)."""
+        return [
+            (
+                "article_summary",
+                ArticleSummaryContext,
+                (self.article,),
+                dict(article_id=self.article.id),
+            ),
+            (
+                "article_title",
+                ArticleTitleContext,
+                (self.article,),
+                dict(article_id=self.article.id),
+            ),
+            (
+                "article_fragment",
+                ArticleFragmentContext,
+                (self.fragment,),
+                dict(article_fragment_id=self.fragment.id),
+            ),
+            (
+                "video_title",
+                VideoTitleContext,
+                (self.video,),
+                dict(video_id=self.video.id),
+            ),
+            (
+                "video_caption",
+                VideoCaptionContext,
+                (self.caption,),
+                dict(caption_id=self.caption.id),
+            ),
+            (
+                "example_sentence",
+                ExampleSentenceContext,
+                (self.example_sentence,),
+                dict(example_sentence_id=self.example_sentence.id),
+            ),
+        ]
+
+    def test_context_find_or_create_is_idempotent(self):
+        for label, ctx_cls, anchor_args, anchor_filter in self._cases():
+            with self.subTest(context=label):
+                bookmark = BookmarkRule(self.user).bookmark
+
+                c1 = ctx_cls.find_or_create(session, bookmark, *anchor_args)
+                c2 = ctx_cls.find_or_create(session, bookmark, *anchor_args)
+
+                assert c1.id == c2.id
+                count = ctx_cls.query.filter_by(
+                    bookmark_id=bookmark.id, **anchor_filter
+                ).count()
+                assert count == 1
+
+    def test_duplicate_context_rejected_by_unique_constraint(self):
+        for label, ctx_cls, anchor_args, _ in self._cases():
+            with self.subTest(context=label):
+                bookmark = BookmarkRule(self.user).bookmark
+
+                # Two raw rows for the same (bookmark, anchor) must not coexist.
+                session.add(ctx_cls(bookmark, *anchor_args))
+                session.add(ctx_cls(bookmark, *anchor_args))
+                with self.assertRaises(IntegrityError):
+                    session.flush()
+                session.rollback()


### PR DESCRIPTION
## Problem

Each of the six bookmark/context join models shares a copy-pasted `find_or_create` with two latent bugs:

1. **Wrong exception swallowed** — `except sqlalchemy.orm.exc.NoResultFound or sqlalchemy.exc.InterfaceError:` is a Python bug: `A or B` evaluates to `A`, so only `NoResultFound` was ever caught; `InterfaceError` never was.
2. **No UNIQUE constraint** on `(bookmark_id, <anchor_id>)` — a concurrent first-open race (two requests INSERTing between each other's SELECT and INSERT) silently created duplicate rows, after which `find_by_bookmark` / `find_or_create` (`.one()`) 500'd with `MultipleResultsFound`.

Affected models: `ArticleSummaryContext`, `ArticleFragmentContext`, `ArticleTitleContext`, `VideoTitleContext`, `VideoCaptionContext`, `ExampleSentenceContext`.

## Fix

Mirrors the pattern already applied to `ArticleLevelSummaryContext` (commit 01520e6b, #698):

- Add a `db.UniqueConstraint(bookmark_id, <anchor_id>)` to each model's `__table_args__` (dict → tuple) so the SQLite test DB enforces it too, plus a matching `ADD UNIQUE KEY` in a new SQL migration.
- Rewrite `find_or_create` to `.one_or_none()` + insert inside `with session.begin_nested():`, catching `IntegrityError` to re-query and return the row the concurrent request created (respecting the `commit` param, so the caller's still-open transaction isn't rolled back when `commit=False`).

## Prod verification

Checked prod before adding the constraints — **0 duplicate `(bookmark_id, anchor_id)` groups** across all six tables on 2026-08-13, so the migration needs no de-dupe step and the `ALTER`s won't fail on existing data.

## Tests

`test_bookmark_context_uniqueness.py` covers idempotency and unique-constraint rejection across all six models (2 tests × 6 models = 12 subtests, passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)