### PR TITLE
Verify the output language of every LLM call that must produce a foreign language

### DIFF
--- a/tools/audit_audio_lesson_script_languages.py
+++ b/tools/audit_audio_lesson_script_languages.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+"""
+Find audio lesson scripts that were generated in the wrong language.
+
+Scripts are cached and reused — an AudioLessonMeaning is reused for everyone
+learning that meaning, and a general AudioLessonDialogue is reused across users —
+so one script the LLM wrote in the wrong language keeps being served until it is
+deprecated. New scripts are checked at generation time by
+zeeguu.core.audio_lessons.script_language_validator; this tool covers the ones
+already in the database.
+
+Usage:
+    python -m tools.audit_audio_lesson_script_languages                 # report only
+    python -m tools.audit_audio_lesson_script_languages --language da   # one learned language
+    python -m tools.audit_audio_lesson_script_languages --deprecate     # mark the bad ones
+
+--deprecate sets deprecated_at, so cache lookups regenerate while daily lessons
+that already reference the row keep playing.
+"""
+
+import sys
+import os
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from zeeguu.api.app import create_app_for_scripts
+from zeeguu.core.model import db
+
+app = create_app_for_scripts()
+app.app_context().push()
+
+from zeeguu.core.audio_lessons.script_language_validator import (
+    describe_mismatches,
+    find_language_mismatches,
+)
+from zeeguu.core.model.audio_lesson_dialogue import AudioLessonDialogue
+from zeeguu.core.model.audio_lesson_meaning import AudioLessonMeaning
+
+DEPRECATE = "--deprecate" in sys.argv
+LANGUAGE = None
+if "--language" in sys.argv:
+    LANGUAGE = sys.argv[sys.argv.index("--language") + 1]
+
+print(f"Mode: {'DEPRECATE bad scripts' if DEPRECATE else 'REPORT ONLY'}")
+if LANGUAGE:
+    print(f"Learned language filter: {LANGUAGE}")
+print()
+
+
+def teacher_code(lesson):
+    return lesson.teacher_language.code if lesson.teacher_language else "en"
+
+
+def audit(label, lessons, learned_code_of, describe):
+    """Check each lesson's script and return the ones whose language is wrong."""
+    print("=" * 70)
+    print(f"{label}: {len(lessons)} to check")
+    print("=" * 70)
+
+    bad = []
+    for lesson in lessons:
+        learned = learned_code_of(lesson)
+        if LANGUAGE and learned != LANGUAGE:
+            continue
+        mismatches = find_language_mismatches(
+            lesson.script, target_language=learned, source_language=teacher_code(lesson)
+        )
+        if mismatches:
+            bad.append(lesson)
+            print(f"  [{lesson.id}] {describe(lesson)} ({learned}/{teacher_code(lesson)})")
+            print(f"      {describe_mismatches(mismatches)}")
+
+    print(f"  → {len(bad)} with a wrong-language script")
+    print()
+    return bad
+
+
+meanings = AudioLessonMeaning.query.filter(
+    AudioLessonMeaning.deprecated_at.is_(None)
+).all()
+bad_meanings = audit(
+    "AudioLessonMeaning",
+    meanings,
+    learned_code_of=lambda m: m.meaning.origin.language.code,
+    describe=lambda m: f"{m.meaning.origin.content} → {m.meaning.translation.content}",
+)
+
+dialogues = AudioLessonDialogue.query.filter(
+    AudioLessonDialogue.deprecated_at.is_(None)
+).all()
+bad_dialogues = audit(
+    "AudioLessonDialogue",
+    dialogues,
+    learned_code_of=lambda d: d.language.code,
+    describe=lambda d: d.title or d.canonical_suggestion,
+)
+
+if DEPRECATE and (bad_meanings or bad_dialogues):
+    now = datetime.now()
+    for lesson in bad_meanings + bad_dialogues:
+        lesson.deprecated_at = now
+    db.session.commit()
+    print(
+        f"Deprecated {len(bad_meanings)} meaning lessons and "
+        f"{len(bad_dialogues)} dialogues. They will be regenerated on next request."
+    )
+elif bad_meanings or bad_dialogues:
+    print("Run again with --deprecate to mark these for regeneration.")
+else:
+    print("No wrong-language scripts found.")

--- a/tools/audit_audio_lesson_script_languages.py
+++ b/tools/audit_audio_lesson_script_languages.py
@@ -30,10 +30,8 @@ from zeeguu.core.model import db
 app = create_app_for_scripts()
 app.app_context().push()
 
-from zeeguu.core.audio_lessons.script_language_validator import (
-    describe_mismatches,
-    find_language_mismatches,
-)
+from zeeguu.core.audio_lessons.script_language_validator import find_language_mismatches
+from zeeguu.core.language.language_check import describe_mismatches
 from zeeguu.core.model.audio_lesson_dialogue import AudioLessonDialogue
 from zeeguu.core.model.audio_lesson_meaning import AudioLessonMeaning
 

--- a/tools/audit_stored_article_languages.py
+++ b/tools/audit_stored_article_languages.py
@@ -40,13 +40,22 @@ Usage:
     python -m tools.audit_stored_article_languages --language da --since 2026-07-01
     python -m tools.audit_stored_article_languages --language da --fix
 
---fix drops what is wrong rather than rewriting it: summaries are nulled and bad
-level-summary rows deleted, so they regenerate; child articles are marked broken
-(LLM_WRONG_LANGUAGE), which takes a simplified one out of
-usable_simplified_versions and a translated one out of the #translated-from URL
-cache, so the next reader at that language+level gets a fresh one. Regenerating
-the summaries themselves is the job of tools/backfill_reassess_summaries.py —
-run it after this, on the same --language/--since window.
+--fix drops what is wrong rather than rewriting it:
+
+  - article.summary is nulled, along with the cached tokenized copy of it (that
+    cache is only ever written when empty, so a stale one would outlive the
+    regeneration and keep rendering);
+  - bad ArticleLevelSummary rows are deleted, with the bookmark anchors that
+    reference them (a real FK, no cascade) removed first;
+  - child articles are marked broken (LLM_WRONG_LANGUAGE), which takes a
+    simplified one out of usable_simplified_versions and a translated one out of
+    the #translated-from URL cache, so the next reader at that language+level
+    gets a fresh one.
+
+Regenerating the summaries themselves is the job of
+tools/backfill_reassess_summaries.py — run it after this, on the same
+--language/--since window, with --include-missing-summaries so it picks up the
+ones emptied here. The exact command is printed at the end of a --fix run.
 """
 
 import argparse
@@ -61,6 +70,8 @@ from zeeguu.core.language.language_check import check_language, describe_mismatc
 from zeeguu.core.model.article import Article
 from zeeguu.core.model.article_broken_code_map import LowQualityTypes
 from zeeguu.core.model.article_level_summary import ArticleLevelSummary
+from zeeguu.core.model.article_level_summary_context import ArticleLevelSummaryContext
+from zeeguu.core.model.article_tokenization_cache import ArticleTokenizationCache
 from zeeguu.core.model.language import Language
 
 session = db.session
@@ -163,6 +174,14 @@ def main():
         query = query.limit(args.limit)
     articles = query.all()
 
+    # Article.language_id is nullable, and a language-less row would take the
+    # whole scan down on article.language.code. There is nothing to check them
+    # against anyway.
+    without_language = [a for a in articles if a.language is None]
+    if without_language:
+        print(f"Skipping {len(without_language)} article(s) with no language set")
+        articles = [a for a in articles if a.language is not None]
+
     originals = [a for a in articles if a.parent_article_id is None]
     children = [a for a in articles if a.parent_article_id is not None]
     # Same language as the parent = a level adaptation. Different language = a
@@ -211,12 +230,34 @@ def main():
         return
 
     # Null the wrong summaries; the article keeps its assessment.
+    #
+    # The tokenized copy has to go with it. ArticleTokenizationCache only ever
+    # writes tokenized_summary when it is empty (`if article.summary and not
+    # cache.tokenized_summary`) and nothing else invalidates it — so leaving it
+    # in place would survive the regeneration below and keep rendering the old
+    # wrong-language tokens as the card's interactive summary.
     for article in summary_articles:
         article.summary = None
         session.add(article)
+        cache = ArticleTokenizationCache.get_for_article(session, article.id)
+        if cache and cache.tokenized_summary:
+            cache.tokenized_summary = None
+            session.add(cache)
 
-    for row in level_summary_rows:
-        session.delete(row)
+    # Bookmarks anchor to a SPECIFIC level summary (ArticleLevelSummaryContext
+    # holds a real FK with no cascade), so the anchors have to go first or the
+    # delete fails on the constraint and takes the whole batch down with it.
+    # They anchor into text we are throwing away, so there is nothing to keep.
+    if level_summary_rows:
+        summary_ids = [row.id for row in level_summary_rows]
+        anchors = ArticleLevelSummaryContext.query.filter(
+            ArticleLevelSummaryContext.article_level_summary_id.in_(summary_ids)
+        ).all()
+        for anchor in anchors:
+            session.delete(anchor)
+        session.flush()
+        for row in level_summary_rows:
+            session.delete(row)
 
     session.commit()
 
@@ -236,7 +277,7 @@ def main():
     print(
         "\nNow regenerate the summaries:\n"
         f"    python tools/backfill_reassess_summaries.py --language {args.language or 'da'}"
-        f" --since {args.since} --apply"
+        f" --since {args.since} --include-missing-summaries --apply"
     )
 
 

--- a/tools/audit_stored_article_languages.py
+++ b/tools/audit_stored_article_languages.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python
+"""
+Find summaries and simplified articles that were stored in the wrong language.
+
+Between the on-demand-simplification rollout and 7cd9d6ca (Aug 15 2026) the
+assess/summarize prompt conveyed the output language through a weak indirection,
+and Haiku honoured it only about half the time for non-English articles. Nothing
+errored — the assessment succeeded and an English summary was written onto a
+Danish article — so the only way to find the residue is to look at what is
+stored. New output is checked at generation time by
+zeeguu.core.language.language_check; this tool covers the rows already in the DB.
+
+Everything is checked against the language of the row it belongs to, never the
+parent's — which is what makes this safe for cross-language shares:
+
+    article.summary                 on originals
+    ArticleLevelSummary.summary     the per-level feed-card blurbs; these only
+                                    ever exist on originals (the assess step
+                                    skips children), so they are always in the
+                                    original's language
+    child Article rows              title + summary + content
+
+A child of an original is one of two things, and they are reported separately:
+
+  - a **simplified** version — same language as the parent, a level adaptation.
+  - a **translated** copy — a different language, created when an article is
+    shared with a friend who is learning another language. It hangs off the same
+    parent so the reader's "Original:" link works and so it coalesces per
+    (original, language, level), but it is a legitimately German article under a
+    Danish parent. It is judged against its OWN language: German here is right,
+    not a defect. Scanning --language da therefore does not even see it; it
+    shows up under --language de.
+
+Titles are not checked on their own: under ~60 characters langdetect can't say
+anything, so nearly all of them come back "can't judge" — which is NOT the same
+as clean. Expect this tool to under-report.
+
+Usage:
+    python -m tools.audit_stored_article_languages --language da            # report only
+    python -m tools.audit_stored_article_languages --language da --since 2026-07-01
+    python -m tools.audit_stored_article_languages --language da --fix
+
+--fix drops what is wrong rather than rewriting it: summaries are nulled and bad
+level-summary rows deleted, so they regenerate; child articles are marked broken
+(LLM_WRONG_LANGUAGE), which takes a simplified one out of
+usable_simplified_versions and a translated one out of the #translated-from URL
+cache, so the next reader at that language+level gets a fresh one. Regenerating
+the summaries themselves is the job of tools/backfill_reassess_summaries.py —
+run it after this, on the same --language/--since window.
+"""
+
+import argparse
+
+from zeeguu.api.app import create_app_for_scripts
+from zeeguu.core.model import db
+
+app = create_app_for_scripts()
+app.app_context().push()
+
+from zeeguu.core.language.language_check import check_language, describe_mismatches
+from zeeguu.core.model.article import Article
+from zeeguu.core.model.article_broken_code_map import LowQualityTypes
+from zeeguu.core.model.article_level_summary import ArticleLevelSummary
+from zeeguu.core.model.language import Language
+
+session = db.session
+
+
+def describe(mismatch):
+    return describe_mismatches([mismatch])
+
+
+def report(header, rows):
+    print("=" * 78)
+    print(f"{header}: {len(rows)} in the wrong language")
+    print("=" * 78)
+    for label, mismatch in rows[:40]:
+        print(f"  {label}")
+        print(f"      {describe(mismatch)}")
+    if len(rows) > 40:
+        print(f"  ... and {len(rows) - 40} more")
+    print()
+
+
+def audit_original_summaries(articles):
+    """article.summary vs the article's own language."""
+    wrong, wrong_articles = [], []
+    for article in articles:
+        mismatch = check_language(article.summary, article.language.code, "summary")
+        if mismatch:
+            wrong.append((f"[{article.id}] {(article.title or '')[:60]}", mismatch))
+            wrong_articles.append(article)
+    return wrong, wrong_articles
+
+
+def audit_level_summaries(articles):
+    """ArticleLevelSummary rows — the tappable per-level feed-card blurbs."""
+    by_id = {article.id: article for article in articles}
+    if not by_id:
+        return [], []
+    rows = ArticleLevelSummary.query.filter(
+        ArticleLevelSummary.article_id.in_(list(by_id))
+    ).all()
+
+    wrong, wrong_rows = [], []
+    for row in rows:
+        article = by_id[row.article_id]
+        mismatch = check_language(row.summary, article.language.code, "level summary")
+        if mismatch:
+            wrong.append((f"[article {row.article_id}] {row.cefr_level} summary", mismatch))
+            wrong_rows.append(row)
+    return wrong, wrong_rows
+
+
+def audit_child_articles(children):
+    """A child article, judged on its whole body — not just its summary."""
+    wrong, wrong_articles = [], []
+    for article in children:
+        text = " ".join(
+            filter(None, [article.title, article.summary, article.get_content()])
+        )
+        mismatch = check_language(text, article.language.code, "simplified article")
+        if mismatch:
+            wrong.append(
+                (
+                    f"[{article.id}] {article.cefr_level} {article.language.code} of "
+                    f"{article.parent_article_id} — {(article.title or '')[:50]}",
+                    mismatch,
+                )
+            )
+            wrong_articles.append(article)
+    return wrong, wrong_articles
+
+
+def main():
+    p = argparse.ArgumentParser(description="Find wrong-language stored article text")
+    p.add_argument("--language", help="language code, e.g. da (default: all)")
+    p.add_argument(
+        "--since",
+        default="2026-08-01",
+        help="published_time >= this date (default 2026-08-01, the bug window)",
+    )
+    p.add_argument("--limit", type=int, default=0, help="cap articles scanned (0 = no cap)")
+    p.add_argument(
+        "--fix",
+        action="store_true",
+        help="drop what is wrong (null summaries, delete level summaries, mark "
+        "simplified articles broken). Reports only without it.",
+    )
+    args = p.parse_args()
+
+    query = Article.query.filter(Article.published_time >= args.since).filter(
+        (Article.deleted.is_(None)) | (Article.deleted == 0)
+    )
+    if args.language:
+        language = Language.find(args.language)
+        if not language:
+            print(f"Unknown language code: {args.language}")
+            return
+        query = query.filter(Article.language_id == language.id)
+    query = query.order_by(Article.id.desc())
+    if args.limit:
+        query = query.limit(args.limit)
+    articles = query.all()
+
+    originals = [a for a in articles if a.parent_article_id is None]
+    children = [a for a in articles if a.parent_article_id is not None]
+    # Same language as the parent = a level adaptation. Different language = a
+    # friend-share translation, which is *supposed* to be in another language and
+    # is only wrong if it doesn't match its own.
+    def is_level_adaptation(child):
+        parent = child.parent_article
+        return parent is not None and child.language_id == parent.language_id
+
+    simplified = [a for a in children if is_level_adaptation(a)]
+    translated = [a for a in children if not is_level_adaptation(a)]
+
+    print(f"\nMode: {'FIX' if args.fix else 'REPORT ONLY'}")
+    print(
+        f"Scanning {len(originals)} originals, {len(simplified)} simplified and "
+        f"{len(translated)} translated children "
+        f"({args.language or 'all languages'}, since {args.since})\n"
+    )
+
+    wrong_summaries, summary_articles = audit_original_summaries(originals)
+    report("article.summary", wrong_summaries)
+
+    wrong_level_summaries, level_summary_rows = audit_level_summaries(originals)
+    report("ArticleLevelSummary.summary", wrong_level_summaries)
+
+    wrong_simplified, simplified_articles = audit_child_articles(simplified)
+    report("simplified children (same language as parent)", wrong_simplified)
+
+    wrong_translated, translated_articles = audit_child_articles(translated)
+    report("translated children (judged against their own language)", wrong_translated)
+
+    bad_children = simplified_articles + translated_articles
+    total = (
+        len(wrong_summaries)
+        + len(wrong_level_summaries)
+        + len(wrong_simplified)
+        + len(wrong_translated)
+    )
+    if not total:
+        print("Nothing stored in the wrong language.")
+        print("(Remember: titles and short summaries can't be judged at all.)")
+        return
+
+    if not args.fix:
+        print(f"{total} wrong-language items. Re-run with --fix to drop them.")
+        return
+
+    # Null the wrong summaries; the article keeps its assessment.
+    for article in summary_articles:
+        article.summary = None
+        session.add(article)
+
+    for row in level_summary_rows:
+        session.delete(row)
+
+    session.commit()
+
+    # Marked broken (not deleted): a reader who already has this article open
+    # keeps it, while usable_simplified_versions (same-language children) and the
+    # #translated-from URL cache (cross-language ones) both stop handing it out,
+    # so the next request at that language+level regenerates.
+    for article in bad_children:
+        article.set_as_broken(session, LowQualityTypes.LLM_WRONG_LANGUAGE)
+
+    print(
+        f"Fixed: nulled {len(summary_articles)} article summaries, deleted "
+        f"{len(level_summary_rows)} level summaries, marked "
+        f"{len(simplified_articles)} simplified and {len(translated_articles)} "
+        f"translated children broken."
+    )
+    print(
+        "\nNow regenerate the summaries:\n"
+        f"    python tools/backfill_reassess_summaries.py --language {args.language or 'da'}"
+        f" --since {args.since} --apply"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/audit_stored_article_languages.py
+++ b/tools/audit_stored_article_languages.py
@@ -48,7 +48,7 @@ Usage:
   - bad ArticleLevelSummary rows are deleted, with the bookmark anchors that
     reference them (a real FK, no cascade) removed first;
   - child articles are marked broken (LLM_WRONG_LANGUAGE), which takes a
-    simplified one out of usable_simplified_versions and a translated one out of
+    simplified one out of available_simplified_versions and a translated one out of
     the #translated-from URL cache, so the next reader at that language+level
     gets a fresh one.
 
@@ -66,7 +66,7 @@ from zeeguu.core.model import db
 app = create_app_for_scripts()
 app.app_context().push()
 
-from zeeguu.core.language.language_check import check_language, describe_mismatches
+from zeeguu.core.language.language_check import language_mismatch, describe_mismatches
 from zeeguu.core.model.article import Article
 from zeeguu.core.model.article_broken_code_map import LowQualityTypes
 from zeeguu.core.model.article_level_summary import ArticleLevelSummary
@@ -97,7 +97,7 @@ def audit_original_summaries(articles):
     """article.summary vs the article's own language."""
     wrong, wrong_articles = [], []
     for article in articles:
-        mismatch = check_language(article.summary, article.language.code, "summary")
+        mismatch = language_mismatch(article.summary, article.language.code, "summary")
         if mismatch:
             wrong.append((f"[{article.id}] {(article.title or '')[:60]}", mismatch))
             wrong_articles.append(article)
@@ -116,7 +116,7 @@ def audit_level_summaries(articles):
     wrong, wrong_rows = [], []
     for row in rows:
         article = by_id[row.article_id]
-        mismatch = check_language(row.summary, article.language.code, "level summary")
+        mismatch = language_mismatch(row.summary, article.language.code, "level summary")
         if mismatch:
             wrong.append((f"[article {row.article_id}] {row.cefr_level} summary", mismatch))
             wrong_rows.append(row)
@@ -130,7 +130,7 @@ def audit_child_articles(children):
         text = " ".join(
             filter(None, [article.title, article.summary, article.get_content()])
         )
-        mismatch = check_language(text, article.language.code, "simplified article")
+        mismatch = language_mismatch(text, article.language.code, "simplified article")
         if mismatch:
             wrong.append(
                 (
@@ -262,7 +262,7 @@ def main():
     session.commit()
 
     # Marked broken (not deleted): a reader who already has this article open
-    # keeps it, while usable_simplified_versions (same-language children) and the
+    # keeps it, while available_simplified_versions (same-language children) and the
     # #translated-from URL cache (cross-language ones) both stop handing it out,
     # so the next request at that language+level regenerates.
     for article in bad_children:

--- a/tools/backfill_reassess_summaries.py
+++ b/tools/backfill_reassess_summaries.py
@@ -39,7 +39,7 @@ from zeeguu.core.model import db
 app = create_app_for_scripts()
 app.app_context().push()
 
-from zeeguu.core.language.language_check import check_language
+from zeeguu.core.language.language_check import language_mismatch
 from zeeguu.core.model.article import Article
 from zeeguu.core.model.language import Language
 from zeeguu.core.llm_services.simplification_and_classification import (
@@ -57,7 +57,7 @@ def wrong_language(text, language_code):
     generation path uses, so this works for every language and agrees with what
     tools/audit_stored_article_languages.py reports.
     """
-    return check_language(text, language_code) is not None
+    return language_mismatch(text, language_code) is not None
 
 
 def main():

--- a/tools/backfill_reassess_summaries.py
+++ b/tools/backfill_reassess_summaries.py
@@ -33,6 +33,7 @@ from zeeguu.core.model import db
 app = create_app_for_scripts()
 app.app_context().push()
 
+from zeeguu.core.language.language_check import check_language
 from zeeguu.core.model.article import Article
 from zeeguu.core.model.language import Language
 from zeeguu.core.llm_services.simplification_and_classification import (
@@ -41,21 +42,16 @@ from zeeguu.core.llm_services.simplification_and_classification import (
 
 session = db.session
 
-# English stopword markers vs Danish markers — the stored summaries are strongly
-# bimodal (fully English or fully target-language), so a simple count separates
-# them cleanly. Danish-specific; good enough for the "da first" pass.
-EN = [" the ", " and ", " is ", " of ", " to ", " with ", " has ", " for ",
-      " in ", " on ", " that ", " was ", " were ", " are ", " a ", " by ",
-      " from ", " this ", " have ", " been "]
-DA = [" og ", " er ", " ikke ", " på ", " til ", " med ", " har ", " som ",
-      " den ", " det ", " af ", " en ", " et ", "æ", "ø", "å"]
 
+def wrong_language(text, language_code):
+    """
+    True only when the summary is confidently in another language.
 
-def looks_english(text):
-    if not text:
-        return False
-    t = " " + text.lower() + " "
-    return sum(t.count(m) for m in EN) > sum(t.count(m) for m in DA)
+    Was a hand-rolled Danish-vs-English stopword count; now the same check the
+    generation path uses, so this works for every language and agrees with what
+    tools/audit_stored_article_languages.py reports.
+    """
+    return check_language(text, language_code) is not None
 
 
 def main():
@@ -84,7 +80,7 @@ def main():
     )
 
     need = []
-    n_no_cefr = n_english = 0
+    n_no_cefr = n_wrong_language = n_no_summary = 0
     for a in candidates:
         if a.get_word_count() < 100:
             continue
@@ -92,15 +88,22 @@ def main():
         if not a.cefr_level:
             reason = "no_cefr"
             n_no_cefr += 1
-        elif looks_english(a.summary or ""):
-            reason = "english_summary"
-            n_english += 1
+        elif wrong_language(a.summary or "", lang.code):
+            reason = "wrong_language"
+            n_wrong_language += 1
+        elif not a.summary:
+            # Includes the ones audit_stored_article_languages.py --fix emptied.
+            reason = "no_summary"
+            n_no_summary += 1
         if reason:
             need.append((a, reason))
 
     print(f"\n=== Backfill re-assess: {lang.name} since {args.since} ===")
     print(f"candidates scanned: {len(candidates)}")
-    print(f"need re-assessment: {len(need)}  (no_cefr={n_no_cefr}, english_summary={n_english})")
+    print(
+        f"need re-assessment: {len(need)}  (no_cefr={n_no_cefr}, "
+        f"wrong_language={n_wrong_language}, no_summary={n_no_summary})"
+    )
     if args.limit:
         need = need[: args.limit]
         print(f"limited to: {len(need)}")

--- a/tools/backfill_reassess_summaries.py
+++ b/tools/backfill_reassess_summaries.py
@@ -17,8 +17,14 @@ IMPORTANT: run this only AFTER the prompt fix (7cd9d6ca) is live on the server,
 or it will just rewrite English summaries again. It imports the deployed prompt.
 
 A candidate needs re-assessment if EITHER its cefr_level is missing (defect 1)
-OR its stored summary looks English (defect 2). Already-correct articles are
-skipped so we don't burn LLM calls (and cap budget) on them.
+OR its stored summary is in the wrong language (defect 2 — judged by the shared
+zeeguu.core.language.language_check, so this works for any language). Already-
+correct articles are skipped so we don't burn LLM calls (and cap budget) on them.
+
+--include-missing-summaries adds a third case: articles with no summary at all.
+Off by default because that describes everything crawled before summaries
+existed; turn it on right after audit_stored_article_languages.py --fix, which
+empties the wrong-language ones.
 
 Usage (inside the api container), DRY-RUN first:
     python tools/backfill_reassess_summaries.py --language da --since 2026-08-13
@@ -59,6 +65,14 @@ def main():
     p.add_argument("--language", default="da", help="language code (default da)")
     p.add_argument("--since", default="2026-08-13", help="published_time >= this date")
     p.add_argument("--apply", action="store_true", help="actually re-assess (else dry-run)")
+    p.add_argument(
+        "--include-missing-summaries",
+        action="store_true",
+        help="also re-assess articles that have no summary at all. Off by default: "
+        "a missing summary is normal for anything crawled before summaries existed, "
+        "so this widens the run far beyond the damaged set. Turn it on right after "
+        "audit_stored_article_languages.py --fix, which is what empties them.",
+    )
     p.add_argument("--limit", type=int, default=0, help="cap number processed (0 = no cap)")
     p.add_argument("--provider", default="anthropic")
     args = p.parse_args()
@@ -91,8 +105,10 @@ def main():
         elif wrong_language(a.summary or "", lang.code):
             reason = "wrong_language"
             n_wrong_language += 1
-        elif not a.summary:
-            # Includes the ones audit_stored_article_languages.py --fix emptied.
+        elif args.include_missing_summaries and not a.summary:
+            # The ones audit_stored_article_languages.py --fix emptied. Opt-in:
+            # without the flag this would also sweep in every article crawled
+            # before summaries existed, which is a lot of LLM calls for nothing.
             reason = "no_summary"
             n_no_summary += 1
         if reason:

--- a/zeeguu/api/endpoints/article.py
+++ b/zeeguu/api/endpoints/article.py
@@ -660,7 +660,7 @@ def simplify_article(article_id):
 
     # Check if already simplified (check for user's specific level)
     existing_simplified = [
-        v for v in article.usable_simplified_versions if v.cefr_level == user_level
+        v for v in article.available_simplified_versions if v.cefr_level == user_level
     ]
     if existing_simplified:
         # Tapping Simplify expresses interest in keeping this article — save it
@@ -677,7 +677,7 @@ def simplify_article(article_id):
             {"id": article.id, "cefr_level": original_cefr, "is_original": True}
         )
         # Add simplified versions
-        for v in article.usable_simplified_versions:
+        for v in article.available_simplified_versions:
             all_levels.append(
                 {"id": v.id, "cefr_level": v.cefr_level, "is_original": False}
             )
@@ -710,7 +710,7 @@ def simplify_article(article_id):
                 {"id": article.id, "cefr_level": original_cefr, "is_original": True}
             )
             # Add all simplified versions (including the new one)
-            for v in article.usable_simplified_versions:
+            for v in article.available_simplified_versions:
                 all_levels.append(
                     {"id": v.id, "cefr_level": v.cefr_level, "is_original": False}
                 )

--- a/zeeguu/api/endpoints/article.py
+++ b/zeeguu/api/endpoints/article.py
@@ -660,7 +660,7 @@ def simplify_article(article_id):
 
     # Check if already simplified (check for user's specific level)
     existing_simplified = [
-        v for v in article.simplified_versions if v.cefr_level == user_level
+        v for v in article.usable_simplified_versions if v.cefr_level == user_level
     ]
     if existing_simplified:
         # Tapping Simplify expresses interest in keeping this article — save it
@@ -677,7 +677,7 @@ def simplify_article(article_id):
             {"id": article.id, "cefr_level": original_cefr, "is_original": True}
         )
         # Add simplified versions
-        for v in article.simplified_versions:
+        for v in article.usable_simplified_versions:
             all_levels.append(
                 {"id": v.id, "cefr_level": v.cefr_level, "is_original": False}
             )
@@ -710,7 +710,7 @@ def simplify_article(article_id):
                 {"id": article.id, "cefr_level": original_cefr, "is_original": True}
             )
             # Add all simplified versions (including the new one)
-            for v in article.simplified_versions:
+            for v in article.usable_simplified_versions:
                 all_levels.append(
                     {"id": v.id, "cefr_level": v.cefr_level, "is_original": False}
                 )

--- a/zeeguu/api/endpoints/article_simplification.py
+++ b/zeeguu/api/endpoints/article_simplification.py
@@ -88,7 +88,7 @@ def article_simplification_levels():
     )
 
     # Add all simplified versions
-    for simplified in original_article.usable_simplified_versions:
+    for simplified in original_article.available_simplified_versions:
         levels.append(
             {
                 "id": simplified.id,

--- a/zeeguu/api/endpoints/article_simplification.py
+++ b/zeeguu/api/endpoints/article_simplification.py
@@ -88,7 +88,7 @@ def article_simplification_levels():
     )
 
     # Add all simplified versions
-    for simplified in original_article.simplified_versions:
+    for simplified in original_article.usable_simplified_versions:
         levels.append(
             {
                 "id": simplified.id,

--- a/zeeguu/api/endpoints/generated_examples.py
+++ b/zeeguu/api/endpoints/generated_examples.py
@@ -547,8 +547,8 @@ def generate_examples_for_word(word, from_lang, to_lang):
         examples = llm_service.generate_examples(
             word=word,
             translation=translation,
-            source_lang=origin_lang,
-            target_lang=translation_lang,
+            source_lang=origin_lang.code,
+            target_lang=translation_lang.code,
             cefr_level=cefr_level,
             prompt_version="v3",
             count=MAX_EXAMPLES_GENERATE,

--- a/zeeguu/core/audio_lessons/script_generator.py
+++ b/zeeguu/core/audio_lessons/script_generator.py
@@ -3,12 +3,22 @@ Script generator for audio lessons using unified LLM service.
 """
 
 import os
+from zeeguu.core.audio_lessons.script_language_validator import (
+    describe_mismatches,
+    find_language_mismatches,
+    log_mismatches,
+)
 from zeeguu.core.llm_services import generate_audio_lesson_script
 from zeeguu.core.model.language import Language
 from zeeguu.logging import log
 
 THREE_WORDS_LESSON = "three_words_lesson"
 VALID_LESSON_TYPES = (THREE_WORDS_LESSON, "topic", "situation")
+
+# How many times we ask for the script before giving up. The LLM ignoring the
+# "Teacher speaks X, Man/Woman speak Y" instruction is rare but not rare enough:
+# a lesson in the wrong language is worse than no lesson, so we retry and then fail.
+LANGUAGE_ATTEMPTS = 3
 
 
 # Load the prompt template
@@ -19,6 +29,54 @@ def get_prompt_template(file_name) -> str:
 
     with open(prompt_file, "r", encoding="utf-8") as f:
         return f.read()
+
+
+def _correction_note(mismatches, target_lang_name, source_lang_name) -> str:
+    return (
+        "\n\nYour previous attempt used the wrong language: "
+        f"{describe_mismatches(mismatches)}.\n"
+        f"Write it again. The Man, Woman and TeacherL2 lines MUST be in {target_lang_name}. "
+        f"The Teacher lines MUST be in {source_lang_name}. Translate — do not leave any line "
+        "in the language of the previous attempt."
+    )
+
+
+def generate_script_in_languages(
+    prompt: str,
+    target_language: str,
+    source_language: str,
+    context: str,
+    max_tokens: int = None,
+) -> str:
+    """
+    Generate a lesson script and verify it came back in the languages we asked for.
+
+    Retries with an explicit correction when the detected language is wrong, and
+    raises if the LLM keeps getting it wrong.
+    """
+    kwargs = {"max_tokens": max_tokens} if max_tokens else {}
+    target_lang_name = Language.LANGUAGE_NAMES.get(target_language, target_language)
+    source_lang_name = Language.LANGUAGE_NAMES.get(source_language, source_language)
+
+    attempt_prompt = prompt
+    mismatches = []
+
+    for attempt in range(1, LANGUAGE_ATTEMPTS + 1):
+        script = generate_audio_lesson_script(attempt_prompt, **kwargs)
+
+        mismatches = find_language_mismatches(script, target_language, source_language)
+        if not mismatches:
+            return script
+
+        log_mismatches(f"{context} (attempt {attempt}/{LANGUAGE_ATTEMPTS})", mismatches)
+        attempt_prompt = prompt + _correction_note(
+            mismatches, target_lang_name, source_lang_name
+        )
+
+    raise Exception(
+        f"Script for {context} came back in the wrong language "
+        f"{LANGUAGE_ATTEMPTS} times: {describe_mismatches(mismatches)}"
+    )
 
 
 def generate_lesson_script(
@@ -49,7 +107,12 @@ def generate_lesson_script(
 
     try:
         # Use unified LLM service with automatic Anthropic -> DeepSeek fallback
-        script = generate_audio_lesson_script(prompt)
+        script = generate_script_in_languages(
+            prompt,
+            target_language=origin_language,
+            source_language=translation_language,
+            context=f"meaning lesson '{origin_word}'",
+        )
         log(f"Successfully generated script for {origin_word}")
         return script
 
@@ -95,7 +158,13 @@ def generate_dialogue_script(
     log(f"Generating dialogue script (suggestion: {suggestion}, type: {lesson_type})")
 
     try:
-        raw = generate_audio_lesson_script(prompt, max_tokens=8000)
+        raw = generate_script_in_languages(
+            prompt,
+            target_language=origin_language,
+            source_language=translation_language,
+            context=f"dialogue lesson '{suggestion}'",
+            max_tokens=8000,
+        )
 
         # Parse title from first line
         title = None

--- a/zeeguu/core/audio_lessons/script_generator.py
+++ b/zeeguu/core/audio_lessons/script_generator.py
@@ -3,11 +3,8 @@ Script generator for audio lessons using unified LLM service.
 """
 
 import os
-from zeeguu.core.audio_lessons.script_language_validator import (
-    describe_mismatches,
-    find_language_mismatches,
-    log_mismatches,
-)
+from zeeguu.core.audio_lessons.script_language_validator import find_language_mismatches
+from zeeguu.core.language.language_check import describe_mismatches, log_mismatches
 from zeeguu.core.llm_services import generate_audio_lesson_script
 from zeeguu.core.model.language import Language
 from zeeguu.logging import log

--- a/zeeguu/core/audio_lessons/script_language_validator.py
+++ b/zeeguu/core/audio_lessons/script_language_validator.py
@@ -1,157 +1,63 @@
 """
-Verifies that a generated audio-lesson script is actually in the languages we asked for.
+Verifies that a generated audio-lesson script is actually in the languages we
+asked for.
 
 LLMs occasionally ignore the "Teacher speaks X, Man/Woman speak Y" instruction and
 emit the whole script in one language — most visibly, a "Danish" lesson where the
 dialogue is in English. The script is expensive to turn into audio and lands directly
 in a user's daily lesson, so we check it before synthesis rather than after.
+
+The detection itself lives in ``zeeguu.core.language.language_check``, which every
+LLM call site that must produce a foreign language shares. What is specific to a
+lesson script — and all that's left here — is knowing which voice speaks which
+language.
+
+Only the target-language voices are checked. The Teacher's lines look checkable
+but are bilingual by design: every challenge is a native-language lead-in
+followed by the exact target sentence the listener must produce
+("Скажіть, the news says it will rain tomorrow"). When the learned language is
+the more prominent of the two — an English course with a Ukrainian-speaking
+teacher — the target sentences outweigh the lead-ins and the teacher's lines read
+as the target language. Checked against production, that rule fired three times
+and was wrong all three; it would have blocked lesson generation for every
+English learner with a non-English native language. The failure it was meant to
+catch (a teacher lecturing entirely in the language being taught) has never been
+observed. Man/Woman/TeacherL2 lines carry no such ambiguity — they are pure
+target language — and they caught every real failure we have.
 """
 
-from collections import namedtuple
-
-from langdetect import detect_langs
-from langdetect.detector_factory import DetectorFactory
-from langdetect.lang_detect_exception import LangDetectException
-
 from zeeguu.core.audio_lessons.script_parser import parse_script
-from zeeguu.logging import log
+from zeeguu.core.language.language_check import check_passage
 
-# langdetect samples internally; without a fixed seed the same script can pass on one
-# call and fail on the next.
-DetectorFactory.seed = 0
-
-# Which voices are expected to speak which language.
-SOURCE_LANGUAGE_VOICES = {"teacher"}
+# Voices that speak the language being learned. "Teacher" is deliberately absent —
+# see the module docstring.
 TARGET_LANGUAGE_VOICES = {"teacherl2", "man", "woman", "armin", "aldo"}
 
-# Zeeguu language codes that langdetect spells differently.
-_ZEEGUU_TO_LANGDETECT = {
-    "zh-CN": "zh-cn",
-    "ind": "id",
-}
-
-# langdetect ships a profile per language; anything outside this set can't be checked.
-# (Notably Zeeguu supports Kurdish and Serbian as native languages; langdetect doesn't.)
-LANGDETECT_SUPPORTED = {
-    "af", "ar", "bg", "bn", "ca", "cs", "cy", "da", "de", "el", "en", "es", "et",
-    "fa", "fi", "fr", "gu", "he", "hi", "hr", "hu", "id", "it", "ja", "kn", "ko",
-    "lt", "lv", "mk", "ml", "mr", "ne", "nl", "no", "pa", "pl", "pt", "ro", "ru",
-    "sk", "sl", "so", "sq", "sv", "sw", "ta", "te", "th", "tl", "tr", "uk", "ur",
-    "vi", "zh-cn", "zh-tw",
-}
-
-# Languages langdetect routinely mixes up with each other. Short, simple sentences —
-# exactly what an A1/A2 lesson is made of — make this worse. We accept any member of
-# the family as evidence for the expected language: the failure we're guarding against
-# is "the Danish dialogue came out in English", not "Danish scored as Norwegian".
-_CONFUSABLE_FAMILIES = [
-    {"da", "no", "sv"},
-    {"hr", "sl", "mk", "bg"},
-    {"es", "ca", "pt"},
-    {"cs", "sk"},
-    {"id", "tl"},
-    {"hi", "mr", "ne"},
-]
-
-# Below this, the joined text is too short for langdetect to say anything meaningful.
-MIN_CHARS_FOR_DETECTION = 60
-
-# Combined probability the expected language (plus its confusables) must reach.
-MIN_EXPECTED_PROBABILITY = 0.5
-
-LanguageMismatch = namedtuple(
-    "LanguageMismatch", ["voices", "expected", "detected", "expected_probability", "sample"]
-)
+TARGET_LABEL = "Man/Woman/TeacherL2"
 
 
-def _langdetect_code(zeeguu_code: str) -> str:
-    return _ZEEGUU_TO_LANGDETECT.get(zeeguu_code, zeeguu_code.lower())
-
-
-def _accepted_codes(code: str) -> set:
-    """The expected code plus the languages langdetect tends to confuse it with."""
-    for family in _CONFUSABLE_FAMILIES:
-        if code in family:
-            return set(family)
-    return {code}
-
-
-def _probabilities(text: str) -> dict:
-    try:
-        return {result.lang: result.prob for result in detect_langs(text)}
-    except LangDetectException:
-        return {}
-
-
-def _check_group(voices, texts, expected_zeeguu_code):
-    """Return a LanguageMismatch if this group of lines isn't in the expected language."""
-    expected = _langdetect_code(expected_zeeguu_code)
-    if expected not in LANGDETECT_SUPPORTED:
-        return None
-
-    text = " ".join(texts).strip()
-    if len(text) < MIN_CHARS_FOR_DETECTION:
-        return None
-
-    probabilities = _probabilities(text)
-    if not probabilities:
-        return None
-
-    accepted = _accepted_codes(expected)
-    expected_probability = sum(p for code, p in probabilities.items() if code in accepted)
-    if expected_probability >= MIN_EXPECTED_PROBABILITY:
-        return None
-
-    detected = max(probabilities, key=probabilities.get)
-    return LanguageMismatch(
-        voices=voices,
-        expected=expected,
-        detected=detected,
-        expected_probability=expected_probability,
-        sample=text[:120],
-    )
-
-
-def find_language_mismatches(script: str, target_language: str, source_language: str) -> list:
+def find_language_mismatches(script: str, target_language: str, source_language=None) -> list:
     """
-    Check a lesson script against the languages it was supposed to be written in.
+    Check a lesson script against the language it was supposed to be written in.
 
     Args:
         script: the raw script, with "Teacher:" / "Man:" / ... voice labels
-        target_language: Zeeguu code of the language being learned (Man/Woman/TeacherL2)
-        source_language: Zeeguu code of the learner's native language (Teacher)
+        target_language: Zeeguu code of the language being learned
+        source_language: accepted and ignored — the teacher's lines are bilingual
+            by design and can't be judged. Kept so call sites read symmetrically.
 
     Returns:
-        A list of LanguageMismatch — empty when the script looks right.
+        A list of LanguageMismatch — empty when the script looks right, and also
+        empty when the script was too short or the language has no detector.
     """
-    target_texts = []
-    source_texts = []
-
-    for voice_type, text, _ in parse_script(script):
-        if voice_type in TARGET_LANGUAGE_VOICES:
-            target_texts.append(text)
-        elif voice_type in SOURCE_LANGUAGE_VOICES:
-            source_texts.append(text)
-
-    mismatches = [
-        _check_group("Man/Woman/TeacherL2", target_texts, target_language),
-        # When the learner's native language is the one being learned there is only
-        # one language in play, and the teacher check would just repeat the first.
-        _check_group("Teacher", source_texts, source_language)
-        if source_language != target_language
-        else None,
+    target_texts = [
+        text
+        for voice_type, text, _ in parse_script(script)
+        if voice_type in TARGET_LANGUAGE_VOICES
     ]
-    return [m for m in mismatches if m]
 
-
-def describe_mismatches(mismatches: list) -> str:
-    """One-line-per-mismatch summary, for logs and for telling the LLM what it got wrong."""
-    return "; ".join(
-        f"the {m.voices} lines should be in '{m.expected}' but read as '{m.detected}' "
-        f"(confidence in '{m.expected}': {m.expected_probability:.2f}) — e.g. \"{m.sample}\""
-        for m in mismatches
-    )
-
-
-def log_mismatches(context: str, mismatches: list) -> None:
-    log(f"[script_language_validator] {context}: {describe_mismatches(mismatches)}")
+    # Checked as a passage, not as one blob: scripts fail in halves. The lesson that
+    # started all this had an all-English opening dialogue followed by correct Danish
+    # practice phrases — 71% Danish overall, which a whole-text check waves through.
+    mismatch = check_passage(target_texts, target_language, TARGET_LABEL)
+    return [mismatch] if mismatch else []

--- a/zeeguu/core/audio_lessons/script_language_validator.py
+++ b/zeeguu/core/audio_lessons/script_language_validator.py
@@ -1,0 +1,157 @@
+"""
+Verifies that a generated audio-lesson script is actually in the languages we asked for.
+
+LLMs occasionally ignore the "Teacher speaks X, Man/Woman speak Y" instruction and
+emit the whole script in one language — most visibly, a "Danish" lesson where the
+dialogue is in English. The script is expensive to turn into audio and lands directly
+in a user's daily lesson, so we check it before synthesis rather than after.
+"""
+
+from collections import namedtuple
+
+from langdetect import detect_langs
+from langdetect.detector_factory import DetectorFactory
+from langdetect.lang_detect_exception import LangDetectException
+
+from zeeguu.core.audio_lessons.script_parser import parse_script
+from zeeguu.logging import log
+
+# langdetect samples internally; without a fixed seed the same script can pass on one
+# call and fail on the next.
+DetectorFactory.seed = 0
+
+# Which voices are expected to speak which language.
+SOURCE_LANGUAGE_VOICES = {"teacher"}
+TARGET_LANGUAGE_VOICES = {"teacherl2", "man", "woman", "armin", "aldo"}
+
+# Zeeguu language codes that langdetect spells differently.
+_ZEEGUU_TO_LANGDETECT = {
+    "zh-CN": "zh-cn",
+    "ind": "id",
+}
+
+# langdetect ships a profile per language; anything outside this set can't be checked.
+# (Notably Zeeguu supports Kurdish and Serbian as native languages; langdetect doesn't.)
+LANGDETECT_SUPPORTED = {
+    "af", "ar", "bg", "bn", "ca", "cs", "cy", "da", "de", "el", "en", "es", "et",
+    "fa", "fi", "fr", "gu", "he", "hi", "hr", "hu", "id", "it", "ja", "kn", "ko",
+    "lt", "lv", "mk", "ml", "mr", "ne", "nl", "no", "pa", "pl", "pt", "ro", "ru",
+    "sk", "sl", "so", "sq", "sv", "sw", "ta", "te", "th", "tl", "tr", "uk", "ur",
+    "vi", "zh-cn", "zh-tw",
+}
+
+# Languages langdetect routinely mixes up with each other. Short, simple sentences —
+# exactly what an A1/A2 lesson is made of — make this worse. We accept any member of
+# the family as evidence for the expected language: the failure we're guarding against
+# is "the Danish dialogue came out in English", not "Danish scored as Norwegian".
+_CONFUSABLE_FAMILIES = [
+    {"da", "no", "sv"},
+    {"hr", "sl", "mk", "bg"},
+    {"es", "ca", "pt"},
+    {"cs", "sk"},
+    {"id", "tl"},
+    {"hi", "mr", "ne"},
+]
+
+# Below this, the joined text is too short for langdetect to say anything meaningful.
+MIN_CHARS_FOR_DETECTION = 60
+
+# Combined probability the expected language (plus its confusables) must reach.
+MIN_EXPECTED_PROBABILITY = 0.5
+
+LanguageMismatch = namedtuple(
+    "LanguageMismatch", ["voices", "expected", "detected", "expected_probability", "sample"]
+)
+
+
+def _langdetect_code(zeeguu_code: str) -> str:
+    return _ZEEGUU_TO_LANGDETECT.get(zeeguu_code, zeeguu_code.lower())
+
+
+def _accepted_codes(code: str) -> set:
+    """The expected code plus the languages langdetect tends to confuse it with."""
+    for family in _CONFUSABLE_FAMILIES:
+        if code in family:
+            return set(family)
+    return {code}
+
+
+def _probabilities(text: str) -> dict:
+    try:
+        return {result.lang: result.prob for result in detect_langs(text)}
+    except LangDetectException:
+        return {}
+
+
+def _check_group(voices, texts, expected_zeeguu_code):
+    """Return a LanguageMismatch if this group of lines isn't in the expected language."""
+    expected = _langdetect_code(expected_zeeguu_code)
+    if expected not in LANGDETECT_SUPPORTED:
+        return None
+
+    text = " ".join(texts).strip()
+    if len(text) < MIN_CHARS_FOR_DETECTION:
+        return None
+
+    probabilities = _probabilities(text)
+    if not probabilities:
+        return None
+
+    accepted = _accepted_codes(expected)
+    expected_probability = sum(p for code, p in probabilities.items() if code in accepted)
+    if expected_probability >= MIN_EXPECTED_PROBABILITY:
+        return None
+
+    detected = max(probabilities, key=probabilities.get)
+    return LanguageMismatch(
+        voices=voices,
+        expected=expected,
+        detected=detected,
+        expected_probability=expected_probability,
+        sample=text[:120],
+    )
+
+
+def find_language_mismatches(script: str, target_language: str, source_language: str) -> list:
+    """
+    Check a lesson script against the languages it was supposed to be written in.
+
+    Args:
+        script: the raw script, with "Teacher:" / "Man:" / ... voice labels
+        target_language: Zeeguu code of the language being learned (Man/Woman/TeacherL2)
+        source_language: Zeeguu code of the learner's native language (Teacher)
+
+    Returns:
+        A list of LanguageMismatch — empty when the script looks right.
+    """
+    target_texts = []
+    source_texts = []
+
+    for voice_type, text, _ in parse_script(script):
+        if voice_type in TARGET_LANGUAGE_VOICES:
+            target_texts.append(text)
+        elif voice_type in SOURCE_LANGUAGE_VOICES:
+            source_texts.append(text)
+
+    mismatches = [
+        _check_group("Man/Woman/TeacherL2", target_texts, target_language),
+        # When the learner's native language is the one being learned there is only
+        # one language in play, and the teacher check would just repeat the first.
+        _check_group("Teacher", source_texts, source_language)
+        if source_language != target_language
+        else None,
+    ]
+    return [m for m in mismatches if m]
+
+
+def describe_mismatches(mismatches: list) -> str:
+    """One-line-per-mismatch summary, for logs and for telling the LLM what it got wrong."""
+    return "; ".join(
+        f"the {m.voices} lines should be in '{m.expected}' but read as '{m.detected}' "
+        f"(confidence in '{m.expected}': {m.expected_probability:.2f}) — e.g. \"{m.sample}\""
+        for m in mismatches
+    )
+
+
+def log_mismatches(context: str, mismatches: list) -> None:
+    log(f"[script_language_validator] {context}: {describe_mismatches(mismatches)}")

--- a/zeeguu/core/audio_lessons/script_language_validator.py
+++ b/zeeguu/core/audio_lessons/script_language_validator.py
@@ -27,11 +27,11 @@ target language — and they caught every real failure we have.
 """
 
 from zeeguu.core.audio_lessons.script_parser import parse_script
-from zeeguu.core.language.language_check import check_passage
+from zeeguu.core.language.language_check import passage_mismatch
 
 # Voices that speak the language being learned. "Teacher" is deliberately absent —
 # see the module docstring.
-TARGET_LANGUAGE_VOICES = {"teacherl2", "man", "woman", "armin", "aldo"}
+TARGET_LANGUAGE_VOICES = {"teacherl2", "man", "woman"}
 
 TARGET_LABEL = "Man/Woman/TeacherL2"
 
@@ -59,5 +59,5 @@ def find_language_mismatches(script: str, target_language: str, source_language=
     # Checked as a passage, not as one blob: scripts fail in halves. The lesson that
     # started all this had an all-English opening dialogue followed by correct Danish
     # practice phrases — 71% Danish overall, which a whole-text check waves through.
-    mismatch = check_passage(target_texts, target_language, TARGET_LABEL)
+    mismatch = passage_mismatch(target_texts, target_language, TARGET_LABEL)
     return [mismatch] if mismatch else []

--- a/zeeguu/core/audio_lessons/script_parser.py
+++ b/zeeguu/core/audio_lessons/script_parser.py
@@ -10,7 +10,7 @@ from typing import List, Tuple
 
 from zeeguu.core.audio_lessons.voice_config import DEFAULT_SILENCE_SECONDS
 
-VOICE_LABELS = ("Teacher", "TeacherL2", "Man", "Woman", "Armin", "Aldo")
+VOICE_LABELS = ("Teacher", "TeacherL2", "Man", "Woman")
 
 _VOICE_LABEL_PATTERN = re.compile(
     r"^(" + "|".join(VOICE_LABELS) + r"):\s*", re.IGNORECASE

--- a/zeeguu/core/audio_lessons/script_parser.py
+++ b/zeeguu/core/audio_lessons/script_parser.py
@@ -1,0 +1,101 @@
+"""
+Parsing of audio-lesson scripts into voice segments.
+
+Kept separate from voice_synthesizer so that consumers which only need to read a
+script (e.g. the language validator) don't pull in Google TTS and pydub.
+"""
+
+import re
+from typing import List, Tuple
+
+from zeeguu.core.audio_lessons.voice_config import DEFAULT_SILENCE_SECONDS
+
+VOICE_LABELS = ("Teacher", "TeacherL2", "Man", "Woman", "Armin", "Aldo")
+
+_VOICE_LABEL_PATTERN = re.compile(
+    r"^(" + "|".join(VOICE_LABELS) + r"):\s*", re.IGNORECASE
+)
+_VOICE_LINE_PATTERN = re.compile(
+    r"^(" + "|".join(VOICE_LABELS) + r"):\s*(.+)$", re.IGNORECASE
+)
+
+
+def join_continuation_lines(script: str) -> str:
+    """
+    Join continuation lines back to their parent voice line.
+
+    Sometimes the LLM breaks a single voice instruction across multiple lines,
+    e.g.:
+        Teacher: In the following conversation...
+        Throughout the dialogue, you will hear the word [0.2 seconds]
+
+    This joins such continuation lines back to the previous voice line.
+    """
+    joined_lines = []
+
+    for line in script.split("\n"):
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        if _VOICE_LABEL_PATTERN.match(stripped):
+            joined_lines.append(stripped)
+        elif stripped.startswith("[") and re.search(
+            r"\[([0-9.]+)\s*seconds?", stripped, re.IGNORECASE
+        ):
+            # Standalone timing/silence marker
+            joined_lines.append(stripped)
+        elif joined_lines:
+            # Continuation line - append to previous line
+            joined_lines[-1] = joined_lines[-1] + " " + stripped
+        # else: orphan line before any voice line - skip it
+
+    return "\n".join(joined_lines)
+
+
+def parse_script(script: str) -> List[Tuple[str, str, float]]:
+    """
+    Parse the script into individual voice segments.
+
+    Returns:
+        List of tuples: (voice_type, text, silence_after)
+    """
+    # First, join any continuation lines back to their parent
+    script = join_continuation_lines(script)
+
+    segments = []
+
+    for line in script.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+
+        # Handle standalone silence/timing markers like [1 seconds], [1 second silence]
+        if line.startswith("["):
+            duration_match = re.search(
+                r"\[([0-9.]+)\s*seconds?\s*(?:silence)?\]", line, re.IGNORECASE
+            )
+            if duration_match:
+                duration = float(duration_match.group(1))
+                segments.append(("silence", "", duration))
+            continue
+
+        # Parse voice lines like "Teacher: Some text [2 seconds]"
+        voice_match = _VOICE_LINE_PATTERN.match(line)
+        if not voice_match:
+            continue
+
+        voice_type = voice_match.group(1).lower()
+        text = voice_match.group(2)
+
+        # Extract silence duration from the last [X seconds] marker
+        silence_duration = DEFAULT_SILENCE_SECONDS
+        silence_match = re.search(r"\[([0-9.]+)\s*seconds?\]", text)
+        if silence_match:
+            silence_duration = float(silence_match.group(1))
+        # Strip ALL timing annotations from the text
+        text = re.sub(r"\s*\[([0-9.]+)\s*seconds?\s*(?:silence)?\]", "", text)
+
+        segments.append((voice_type, text.strip(), silence_duration))
+
+    return segments

--- a/zeeguu/core/audio_lessons/voice_synthesizer.py
+++ b/zeeguu/core/audio_lessons/voice_synthesizer.py
@@ -4,7 +4,6 @@ Uses Azure for languages not well-supported by Google (e.g., Greek with male voi
 """
 
 import os
-import re
 import hashlib
 from typing import List, Tuple
 from google.cloud import texttospeech
@@ -15,10 +14,10 @@ from zeeguu.core.audio_lessons.voice_config import (
     get_voice_id,
     get_teacher_voice,
     normalize_language_code,
-    DEFAULT_SILENCE_SECONDS,
     VOICE_CONFIG,
 )
 from zeeguu.core.audio_lessons.azure_voice_synthesizer import AzureVoiceSynthesizer
+from zeeguu.core.audio_lessons.script_parser import parse_script
 from zeeguu.logging import log
 
 
@@ -55,86 +54,9 @@ class VoiceSynthesizer:
             self.azure_client = AzureVoiceSynthesizer()
         return self.azure_client
 
-    def _join_continuation_lines(self, script: str) -> str:
-        """
-        Join continuation lines back to their parent voice line.
-
-        Sometimes the LLM breaks a single voice instruction across multiple lines,
-        e.g.:
-            Teacher: In the following conversation...
-            Throughout the dialogue, you will hear the word [0.2 seconds]
-
-        This method joins such continuation lines back to the previous voice line.
-        """
-        lines = script.split("\n")
-        joined_lines = []
-        voice_pattern = re.compile(r"^(Teacher|TeacherL2|Man|Woman|Armin|Aldo):\s*", re.IGNORECASE)
-
-        for line in lines:
-            stripped = line.strip()
-            if not stripped:
-                continue
-
-            # Check if this line starts with a voice label
-            if voice_pattern.match(stripped):
-                joined_lines.append(stripped)
-            elif stripped.startswith("[") and re.search(r"\[([0-9.]+)\s*seconds?", stripped, re.IGNORECASE):
-                # Standalone timing/silence marker
-                joined_lines.append(stripped)
-            elif joined_lines:
-                # Continuation line - append to previous line
-                joined_lines[-1] = joined_lines[-1] + " " + stripped
-            # else: orphan line before any voice line - skip it
-
-        return "\n".join(joined_lines)
-
     def parse_script(self, script: str) -> List[Tuple[str, str, float]]:
-        """
-        Parse the script into individual voice segments.
-
-        Returns:
-            List of tuples: (voice_type, text, silence_after)
-        """
-        # First, join any continuation lines back to their parent
-        script = self._join_continuation_lines(script)
-
-        segments = []
-        lines = script.split("\n")
-
-        for line in lines:
-            line = line.strip()
-            if not line:
-                continue
-
-            # Handle standalone silence/timing markers like [1 seconds], [1 second silence]
-            if line.startswith("["):
-                duration_match = re.search(
-                    r"\[([0-9.]+)\s*seconds?\s*(?:silence)?\]", line, re.IGNORECASE
-                )
-                if duration_match:
-                    duration = float(duration_match.group(1))
-                    segments.append(("silence", "", duration))
-                continue
-
-            # Parse voice lines like "Teacher: Some text [2 seconds]"
-            voice_match = re.match(r"^(Teacher|TeacherL2|Man|Woman|Armin|Aldo):\s*(.+)$", line, re.IGNORECASE)
-            if not voice_match:
-                continue
-
-            voice_type = voice_match.group(1).lower()
-            text = voice_match.group(2)
-
-            # Extract silence duration from the last [X seconds] marker
-            silence_duration = DEFAULT_SILENCE_SECONDS
-            silence_match = re.search(r"\[([0-9.]+)\s*seconds?\]", text)
-            if silence_match:
-                silence_duration = float(silence_match.group(1))
-            # Strip ALL timing annotations from the text
-            text = re.sub(r"\s*\[([0-9.]+)\s*seconds?\s*(?:silence)?\]", "", text)
-
-            segments.append((voice_type, text.strip(), silence_duration))
-
-        return segments
+        """Parse the script into (voice_type, text, silence_after) segments."""
+        return parse_script(script)
 
     def get_voice_config(self, voice_type: str, language_code: str, teacher_language: str = None) -> dict:
         """Get the voice configuration for TTS.

--- a/zeeguu/core/audio_lessons/voice_synthesizer.py
+++ b/zeeguu/core/audio_lessons/voice_synthesizer.py
@@ -54,10 +54,6 @@ class VoiceSynthesizer:
             self.azure_client = AzureVoiceSynthesizer()
         return self.azure_client
 
-    def parse_script(self, script: str) -> List[Tuple[str, str, float]]:
-        """Parse the script into (voice_type, text, silence_after) segments."""
-        return parse_script(script)
-
     def get_voice_config(self, voice_type: str, language_code: str, teacher_language: str = None) -> dict:
         """Get the voice configuration for TTS.
         
@@ -170,7 +166,7 @@ class VoiceSynthesizer:
 
     def _synthesize_script_to_file(self, script, output_path, language_code, teacher_language_code, cefr_level=None, on_progress=None):
         """Shared logic: parse script, synthesize all segments, combine and export to output_path."""
-        segments = self.parse_script(script)
+        segments = parse_script(script)
         audio_segments = []
 
         speech_segments = [(v, t, s) for v, t, s in segments if v != "silence"]

--- a/zeeguu/core/elastic/indexing.py
+++ b/zeeguu/core/elastic/indexing.py
@@ -155,7 +155,7 @@ def document_from_article(article, session, current_doc=None):
         # This is an original article - collect its level + all simplified versions
         if article.cefr_level:
             available_cefr_levels.append(article.cefr_level)
-        for simplified in article.usable_simplified_versions:
+        for simplified in article.available_simplified_versions:
             if simplified.cefr_level:
                 available_cefr_levels.append(simplified.cefr_level)
     else:

--- a/zeeguu/core/elastic/indexing.py
+++ b/zeeguu/core/elastic/indexing.py
@@ -155,7 +155,7 @@ def document_from_article(article, session, current_doc=None):
         # This is an original article - collect its level + all simplified versions
         if article.cefr_level:
             available_cefr_levels.append(article.cefr_level)
-        for simplified in article.simplified_versions:
+        for simplified in article.usable_simplified_versions:
             if simplified.cefr_level:
                 available_cefr_levels.append(simplified.cefr_level)
     else:

--- a/zeeguu/core/language/generate_in_language.py
+++ b/zeeguu/core/language/generate_in_language.py
@@ -1,0 +1,93 @@
+"""
+Ask an LLM again when it answered in the wrong language.
+
+The detection lives next door in ``language_check``; this is what to do about it
+— re-prompt with the specific failure named, and give up after a bounded number
+of tries. It is the only part of the language machinery that knows an LLM is
+involved, which is why it is not in the detector.
+
+What to do when it gives up is the *call site's* policy, and it differs: drop the
+summary and keep the assessment, fail the whole simplification run, return None
+and let the caller cope. So this raises, carrying enough for any of those.
+"""
+
+from zeeguu.core.language.language_check import (
+    describe_mismatches,
+    field_mismatches,
+    log_mismatches,
+)
+from zeeguu.core.language.language_codes import language_name
+
+
+class LanguageMismatchError(Exception):
+    """
+    Raised by ``generate_in_language`` when the LLM keeps answering in the wrong
+    language.
+
+    Carries ``.mismatches`` (which fields were wrong) and ``.result`` (the last
+    thing generated), so callers whose policy is partial salvage — keep the
+    assessment and drop the summary, keep five levels and drop the sixth — can
+    act on it instead of losing everything.
+    """
+
+    def __init__(self, context, mismatches, result=None):
+        super().__init__(f"{context}: {describe_mismatches(mismatches)}")
+        self.context = context
+        self.mismatches = mismatches
+        self.result = result
+
+
+def correction_note(mismatches: list, expected_zeeguu_code: str) -> str:
+    """
+    The note appended to the prompt on a retry. Naming the specific fields that
+    came back wrong works far better than repeating the original instruction.
+    """
+    name = language_name(expected_zeeguu_code)
+    return (
+        "\n\nYour previous attempt used the wrong language: "
+        f"{describe_mismatches(mismatches)}.\n"
+        f"Write it again, entirely in {name}. Translate everything — do not leave "
+        "any part in the language of the previous attempt."
+    )
+
+
+def generate_in_language(generate, expected_language, fields_of, context, attempts=2):
+    """
+    Call `generate` until what it produces is in `expected_language`.
+
+    Args:
+        generate: called as ``generate(correction)``. `correction` is "" on the
+            first attempt and, after a mismatch, a note naming exactly what came
+            back wrong — the caller appends it to its prompt.
+        expected_language: Zeeguu language code, e.g. 'da'.
+        fields_of: ``result -> [(label, text), ...]`` — the parts worth checking.
+            One entry per independently droppable piece, so a caller returning a
+            dict of CEFR levels can lose one level and keep the others.
+        context: what is being generated, for logs and the raised error.
+        attempts: total generations, including the first. Default 2 = one retry.
+
+    Returns:
+        The first result that passes the check.
+
+    Raises:
+        LanguageMismatchError, carrying the mismatches and the last result. What
+        to do about it — drop a field, drop a level, return None, fail loudly —
+        is the call site's policy, deliberately not decided here.
+    """
+    correction = ""
+    result = None
+    mismatches = []
+
+    for attempt in range(1, attempts + 1):
+        result = generate(correction)
+        mismatches = field_mismatches(fields_of(result), expected_language)
+        if not mismatches:
+            return result
+        log_mismatches(f"{context} (attempt {attempt}/{attempts})", mismatches)
+        correction = correction_note(mismatches, expected_language)
+
+    raise LanguageMismatchError(
+        f"{context} came back in the wrong language {attempts} times",
+        mismatches,
+        result,
+    )

--- a/zeeguu/core/language/language_check.py
+++ b/zeeguu/core/language/language_check.py
@@ -32,6 +32,7 @@ from langdetect import detect_langs
 from langdetect.detector_factory import DetectorFactory
 from langdetect.lang_detect_exception import LangDetectException
 
+from zeeguu.core.language.language_codes import language_name
 from zeeguu.logging import log
 
 # langdetect samples internally; without a fixed seed the same text can pass on
@@ -98,38 +99,6 @@ class LanguageMismatchError(Exception):
         self.result = result
 
 
-def language_code_of(language) -> str:
-    """
-    Best-effort Zeeguu code for whatever the call site has at hand: a Language
-    object, a code ('da'), or a language name ('Danish') — the LLM services are
-    inconsistent about which of the three they pass around.
-    """
-    code = getattr(language, "code", language)
-    if not isinstance(code, str):
-        return ""
-    return _NAME_TO_CODE().get(code.strip().lower(), code.strip())
-
-
-_name_to_code_cache = None
-
-
-def _NAME_TO_CODE() -> dict:
-    """Lowercased language name -> Zeeguu code, from the Language model."""
-    global _name_to_code_cache
-    if _name_to_code_cache is None:
-        try:
-            # Imported lazily: this module is a leaf that the LLM services and the
-            # audio lessons both depend on, and must not pull in the ORM to load.
-            from zeeguu.core.model.language import Language
-
-            _name_to_code_cache = {
-                name.lower(): code for code, name in Language.LANGUAGE_NAMES.items()
-            }
-        except Exception:
-            _name_to_code_cache = {}
-    return _name_to_code_cache
-
-
 def _langdetect_code(zeeguu_code: str) -> str:
     return _ZEEGUU_TO_LANGDETECT.get(zeeguu_code, zeeguu_code.lower())
 
@@ -164,7 +133,7 @@ def language_mismatch(text, expected_zeeguu_code, label="text"):
     None also means "can't judge": empty or short text, or a language langdetect
     has no profile for. Callers must not read None as proof the text is right.
     """
-    expected = _langdetect_code(language_code_of(expected_zeeguu_code))
+    expected = _langdetect_code(expected_zeeguu_code)
     if expected not in LANGDETECT_SUPPORTED:
         return None
 
@@ -290,22 +259,12 @@ def log_mismatches(context: str, mismatches: list) -> None:
     log(f"[language_check] {context}: {describe_mismatches(mismatches)}")
 
 
-def language_name(zeeguu_code: str) -> str:
-    """'da' -> 'Danish', for prompts. Falls back to the code itself."""
-    try:
-        from zeeguu.core.model.language import Language
-
-        return Language.LANGUAGE_NAMES.get(zeeguu_code, zeeguu_code)
-    except Exception:
-        return zeeguu_code
-
-
 def correction_note(mismatches: list, expected_zeeguu_code: str) -> str:
     """
     The note appended to the prompt on a retry. Naming the specific fields that
     came back wrong works far better than repeating the original instruction.
     """
-    name = language_name(language_code_of(expected_zeeguu_code))
+    name = language_name(expected_zeeguu_code)
     return (
         "\n\nYour previous attempt used the wrong language: "
         f"{describe_mismatches(mismatches)}.\n"
@@ -322,7 +281,7 @@ def generate_in_language(generate, expected_language, fields_of, context, attemp
         generate: called as ``generate(correction)``. `correction` is "" on the
             first attempt and, after a mismatch, a note naming exactly what came
             back wrong — the caller appends it to its prompt.
-        expected_language: Zeeguu code (or Language, or language name).
+        expected_language: Zeeguu language code, e.g. 'da'.
         fields_of: ``result -> [(label, text), ...]`` — the parts worth checking.
             One entry per independently droppable piece, so a caller returning a
             dict of CEFR levels can lose one level and keep the others.
@@ -337,18 +296,17 @@ def generate_in_language(generate, expected_language, fields_of, context, attemp
         to do about it — drop a field, drop a level, return None, fail loudly —
         is the call site's policy, deliberately not decided here.
     """
-    expected = language_code_of(expected_language)
     correction = ""
     result = None
     mismatches = []
 
     for attempt in range(1, attempts + 1):
         result = generate(correction)
-        mismatches = field_mismatches(fields_of(result), expected)
+        mismatches = field_mismatches(fields_of(result), expected_language)
         if not mismatches:
             return result
         log_mismatches(f"{context} (attempt {attempt}/{attempts})", mismatches)
-        correction = correction_note(mismatches, expected)
+        correction = correction_note(mismatches, expected_language)
 
     raise LanguageMismatchError(
         f"{context} came back in the wrong language {attempts} times",

--- a/zeeguu/core/language/language_check.py
+++ b/zeeguu/core/language/language_check.py
@@ -1,0 +1,357 @@
+"""
+Verifies that text an LLM produced is actually in the language we asked for.
+
+Every one of these failures is silent by construction: the pipeline succeeds, the
+row is written, and it is usually cached and reused. An audio lesson comes back
+entirely in English, a "Danish" summary reads as English, a translation is never
+translated. Asking harder in the prompt lowers the rate; only checking the output
+finds the residue.
+
+Three things here were calibrated against real lessons and articles, and are the
+reason this is a shared module rather than a one-line ``detect(text) == code``:
+
+- **A fixed detector seed.** langdetect samples internally; without it the same
+  text passes on one call and fails on the next.
+- **Confusable families.** langdetect routinely reads short Danish as Norwegian.
+  The failure worth catching is a whole text in the wrong language, not a
+  marginal misread, so any member of a family counts as evidence for the others.
+- **"Can't judge" is a distinct answer from "wrong."** Under ~60 characters there
+  isn't enough signal, and some languages Zeeguu offers (Kurdish, Serbian) have
+  no langdetect profile at all. Neither may block.
+
+Detection is shared; *policy* is not. What to do about a mismatch — retry, drop
+the field, drop one level and keep the rest, discard the correction — differs per
+call site, so this module only ever reports and (in ``generate_in_language``)
+re-prompts. See docs/future-work/llm-output-language-verification.md.
+"""
+
+import re
+from collections import namedtuple
+
+from langdetect import detect_langs
+from langdetect.detector_factory import DetectorFactory
+from langdetect.lang_detect_exception import LangDetectException
+
+from zeeguu.logging import log
+
+# langdetect samples internally; without a fixed seed the same text can pass on
+# one call and fail on the next.
+DetectorFactory.seed = 0
+
+# Zeeguu language codes that langdetect spells differently.
+_ZEEGUU_TO_LANGDETECT = {
+    "zh-CN": "zh-cn",
+    "ind": "id",
+}
+
+# langdetect ships a profile per language; anything outside this set can't be checked.
+# (Notably Zeeguu supports Kurdish and Serbian as native languages; langdetect doesn't.)
+LANGDETECT_SUPPORTED = {
+    "af", "ar", "bg", "bn", "ca", "cs", "cy", "da", "de", "el", "en", "es", "et",
+    "fa", "fi", "fr", "gu", "he", "hi", "hr", "hu", "id", "it", "ja", "kn", "ko",
+    "lt", "lv", "mk", "ml", "mr", "ne", "nl", "no", "pa", "pl", "pt", "ro", "ru",
+    "sk", "sl", "so", "sq", "sv", "sw", "ta", "te", "th", "tl", "tr", "uk", "ur",
+    "vi", "zh-cn", "zh-tw",
+}
+
+# Languages langdetect routinely mixes up with each other. Short, simple sentences —
+# exactly what an A1/A2 text is made of — make this worse. We accept any member of
+# the family as evidence for the expected language: the failure we're guarding
+# against is "the Danish text came out in English", not "Danish scored as Norwegian".
+_CONFUSABLE_FAMILIES = [
+    {"da", "no", "sv"},
+    {"hr", "sl", "mk", "bg"},
+    {"es", "ca", "pt"},
+    {"cs", "sk"},
+    {"id", "tl"},
+    {"hi", "mr", "ne"},
+]
+
+# Below this, the text is too short for langdetect to say anything meaningful.
+# Titles and single-word translations sit under it and will always be "can't judge".
+MIN_CHARS_FOR_DETECTION = 60
+
+# Combined probability the expected language (plus its confusables) must reach.
+MIN_EXPECTED_PROBABILITY = 0.5
+
+LanguageMismatch = namedtuple(
+    "LanguageMismatch",
+    ["label", "expected", "detected", "expected_probability", "sample"],
+)
+
+
+class LanguageMismatchError(Exception):
+    """
+    Raised by ``generate_in_language`` when the LLM keeps answering in the wrong
+    language.
+
+    Carries ``.mismatches`` (which fields were wrong) and ``.result`` (the last
+    thing generated), so callers whose policy is partial salvage — keep the
+    assessment and drop the summary, keep five levels and drop the sixth — can
+    act on it instead of losing everything.
+    """
+
+    def __init__(self, context, mismatches, result=None):
+        super().__init__(f"{context}: {describe_mismatches(mismatches)}")
+        self.context = context
+        self.mismatches = mismatches
+        self.result = result
+
+
+def language_code_of(language) -> str:
+    """
+    Best-effort Zeeguu code for whatever the call site has at hand: a Language
+    object, a code ('da'), or a language name ('Danish') — the LLM services are
+    inconsistent about which of the three they pass around.
+    """
+    code = getattr(language, "code", language)
+    if not isinstance(code, str):
+        return ""
+    return _NAME_TO_CODE().get(code.strip().lower(), code.strip())
+
+
+_name_to_code_cache = None
+
+
+def _NAME_TO_CODE() -> dict:
+    """Lowercased language name -> Zeeguu code, from the Language model."""
+    global _name_to_code_cache
+    if _name_to_code_cache is None:
+        try:
+            # Imported lazily: this module is a leaf that the LLM services and the
+            # audio lessons both depend on, and must not pull in the ORM to load.
+            from zeeguu.core.model.language import Language
+
+            _name_to_code_cache = {
+                name.lower(): code for code, name in Language.LANGUAGE_NAMES.items()
+            }
+        except Exception:
+            _name_to_code_cache = {}
+    return _name_to_code_cache
+
+
+def _langdetect_code(zeeguu_code: str) -> str:
+    return _ZEEGUU_TO_LANGDETECT.get(zeeguu_code, zeeguu_code.lower())
+
+
+def _accepted_codes(code: str) -> set:
+    """The expected code plus the languages langdetect tends to confuse it with."""
+    for family in _CONFUSABLE_FAMILIES:
+        if code in family:
+            return set(family)
+    return {code}
+
+
+def _probabilities(text: str) -> dict:
+    try:
+        return {result.lang: result.prob for result in detect_langs(text)}
+    except LangDetectException:
+        return {}
+
+
+_TAG = re.compile(r"<[^>]+>")
+
+
+def _detectable_text(text: str) -> str:
+    """Strip HTML tags and collapse whitespace — much of what we check is markup."""
+    return re.sub(r"\s+", " ", _TAG.sub(" ", text or "")).strip()
+
+
+def check_language(text, expected_zeeguu_code, label="text"):
+    """
+    Return a LanguageMismatch if `text` isn't in the expected language, else None.
+
+    None also means "can't judge": empty or short text, or a language langdetect
+    has no profile for. Callers must not read None as proof the text is right.
+    """
+    expected = _langdetect_code(language_code_of(expected_zeeguu_code))
+    if expected not in LANGDETECT_SUPPORTED:
+        return None
+
+    text = _detectable_text(text)
+    if len(text) < MIN_CHARS_FOR_DETECTION:
+        return None
+
+    probabilities = _probabilities(text)
+    if not probabilities:
+        return None
+
+    accepted = _accepted_codes(expected)
+    expected_probability = sum(p for code, p in probabilities.items() if code in accepted)
+    if expected_probability >= MIN_EXPECTED_PROBABILITY:
+        return None
+
+    return LanguageMismatch(
+        label=label,
+        expected=expected,
+        detected=max(probabilities, key=probabilities.get),
+        expected_probability=expected_probability,
+        sample=text[:120],
+    )
+
+
+# A contiguous run this long in the wrong language is a real failure, not a misread.
+PASSAGE_CHUNK_CHARS = 300
+
+# How much of a text may be in the wrong language before the whole thing is wrong.
+# A quoted foreign sentence inside an article is normal; half the dialogue is not.
+MAX_WRONG_SHARE = 0.25
+
+
+def _chunk(pieces, size=PASSAGE_CHUNK_CHARS) -> list:
+    """Group consecutive pieces into blocks of roughly `size` characters."""
+    chunks, current, length = [], [], 0
+    for piece in pieces:
+        piece = _detectable_text(piece)
+        if not piece:
+            continue
+        current.append(piece)
+        length += len(piece) + 1
+        if length >= size:
+            chunks.append(" ".join(current))
+            current, length = [], 0
+    if current:
+        tail = " ".join(current)
+        # Fold a short trailing block into the previous one rather than judge it alone.
+        if chunks and len(tail) < size // 2:
+            chunks[-1] += " " + tail
+        else:
+            chunks.append(tail)
+    return chunks
+
+
+def check_passage(pieces, expected_zeeguu_code, label="text"):
+    """
+    Check a long text made of many pieces (voice lines, paragraphs) for a
+    wrong-language *run*, and return a LanguageMismatch if one is big enough.
+
+    ``check_language`` judges a text as a single blob, which averages partial
+    failures away — the case this exists for: a Danish lesson whose opening
+    dialogue is entirely English but whose practice phrases are correctly Danish
+    scores 71% Danish overall and passes, while the learner hears two solid
+    minutes of English. Chunking finds the English half; the share threshold
+    keeps a single quoted foreign sentence from failing an otherwise good text.
+    """
+    chunks = _chunk(pieces)
+    if not chunks:
+        return None
+    if len(chunks) == 1:
+        return check_language(chunks[0], expected_zeeguu_code, label)
+
+    wrong = [
+        (chunk, mismatch)
+        for chunk, mismatch in (
+            (c, check_language(c, expected_zeeguu_code, label)) for c in chunks
+        )
+        if mismatch
+    ]
+    if not wrong:
+        return None
+
+    wrong_chars = sum(len(c) for c, _ in wrong)
+    share = wrong_chars / sum(len(c) for c in chunks)
+    if share < MAX_WRONG_SHARE:
+        return None
+
+    worst = min(wrong, key=lambda pair: pair[1].expected_probability)[1]
+    return worst._replace(label=f"{label} ({round(100 * share)}% of it)")
+
+
+def check_fields(fields, expected_zeeguu_code) -> list:
+    """
+    Check several labelled texts at once.
+
+    Args:
+        fields: [(label, text), ...] — one entry per thing a caller can drop
+            independently (a summary, a CEFR level, a group of voice lines).
+        expected_zeeguu_code: the language all of them should be in.
+
+    Returns:
+        A LanguageMismatch per wrong field; empty when everything looks right
+        (or couldn't be judged).
+    """
+    mismatches = [
+        check_language(text, expected_zeeguu_code, label) for label, text in fields
+    ]
+    return [m for m in mismatches if m]
+
+
+def describe_mismatches(mismatches: list) -> str:
+    """One clause per mismatch, for logs and for telling the LLM what it got wrong."""
+    return "; ".join(
+        f"{m.label}: expected '{m.expected}' but reads as '{m.detected}' "
+        f"(confidence in '{m.expected}': {m.expected_probability:.2f}) — "
+        f'e.g. "{m.sample}"'
+        for m in mismatches
+    )
+
+
+def log_mismatches(context: str, mismatches: list) -> None:
+    log(f"[language_check] {context}: {describe_mismatches(mismatches)}")
+
+
+def language_name(zeeguu_code: str) -> str:
+    """'da' -> 'Danish', for prompts. Falls back to the code itself."""
+    try:
+        from zeeguu.core.model.language import Language
+
+        return Language.LANGUAGE_NAMES.get(zeeguu_code, zeeguu_code)
+    except Exception:
+        return zeeguu_code
+
+
+def correction_note(mismatches: list, expected_zeeguu_code: str) -> str:
+    """
+    The note appended to the prompt on a retry. Naming the specific fields that
+    came back wrong works far better than repeating the original instruction.
+    """
+    name = language_name(language_code_of(expected_zeeguu_code))
+    return (
+        "\n\nYour previous attempt used the wrong language: "
+        f"{describe_mismatches(mismatches)}.\n"
+        f"Write it again, entirely in {name}. Translate everything — do not leave "
+        "any part in the language of the previous attempt."
+    )
+
+
+def generate_in_language(generate, expected_language, fields_of, context, attempts=2):
+    """
+    Call `generate` until what it produces is in `expected_language`.
+
+    Args:
+        generate: called as ``generate(correction)``. `correction` is "" on the
+            first attempt and, after a mismatch, a note naming exactly what came
+            back wrong — the caller appends it to its prompt.
+        expected_language: Zeeguu code (or Language, or language name).
+        fields_of: ``result -> [(label, text), ...]`` — the parts worth checking.
+            One entry per independently droppable piece, so a caller returning a
+            dict of CEFR levels can lose one level and keep the others.
+        context: what is being generated, for logs and the raised error.
+        attempts: total generations, including the first. Default 2 = one retry.
+
+    Returns:
+        The first result that passes the check.
+
+    Raises:
+        LanguageMismatchError, carrying the mismatches and the last result. What
+        to do about it — drop a field, drop a level, return None, fail loudly —
+        is the call site's policy, deliberately not decided here.
+    """
+    expected = language_code_of(expected_language)
+    correction = ""
+    result = None
+    mismatches = []
+
+    for attempt in range(1, attempts + 1):
+        result = generate(correction)
+        mismatches = check_fields(fields_of(result), expected)
+        if not mismatches:
+            return result
+        log_mismatches(f"{context} (attempt {attempt}/{attempts})", mismatches)
+        correction = correction_note(mismatches, expected)
+
+    raise LanguageMismatchError(
+        f"{context} came back in the wrong language {attempts} times",
+        mismatches,
+        result,
+    )

--- a/zeeguu/core/language/language_check.py
+++ b/zeeguu/core/language/language_check.py
@@ -19,10 +19,10 @@ reason this is a shared module rather than a one-line ``detect(text) == code``:
   isn't enough signal, and some languages Zeeguu offers (Kurdish, Serbian) have
   no langdetect profile at all. Neither may block.
 
-Detection is shared; *policy* is not. What to do about a mismatch — retry, drop
-the field, drop one level and keep the rest, discard the correction — differs per
-call site, so this module only ever reports and (in ``generate_in_language``)
-re-prompts. See docs/future-work/llm-output-language-verification.md.
+This module only ever *reports*. What to do about a mismatch — retry, drop the
+field, discard the correction — differs per call site, and the retrying itself
+lives in the sibling ``generate_in_language``. See
+docs/future-work/llm-output-language-verification.md.
 """
 
 import re
@@ -79,24 +79,6 @@ LanguageMismatch = namedtuple(
     "LanguageMismatch",
     ["label", "expected", "detected", "expected_probability", "sample"],
 )
-
-
-class LanguageMismatchError(Exception):
-    """
-    Raised by ``generate_in_language`` when the LLM keeps answering in the wrong
-    language.
-
-    Carries ``.mismatches`` (which fields were wrong) and ``.result`` (the last
-    thing generated), so callers whose policy is partial salvage — keep the
-    assessment and drop the summary, keep five levels and drop the sixth — can
-    act on it instead of losing everything.
-    """
-
-    def __init__(self, context, mismatches, result=None):
-        super().__init__(f"{context}: {describe_mismatches(mismatches)}")
-        self.context = context
-        self.mismatches = mismatches
-        self.result = result
 
 
 def _langdetect_code(zeeguu_code: str) -> str:
@@ -291,59 +273,3 @@ def describe_mismatches(mismatches: list) -> str:
 
 def log_mismatches(context: str, mismatches: list) -> None:
     log(f"[language_check] {context}: {describe_mismatches(mismatches)}")
-
-
-def correction_note(mismatches: list, expected_zeeguu_code: str) -> str:
-    """
-    The note appended to the prompt on a retry. Naming the specific fields that
-    came back wrong works far better than repeating the original instruction.
-    """
-    name = language_name(expected_zeeguu_code)
-    return (
-        "\n\nYour previous attempt used the wrong language: "
-        f"{describe_mismatches(mismatches)}.\n"
-        f"Write it again, entirely in {name}. Translate everything — do not leave "
-        "any part in the language of the previous attempt."
-    )
-
-
-def generate_in_language(generate, expected_language, fields_of, context, attempts=2):
-    """
-    Call `generate` until what it produces is in `expected_language`.
-
-    Args:
-        generate: called as ``generate(correction)``. `correction` is "" on the
-            first attempt and, after a mismatch, a note naming exactly what came
-            back wrong — the caller appends it to its prompt.
-        expected_language: Zeeguu language code, e.g. 'da'.
-        fields_of: ``result -> [(label, text), ...]`` — the parts worth checking.
-            One entry per independently droppable piece, so a caller returning a
-            dict of CEFR levels can lose one level and keep the others.
-        context: what is being generated, for logs and the raised error.
-        attempts: total generations, including the first. Default 2 = one retry.
-
-    Returns:
-        The first result that passes the check.
-
-    Raises:
-        LanguageMismatchError, carrying the mismatches and the last result. What
-        to do about it — drop a field, drop a level, return None, fail loudly —
-        is the call site's policy, deliberately not decided here.
-    """
-    correction = ""
-    result = None
-    mismatches = []
-
-    for attempt in range(1, attempts + 1):
-        result = generate(correction)
-        mismatches = field_mismatches(fields_of(result), expected_language)
-        if not mismatches:
-            return result
-        log_mismatches(f"{context} (attempt {attempt}/{attempts})", mismatches)
-        correction = correction_note(mismatches, expected_language)
-
-    raise LanguageMismatchError(
-        f"{context} came back in the wrong language {attempts} times",
-        mismatches,
-        result,
-    )

--- a/zeeguu/core/language/language_check.py
+++ b/zeeguu/core/language/language_check.py
@@ -191,15 +191,26 @@ def _chunk(pieces, size=PASSAGE_CHUNK_CHARS) -> list:
 
 def passage_mismatch(pieces, expected_zeeguu_code, label="text"):
     """
-    Check a long text made of many pieces (voice lines, paragraphs) for a
-    wrong-language *run*, and return a LanguageMismatch if one is big enough.
+    Check a stretch of text that is supposed to be in ONE language throughout,
+    handed over as the pieces it is made of, and return a LanguageMismatch when a
+    big enough run of it is not.
 
-    ``language_mismatch`` judges a text as a single blob, which averages partial
-    failures away — the case this exists for: a Danish lesson whose opening
-    dialogue is entirely English but whose practice phrases are correctly Danish
-    scores 71% Danish overall and passes, while the learner hears two solid
-    minutes of English. Chunking finds the English half; the share threshold
-    keeps a single quoted foreign sentence from failing an otherwise good text.
+    Its one caller is the audio-lesson validator, which passes the Man, Woman and
+    TeacherL2 lines in script order. What makes that sound is that the bilingual
+    voice is already gone: the Teacher's English intro and English challenges are
+    filtered out upstream, so everything arriving here is material that should be
+    target language from end to end.
+
+    It exists because ``language_mismatch`` judges a text as one blob and averages
+    partial failures away. A Danish lesson whose opening dialogue was entirely
+    English, but whose practice answers were correctly Danish, scored 71% Danish
+    overall — passed, and shipped. Chunking separates the English dialogue from
+    the Danish answers rather than averaging them, and the share threshold then
+    keeps one stray sentence from failing an otherwise good passage.
+
+    Not for article bodies: prose that legitimately quotes a long foreign
+    statement would trip that threshold, which is why the simplification call
+    sites check whole fields instead.
     """
     chunks = _chunk(pieces)
     if not chunks:

--- a/zeeguu/core/language/language_check.py
+++ b/zeeguu/core/language/language_check.py
@@ -118,7 +118,10 @@ def _probabilities(text: str) -> dict:
         return {}
 
 
-_TAG = re.compile(r"<[^>]+>")
+# Anchored to a letter after the bracket so this strips markup and not prose:
+# an unanchored <[^>]+> turns "Hvis 5 < 10 og 20 > 15" into "Hvis 5 15", quietly
+# deleting the evidence we are about to judge.
+_TAG = re.compile(r"</?[a-zA-Z][^>]*>")
 
 
 def _detectable_text(text: str) -> str:
@@ -133,6 +136,12 @@ def language_mismatch(text, expected_zeeguu_code, label="text"):
     None also means "can't judge": empty or short text, or a language langdetect
     has no profile for. Callers must not read None as proof the text is right.
     """
+    if not isinstance(expected_zeeguu_code, str) or not expected_zeeguu_code:
+        # No language to check against is a genuine "can't judge", but a silent
+        # one is how this whole class of bug hides — so it gets a line.
+        log(f"[language_check] nothing to check {label!r} against: {expected_zeeguu_code!r}")
+        return None
+
     expected = _langdetect_code(expected_zeeguu_code)
     if expected not in LANGDETECT_SUPPORTED:
         return None
@@ -217,6 +226,15 @@ def passage_mismatch(pieces, expected_zeeguu_code, label="text"):
     be loose enough to swallow both — which is why the simplification call sites
     check whole fields instead of passages.
     """
+    if isinstance(pieces, str):
+        # Iterating a string yields characters, and the chunks come out as
+        # "R e g e r i n g e n", which reads as Welsh. Loud beats plausible.
+        raise TypeError(
+            "passage_mismatch takes the pieces a passage is made of, not the "
+            "passage itself. Pass [text] for a single piece, or use "
+            "language_mismatch for text you already have as one string."
+        )
+
     chunks = _chunk(pieces)
     if not chunks:
         return None

--- a/zeeguu/core/language/language_check.py
+++ b/zeeguu/core/language/language_check.py
@@ -157,7 +157,7 @@ def _detectable_text(text: str) -> str:
     return re.sub(r"\s+", " ", _TAG.sub(" ", text or "")).strip()
 
 
-def check_language(text, expected_zeeguu_code, label="text"):
+def language_mismatch(text, expected_zeeguu_code, label="text"):
     """
     Return a LanguageMismatch if `text` isn't in the expected language, else None.
 
@@ -220,12 +220,12 @@ def _chunk(pieces, size=PASSAGE_CHUNK_CHARS) -> list:
     return chunks
 
 
-def check_passage(pieces, expected_zeeguu_code, label="text"):
+def passage_mismatch(pieces, expected_zeeguu_code, label="text"):
     """
     Check a long text made of many pieces (voice lines, paragraphs) for a
     wrong-language *run*, and return a LanguageMismatch if one is big enough.
 
-    ``check_language`` judges a text as a single blob, which averages partial
+    ``language_mismatch`` judges a text as a single blob, which averages partial
     failures away — the case this exists for: a Danish lesson whose opening
     dialogue is entirely English but whose practice phrases are correctly Danish
     scores 71% Danish overall and passes, while the learner hears two solid
@@ -236,12 +236,12 @@ def check_passage(pieces, expected_zeeguu_code, label="text"):
     if not chunks:
         return None
     if len(chunks) == 1:
-        return check_language(chunks[0], expected_zeeguu_code, label)
+        return language_mismatch(chunks[0], expected_zeeguu_code, label)
 
     wrong = [
         (chunk, mismatch)
         for chunk, mismatch in (
-            (c, check_language(c, expected_zeeguu_code, label)) for c in chunks
+            (c, language_mismatch(c, expected_zeeguu_code, label)) for c in chunks
         )
         if mismatch
     ]
@@ -257,7 +257,7 @@ def check_passage(pieces, expected_zeeguu_code, label="text"):
     return worst._replace(label=f"{label} ({round(100 * share)}% of it)")
 
 
-def check_fields(fields, expected_zeeguu_code) -> list:
+def field_mismatches(fields, expected_zeeguu_code) -> list:
     """
     Check several labelled texts at once.
 
@@ -271,7 +271,7 @@ def check_fields(fields, expected_zeeguu_code) -> list:
         (or couldn't be judged).
     """
     mismatches = [
-        check_language(text, expected_zeeguu_code, label) for label, text in fields
+        language_mismatch(text, expected_zeeguu_code, label) for label, text in fields
     ]
     return [m for m in mismatches if m]
 
@@ -344,7 +344,7 @@ def generate_in_language(generate, expected_language, fields_of, context, attemp
 
     for attempt in range(1, attempts + 1):
         result = generate(correction)
-        mismatches = check_fields(fields_of(result), expected)
+        mismatches = field_mismatches(fields_of(result), expected)
         if not mismatches:
             return result
         log_mismatches(f"{context} (attempt {attempt}/{attempts})", mismatches)

--- a/zeeguu/core/language/language_check.py
+++ b/zeeguu/core/language/language_check.py
@@ -162,9 +162,13 @@ def language_mismatch(text, expected_zeeguu_code, label="text"):
 # A contiguous run this long in the wrong language is a real failure, not a misread.
 PASSAGE_CHUNK_CHARS = 300
 
-# How much of a text may be in the wrong language before the whole thing is wrong.
-# A quoted foreign sentence inside an article is normal; half the dialogue is not.
-MAX_WRONG_SHARE = 0.25
+# How much of a passage may read as another language before we call the whole
+# thing wrong. There is nothing to calibrate here: the passage is one language by
+# contract, because the label carries the language — a line in the other language
+# would be a different label (TeacherL2, not Teacher). So this absorbs detector
+# error only, which in practice means stretches thick with proper names. Past a
+# tenth it is a real run of the wrong language, not a misread.
+MAX_WRONG_SHARE = 0.10
 
 
 def _chunk(pieces, size=PASSAGE_CHUNK_CHARS) -> list:
@@ -208,9 +212,10 @@ def passage_mismatch(pieces, expected_zeeguu_code, label="text"):
     the Danish answers rather than averaging them, and the share threshold then
     keeps one stray sentence from failing an otherwise good passage.
 
-    Not for article bodies: prose that legitimately quotes a long foreign
-    statement would trip that threshold, which is why the simplification call
-    sites check whole fields instead.
+    Not for article bodies. There the labels do not exist, so a quoted foreign
+    statement is indistinguishable from a defect and the threshold would have to
+    be loose enough to swallow both — which is why the simplification call sites
+    check whole fields instead of passages.
     """
     chunks = _chunk(pieces)
     if not chunks:

--- a/zeeguu/core/language/language_codes.py
+++ b/zeeguu/core/language/language_codes.py
@@ -1,0 +1,22 @@
+"""
+Zeeguu language codes, and the names that go with them.
+
+A leaf: everything that needs to turn a code into something a human (or an LLM)
+reads goes through here, without importing the ORM to load.
+"""
+
+
+def language_name(zeeguu_code: str) -> str:
+    """
+    'da' -> 'Danish'. Falls back to the code itself for anything unknown.
+
+    The names live on the Language model, which is imported lazily so that this
+    module stays usable from anywhere — including the modules the model itself
+    depends on.
+    """
+    try:
+        from zeeguu.core.model.language import Language
+
+        return Language.LANGUAGE_NAMES.get(zeeguu_code, zeeguu_code)
+    except Exception:
+        return zeeguu_code

--- a/zeeguu/core/llm_services/anthropic_service.py
+++ b/zeeguu/core/llm_services/anthropic_service.py
@@ -7,7 +7,8 @@ import json
 from typing import List, Dict, Optional
 
 from .llm_service import LLMService
-from .prompts import format_prompt, PROMPT_VERSION_V3
+from .prompts import example_sentence_fields, format_prompt, PROMPT_VERSION_V3
+from zeeguu.core.language.language_check import generate_in_language
 from zeeguu.core.llm_services import models
 from zeeguu.logging import log
 
@@ -48,14 +49,27 @@ class AnthropicService(LLMService):
             log(f"Anthropic API failed: {e}")
             raise e
 
-    def generate_examples(self, word: str, translation: str, source_lang: str, 
+    def generate_examples(self, word: str, translation: str, source_lang: str,
                          target_lang: str, cefr_level: str, prompt_version: str = PROMPT_VERSION_V3, count: int = 3) -> List[Dict]:
-        """Generate example sentences using Claude - fail fast to DeepSeek fallback"""
-        prompt = format_prompt(word, translation, source_lang, target_lang, cefr_level, prompt_version, count)
-        
-        # Try API request - fail fast
-        content = self._make_api_request(prompt)
-        
+        """
+        Generate example sentences using Claude - fail fast to DeepSeek fallback.
+
+        The sentences must be in the language being learned; examples in the
+        learner's own language teach nothing. Asked for once more when they come
+        back wrong, then allowed to fail into the DeepSeek fallback.
+        """
+        def generate(correction):
+            prompt = format_prompt(word, translation, source_lang, target_lang, cefr_level, prompt_version, count)
+            if correction:
+                prompt = {**prompt, "user": prompt["user"] + correction}
+            return self._parse_examples(self._make_api_request(prompt), cefr_level, prompt_version)
+
+        return generate_in_language(
+            generate, source_lang, example_sentence_fields, f"examples for '{word}'"
+        )
+
+    def _parse_examples(self, content: str, cefr_level: str, prompt_version: str) -> List[Dict]:
+        """Pull the examples out of one response, annotated with their provenance."""
         # Clean the content to extract JSON
         content = content.strip()
         
@@ -92,11 +106,18 @@ class AnthropicService(LLMService):
             log(f"Raw Anthropic response content: {content}")
             raise ValueError("Invalid response format from Anthropic")
     
-    def generate_text(self, prompt: str, max_tokens: int = 1000, temperature: float = 0.7) -> str:
-        """Generate text using Anthropic API - fail fast to DeepSeek fallback"""
+    def generate_text(self, prompt: str, max_tokens: int = 1000, temperature: float = 0.7,
+                      system: str = None) -> str:
+        """Generate text using Anthropic API - fail fast to DeepSeek fallback
+
+        `system` carries constraints that must hold for the whole response. The
+        provider docs single the system prompt out as the reliable place for an
+        output-language rule, and measured against DeepSeek it moved a
+        non-English-teacher script from 1/9 correct to 7/9.
+        """
         # Try Anthropic API - fail fast
         content = self._make_api_request(
-            {"system": "You are a helpful assistant.", "user": prompt},
+            {"system": system or "You are a helpful assistant.", "user": prompt},
             max_tokens=max_tokens,
             temperature=temperature,
         )

--- a/zeeguu/core/llm_services/anthropic_service.py
+++ b/zeeguu/core/llm_services/anthropic_service.py
@@ -54,6 +54,8 @@ class AnthropicService(LLMService):
         """
         Generate example sentences using Claude - fail fast to DeepSeek fallback.
 
+        `source_lang`/`target_lang` are Zeeguu codes, as every caller passes.
+
         The sentences must be in the language being learned; examples in the
         learner's own language teach nothing. Asked for once more when they come
         back wrong, then allowed to fail into the DeepSeek fallback.

--- a/zeeguu/core/llm_services/anthropic_service.py
+++ b/zeeguu/core/llm_services/anthropic_service.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Optional
 
 from .llm_service import LLMService
 from .prompts import example_sentence_fields, format_prompt, PROMPT_VERSION_V3
-from zeeguu.core.language.language_check import generate_in_language
+from zeeguu.core.language.generate_in_language import generate_in_language
 from zeeguu.core.llm_services import models
 from zeeguu.logging import log
 

--- a/zeeguu/core/llm_services/deepseek_service.py
+++ b/zeeguu/core/llm_services/deepseek_service.py
@@ -8,7 +8,8 @@ import requests
 from typing import List, Dict, Optional
 
 from .llm_service import LLMService
-from .prompts import format_prompt, PROMPT_VERSION_V3
+from .prompts import example_sentence_fields, format_prompt, PROMPT_VERSION_V3
+from zeeguu.core.language.language_check import generate_in_language
 from zeeguu.core.llm_services import models
 from zeeguu.logging import log
 
@@ -63,14 +64,26 @@ class DeepSeekService(LLMService):
         except requests.exceptions.RequestException as e:
             raise Exception(f"DeepSeek API request failed: {e}")
     
-    def generate_examples(self, word: str, translation: str, source_lang: str, 
+    def generate_examples(self, word: str, translation: str, source_lang: str,
                          target_lang: str, cefr_level: str, prompt_version: str = PROMPT_VERSION_V3, count: int = 3) -> List[Dict]:
-        """Generate example sentences using DeepSeek API"""
-        prompt = format_prompt(word, translation, source_lang, target_lang, cefr_level, prompt_version, count)
-        
-        # Make API request
-        content = self._make_deepseek_request(prompt)
-        
+        """
+        Generate example sentences using DeepSeek API.
+
+        Like the Anthropic path: the sentences must be in the language being
+        learned, so they are re-requested once and then allowed to fail.
+        """
+        def generate(correction):
+            prompt = format_prompt(word, translation, source_lang, target_lang, cefr_level, prompt_version, count)
+            if correction:
+                prompt = {**prompt, "user": prompt["user"] + correction}
+            return self._parse_examples(self._make_deepseek_request(prompt), cefr_level, prompt_version)
+
+        return generate_in_language(
+            generate, source_lang, example_sentence_fields, f"examples for '{word}'"
+        )
+
+    def _parse_examples(self, content: str, cefr_level: str, prompt_version: str) -> List[Dict]:
+        """Pull the examples out of one response, annotated with their provenance."""
         # Clean and parse the JSON response (same logic as Anthropic)
         content = content.strip()
         
@@ -108,11 +121,18 @@ class DeepSeekService(LLMService):
             log(f"Raw DeepSeek response content: {content}")
             raise ValueError("Invalid response format from DeepSeek")
     
-    def generate_text(self, prompt: str, max_tokens: int = 1000, temperature: float = 0.7) -> str:
-        """Generate text using DeepSeek API - fail fast"""
+    def generate_text(self, prompt: str, max_tokens: int = 1000, temperature: float = 0.7,
+                      system: str = None) -> str:
+        """Generate text using DeepSeek API - fail fast
+
+        `system` carries constraints that must hold for the whole response. The
+        provider docs single the system prompt out as the reliable place for an
+        output-language rule, and measured against DeepSeek it moved a
+        non-English-teacher script from 1/9 correct to 7/9.
+        """
         # Make API request
         return self._make_deepseek_request(
-            {"system": "You are a helpful assistant.", "user": prompt},
+            {"system": system or "You are a helpful assistant.", "user": prompt},
             max_tokens,
             temperature
         )

--- a/zeeguu/core/llm_services/deepseek_service.py
+++ b/zeeguu/core/llm_services/deepseek_service.py
@@ -69,6 +69,8 @@ class DeepSeekService(LLMService):
         """
         Generate example sentences using DeepSeek API.
 
+        `source_lang`/`target_lang` are Zeeguu codes, as every caller passes.
+
         Like the Anthropic path: the sentences must be in the language being
         learned, so they are re-requested once and then allowed to fail.
         """

--- a/zeeguu/core/llm_services/deepseek_service.py
+++ b/zeeguu/core/llm_services/deepseek_service.py
@@ -9,7 +9,7 @@ from typing import List, Dict, Optional
 
 from .llm_service import LLMService
 from .prompts import example_sentence_fields, format_prompt, PROMPT_VERSION_V3
-from zeeguu.core.language.language_check import generate_in_language
+from zeeguu.core.language.generate_in_language import generate_in_language
 from zeeguu.core.llm_services import models
 from zeeguu.logging import log
 

--- a/zeeguu/core/llm_services/grammar_correction_service.py
+++ b/zeeguu/core/llm_services/grammar_correction_service.py
@@ -10,6 +10,7 @@ import re
 import requests
 import time
 from zeeguu.logging import log
+from zeeguu.core.language.language_check import check_fields, describe_mismatches
 from .haiku_client import HAIKU_MODEL, haiku_completion_or_raise
 from .prompts.grammar_correction import get_full_article_correction_prompt
 from zeeguu.core.llm_services import models
@@ -38,6 +39,12 @@ class GrammarCorrectionService:
             language_code: Language code (e.g., 'da', 'es')
             provider: LLM provider to use ('anthropic' or 'deepseek')
 
+        A correction must come back in the language it went in as. If it doesn't,
+        we throw the correction away and keep the uncorrected text — the same
+        thing this service already does when the API call fails, and the right
+        trade: the corrections are cosmetic, a translated article is not. No
+        retry, for the same reason.
+
         Returns:
             Dict with corrected 'title', 'content', and 'summary'
         """
@@ -57,6 +64,17 @@ class GrammarCorrectionService:
 
         # Parse the response
         corrected = self._parse_correction_response(response_text, version_data)
+
+        mismatches = check_fields(
+            [(field, corrected.get(field, "")) for field in ("title", "summary", "content")],
+            language_code,
+        )
+        if mismatches:
+            log(
+                "Discarding grammar correction — it came back in another language: "
+                f"{describe_mismatches(mismatches)}"
+            )
+            return version_data
 
         return corrected
 

--- a/zeeguu/core/llm_services/grammar_correction_service.py
+++ b/zeeguu/core/llm_services/grammar_correction_service.py
@@ -10,7 +10,7 @@ import re
 import requests
 import time
 from zeeguu.logging import log
-from zeeguu.core.language.language_check import check_fields, describe_mismatches
+from zeeguu.core.language.language_check import field_mismatches, describe_mismatches
 from .haiku_client import HAIKU_MODEL, haiku_completion_or_raise
 from .prompts.grammar_correction import get_full_article_correction_prompt
 from zeeguu.core.llm_services import models
@@ -65,7 +65,7 @@ class GrammarCorrectionService:
         # Parse the response
         corrected = self._parse_correction_response(response_text, version_data)
 
-        mismatches = check_fields(
+        mismatches = field_mismatches(
             [(field, corrected.get(field, "")) for field in ("title", "summary", "content")],
             language_code,
         )

--- a/zeeguu/core/llm_services/mwe_translation_service.py
+++ b/zeeguu/core/llm_services/mwe_translation_service.py
@@ -22,24 +22,11 @@ import json
 import logging
 from typing import Optional
 
-from zeeguu.core.language.language_check import language_mismatch
 from zeeguu.core.llm_services import models
 
 logger = logging.getLogger(__name__)
 
 
-def _warn_if_wrong_language(translation, target_lang, what):
-    """
-    Report — don't act. A translation of a word or short phrase is almost always
-    under the length langdetect needs, so the check answers "can't judge" for
-    most of them; dropping a translation on that basis would cost more than the
-    rare wrong-language one it caught.
-    """
-    mismatch = language_mismatch(translation, target_lang, label=what)
-    if mismatch:
-        logger.warning(f"LLM translation in the wrong language: {mismatch}")
-
-# Language code to name mapping
 LANG_NAMES = {
     "de": "German", "da": "Danish", "nl": "Dutch", "sv": "Swedish", "no": "Norwegian",
     "el": "Greek", "it": "Italian", "es": "Spanish", "fr": "French", "ro": "Romanian",
@@ -125,7 +112,6 @@ def translate_word_in_context(
 
         translation = response.content[0].text.strip().strip('"\'.')
         logger.debug(f"LLM translated '{word}' -> '{translation}'")
-        _warn_if_wrong_language(translation, target_lang, f"translation of '{word}'")
         return translation or None
     except ImportError:
         logger.error("anthropic package not installed")
@@ -188,7 +174,6 @@ def translate_separated_mwe(
         translation = translation.strip('"\'.')
 
         logger.debug(f"Translated MWE '{mwe_text}' -> '{translation}'")
-        _warn_if_wrong_language(translation, target_lang, f"translation of '{mwe_text}'")
         return translation
 
     except ImportError:

--- a/zeeguu/core/llm_services/mwe_translation_service.py
+++ b/zeeguu/core/llm_services/mwe_translation_service.py
@@ -22,7 +22,7 @@ import json
 import logging
 from typing import Optional
 
-from zeeguu.core.language.language_check import check_language
+from zeeguu.core.language.language_check import language_mismatch
 from zeeguu.core.llm_services import models
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ def _warn_if_wrong_language(translation, target_lang, what):
     most of them; dropping a translation on that basis would cost more than the
     rare wrong-language one it caught.
     """
-    mismatch = check_language(translation, target_lang, label=what)
+    mismatch = language_mismatch(translation, target_lang, label=what)
     if mismatch:
         logger.warning(f"LLM translation in the wrong language: {mismatch}")
 

--- a/zeeguu/core/llm_services/mwe_translation_service.py
+++ b/zeeguu/core/llm_services/mwe_translation_service.py
@@ -22,9 +22,22 @@ import json
 import logging
 from typing import Optional
 
+from zeeguu.core.language.language_check import check_language
 from zeeguu.core.llm_services import models
 
 logger = logging.getLogger(__name__)
+
+
+def _warn_if_wrong_language(translation, target_lang, what):
+    """
+    Report — don't act. A translation of a word or short phrase is almost always
+    under the length langdetect needs, so the check answers "can't judge" for
+    most of them; dropping a translation on that basis would cost more than the
+    rare wrong-language one it caught.
+    """
+    mismatch = check_language(translation, target_lang, label=what)
+    if mismatch:
+        logger.warning(f"LLM translation in the wrong language: {mismatch}")
 
 # Language code to name mapping
 LANG_NAMES = {
@@ -112,6 +125,7 @@ def translate_word_in_context(
 
         translation = response.content[0].text.strip().strip('"\'.')
         logger.debug(f"LLM translated '{word}' -> '{translation}'")
+        _warn_if_wrong_language(translation, target_lang, f"translation of '{word}'")
         return translation or None
     except ImportError:
         logger.error("anthropic package not installed")
@@ -174,6 +188,7 @@ def translate_separated_mwe(
         translation = translation.strip('"\'.')
 
         logger.debug(f"Translated MWE '{mwe_text}' -> '{translation}'")
+        _warn_if_wrong_language(translation, target_lang, f"translation of '{mwe_text}'")
         return translation
 
     except ImportError:

--- a/zeeguu/core/llm_services/prompts/__init__.py
+++ b/zeeguu/core/llm_services/prompts/__init__.py
@@ -2,7 +2,11 @@
 Unified prompts module for all LLM-powered features in Zeeguu.
 """
 
-from .example_generation import format_prompt, PROMPT_VERSION_V3
+from .example_generation import (
+    example_sentence_fields,
+    format_prompt,
+    PROMPT_VERSION_V3,
+)
 from .meaning_frequency_classifier import (
     create_meaning_frequency_and_type_prompt,
     create_meaning_frequency_prompt,
@@ -10,6 +14,7 @@ from .meaning_frequency_classifier import (
 )
 
 __all__ = [
+    'example_sentence_fields',
     'format_prompt',
     'PROMPT_VERSION_V3',
     'create_meaning_frequency_and_type_prompt',

--- a/zeeguu/core/llm_services/prompts/example_generation.py
+++ b/zeeguu/core/llm_services/prompts/example_generation.py
@@ -132,6 +132,19 @@ Format your response as JSON:
     }
 }
 
+def example_sentence_fields(examples):
+    """
+    The generated sentences, as (label, text) pairs for the output-language check.
+
+    Joined into one field on purpose: a single example sentence is well under the
+    length langdetect needs, while three of them together are usually enough to
+    judge — and a whole batch coming back in the wrong language is the failure
+    worth catching.
+    """
+    sentences = " ".join(example.get("sentence", "") for example in examples)
+    return [("example sentences", sentences)]
+
+
 def get_prompt_template(version=PROMPT_VERSION_V3):
     """Get prompt template by version."""
     if version not in EXAMPLE_GENERATION_PROMPTS:

--- a/zeeguu/core/llm_services/simplification_and_classification.py
+++ b/zeeguu/core/llm_services/simplification_and_classification.py
@@ -13,6 +13,11 @@ import requests
 import time
 from requests.exceptions import Timeout, RequestException
 from zeeguu.logging import log
+from zeeguu.core.language.language_check import (
+    LanguageMismatchError,
+    describe_mismatches,
+    generate_in_language,
+)
 from zeeguu.core.model.article import Article
 from zeeguu.core.model.url import Url
 from .haiku_client import HAIKU_MODEL, haiku_completion_or_raise
@@ -132,6 +137,46 @@ def _strip_markdown_from_summary(text):
     return text
 
 
+# Labels for the language check on the summaries. They double as the keys we use
+# to drop exactly the summaries that came back in the wrong language.
+ORIGINAL_SUMMARY_LABEL = "original summary"
+
+
+def _level_summary_label(level: str) -> str:
+    return f"{level} summary"
+
+
+def _summary_fields(assessment: dict) -> list:
+    """The parts of an assessment that must be in the article's language."""
+    fields = [(ORIGINAL_SUMMARY_LABEL, assessment.get("original_summary", ""))]
+    fields += [
+        (_level_summary_label(level), text)
+        for level, text in assessment.get("level_summaries", {}).items()
+    ]
+    return fields
+
+
+def _without_wrong_language_summaries(assessment: dict, mismatches: list) -> dict:
+    """
+    Policy for a summary that stayed English: drop it, keep the assessment.
+
+    CEFR level, article type and the disturbing-content flag are language-
+    independent and still correct, and the crawl path only overwrites
+    ``article.summary`` when the summary is non-empty — so dropping one leaves
+    the feed blurb in place rather than an English summary on a Danish article.
+    """
+    wrong = {m.label for m in mismatches}
+    result = dict(assessment)
+    if ORIGINAL_SUMMARY_LABEL in wrong:
+        result["original_summary"] = ""
+    result["level_summaries"] = {
+        level: text
+        for level, text in result.get("level_summaries", {}).items()
+        if _level_summary_label(level) not in wrong
+    }
+    return result
+
+
 def assess_and_summarize(
     title: str,
     content: str,
@@ -157,6 +202,11 @@ def assess_and_summarize(
             'model_name': str,
         }
 
+    The summaries must be in the article's language; the LLM used to return
+    English for half of them and nothing errored. They are re-requested once with
+    the mismatch named, and dropped if they come back wrong again — the
+    assessment itself is language-independent and always kept.
+
     Raises:
         Exception: "PAYWALL: ..." or "ADVERTORIAL: ..." when the LLM flags the
         article, or on API failure.
@@ -167,15 +217,33 @@ def assess_and_summarize(
     provider, api_key = _select_provider_and_key(simplification_provider)
     log(f"Assessing+summarizing article '{title[:50]}...' in {target_language}")
 
-    # Assessment + one ~70-word summary PER level below the original (up to 5 for a
-    # C2 article) plus the original summary. 2000 gives headroom over the single-
-    # summary sizing so the last-emitted levels aren't truncated — still a fraction
-    # of the 6000 the full multi-level bodies needed.
-    result, model_name = _call_simplification_llm(
-        prompt, provider, api_key, max_tokens=2000, timeout=120
-    )
-    _raise_if_paywall_or_advertorial(result)
+    def generate(correction):
+        # Assessment + one ~70-word summary PER level below the original (up to 5
+        # for a C2 article) plus the original summary. 2000 gives headroom over the
+        # single-summary sizing so the last-emitted levels aren't truncated — still
+        # a fraction of the 6000 the full multi-level bodies needed.
+        result, model_name = _call_simplification_llm(
+            prompt + correction, provider, api_key, max_tokens=2000, timeout=120
+        )
+        _raise_if_paywall_or_advertorial(result)
+        return _parse_assessment_and_summary(result, provider, model_name)
 
+    try:
+        return generate_in_language(
+            generate,
+            target_language,
+            _summary_fields,
+            f"summary of '{title[:50]}'",
+        )
+    except LanguageMismatchError as e:
+        log(
+            f"  Dropping wrong-language summaries for '{title[:50]}': "
+            f"{describe_mismatches(e.mismatches)}"
+        )
+        return _without_wrong_language_summaries(e.result, e.mismatches)
+
+
+def _parse_assessment_and_summary(result: str, provider: str, model_name: str) -> dict:
     # Parse the small set of labelled fields, plus any per-level [LEVEL]_SUMMARY
     # sections (e.g. "A1_SUMMARY:", "B1_SUMMARY:").
     sections = {}
@@ -382,6 +450,213 @@ def get_target_levels_for_original_level(original_level: str) -> list[str]:
     return target_levels
 
 
+def _version_fields(simplification: dict) -> list:
+    """
+    The parts of a multi-level simplification that must be in the article's
+    language — one field per level, so a level that comes back English can be
+    dropped without taking the others with it.
+    """
+    fields = [(ORIGINAL_SUMMARY_LABEL, simplification.get("original_summary", ""))]
+    for level, version in simplification.get("versions", {}).items():
+        fields.append(
+            (
+                level,
+                " ".join(
+                    [
+                        version.get("title", ""),
+                        version.get("summary", ""),
+                        version.get("content", ""),
+                    ]
+                ),
+            )
+        )
+    return fields
+
+
+def _without_wrong_language_levels(simplification: dict, mismatches: list) -> dict:
+    """
+    Policy for a level that came back in the wrong language: drop that level and
+    keep the good ones. A run produces up to six levels and every caller already
+    tolerates a partial set, so one bad generation must not cost the other five.
+
+    Raises when nothing survives — same contract as "no complete versions".
+    """
+    wrong = {m.label for m in mismatches}
+    result = dict(simplification)
+    if ORIGINAL_SUMMARY_LABEL in wrong:
+        result["original_summary"] = ""
+    result["versions"] = {
+        level: version
+        for level, version in result.get("versions", {}).items()
+        if level not in wrong
+    }
+    result["simplified_levels"] = [
+        level for level in result.get("simplified_levels", []) if level not in wrong
+    ]
+    log(
+        f"  Dropping wrong-language output {sorted(wrong)}; "
+        f"keeping levels {result['simplified_levels']}"
+    )
+    if not result["simplified_levels"]:
+        raise Exception(
+            "No simplified versions survived the language check: "
+            f"{describe_mismatches(mismatches)}"
+        )
+    return result
+
+
+def _parse_adaptive_response(result: str, provider: str, model_name: str) -> dict:
+    """Turn one adaptive-simplification response into the levels it describes."""
+    log(f"  Parsing response sections...")
+    # Parse the response
+    sections = {}
+    lines = result.split("\n")
+    current_section = None
+    current_content = []
+
+    for line in lines:
+        line = line.strip()
+        if ":" in line and any(
+            line.startswith(prefix)
+            for prefix in [
+                "DISTURBING_CONTENT",
+                "ARTICLE_TYPE",
+                "ORIGINAL_LEVEL",
+                "ORIGINAL_SUMMARY",
+                "SIMPLIFIED_LEVELS",
+            ]
+        ):
+            # Save previous section
+            if current_section:
+                sections[current_section] = "\n".join(current_content).strip()
+            # Start new section
+            section_name = line.split(":")[0]
+            current_section = section_name
+            current_content = [line.split(":", 1)[1].strip()]
+        elif "_TITLE:" in line or "_CONTENT:" in line or "_SUMMARY:" in line:
+            # Save previous section
+            if current_section:
+                sections[current_section] = "\n".join(current_content).strip()
+            # Start new section
+            section_name = line.split(":")[0]
+            current_section = section_name
+            current_content = [line.split(":", 1)[1].strip()]
+        elif current_section:
+            current_content.append(line)
+
+    # Save last section
+    if current_section:
+        sections[current_section] = "\n".join(current_content).strip()
+
+    log(f"  Found {len(sections)} sections in response")
+    log(f"  Section keys: {list(sections.keys())}")
+
+    # Extract basic info
+    is_disturbing = (
+        _clean_text(sections.get("DISTURBING_CONTENT", "NO")).upper() == "YES"
+    )
+    article_type_raw = _clean_text(sections.get("ARTICLE_TYPE", "")).upper()
+    article_type = (
+        article_type_raw if article_type_raw in ["NEWS", "GENERAL"] else None
+    )
+    original_level = _clean_text(sections.get("ORIGINAL_LEVEL", ""))
+    original_summary = _strip_markdown_from_summary(
+        _clean_text(sections.get("ORIGINAL_SUMMARY", ""))
+    )
+    simplified_levels_str = _clean_text(sections.get("SIMPLIFIED_LEVELS", ""))
+
+    # Parse simplified levels
+    if simplified_levels_str:
+        simplified_levels = [
+            level.strip() for level in simplified_levels_str.split(",")
+        ]
+    else:
+        simplified_levels = []
+
+    # Validate CEFR level
+    valid_levels = ["A1", "A2", "B1", "B2", "C1", "C2"]
+    if original_level not in valid_levels:
+        log(
+            f"Warning: Invalid original CEFR level '{original_level}', defaulting to 'B2'"
+        )
+        original_level = "B2"
+
+    log(
+        f"  Extracted: original_level={original_level}, simplified_levels={simplified_levels}"
+    )
+
+    # Extract simplified versions
+    log(f"  Extracting simplified versions for levels: {simplified_levels}")
+    versions = {}
+    for level in simplified_levels:
+        log(f"    Processing level {level}...")
+        title_key = f"{level}_TITLE"
+        content_key = f"{level}_CONTENT"
+        summary_key = f"{level}_SUMMARY"
+
+        if all(key in sections for key in [title_key, content_key, summary_key]):
+            versions[level] = {
+                "title": _clean_text(sections[title_key]),
+                "content": _clean_text(sections[content_key]),
+                "summary": _strip_markdown_from_summary(
+                    _clean_text(sections[summary_key])
+                ),
+            }
+            log(f"    Successfully extracted {level} version")
+        else:
+            missing_keys = [
+                key
+                for key in [title_key, content_key, summary_key]
+                if key not in sections
+            ]
+            log(f"    Missing keys for {level}: {missing_keys}")
+
+    # Validate we got the expected content
+    if not original_summary:
+        raise Exception("Missing original summary in response")
+
+    # Filter out incomplete levels but keep the ones that are complete
+    valid_levels = []
+    invalid_levels = []
+    for level in simplified_levels:
+        if level in versions and all(versions[level].values()):
+            valid_levels.append(level)
+        else:
+            invalid_levels.append(level)
+            log(
+                f"  Warning: Missing or incomplete content for {level} level, skipping"
+            )
+
+    # Update simplified_levels to only include valid ones
+    simplified_levels = valid_levels
+
+    # Only fail if we got NO valid levels at all
+    if not simplified_levels:
+        raise Exception(
+            f"No complete simplified versions were created. Incomplete levels: {invalid_levels}"
+        )
+
+    if invalid_levels:
+        log(
+            f"Partially successful: simplified article to {len(simplified_levels)} levels: {simplified_levels} (skipped incomplete: {invalid_levels})"
+        )
+    else:
+        log(
+            f"Successfully simplified article to {len(simplified_levels)} levels: {simplified_levels} (original was {original_level}, disturbing: {is_disturbing})"
+        )
+
+    return {
+        "is_disturbing": is_disturbing,
+        "article_type": article_type.lower() if article_type else None,
+        "original_cefr_level": original_level,
+        "original_summary": original_summary,
+        "simplified_levels": simplified_levels,
+        "versions": versions,
+        "provider": provider,
+        "model_name": model_name,
+    }
+
+
 def simplify_article_adaptive_levels(
     title: str,
     content: str,
@@ -417,8 +692,13 @@ def simplify_article_adaptive_levels(
             'model_name': str  # e.g., 'deepseek-chat' or 'claude-haiku-4-5-20251001'
         }
 
+    Every level must come back in the article's language. If any doesn't, the
+    whole set is re-requested once with the offending levels named; whatever is
+    still wrong after that is dropped, and the levels that are right are kept.
+
     Raises:
-        Exception: If API call fails or returns unexpected response
+        Exception: If API call fails, returns unexpected response, or no level
+        survives the language check
     """
 
     # Get the adaptive prompt
@@ -432,148 +712,25 @@ def simplify_article_adaptive_levels(
         log(f"  Article length: {len(content)} characters")
         log(f"  Prompt length: {len(prompt)} characters")
 
-        result, model_name = _call_simplification_llm(
-            prompt, provider, api_key, max_tokens=6000, timeout=180
-        )
-        _raise_if_paywall_or_advertorial(result)
-
-        log(f"  Parsing response sections...")
-        # Parse the response
-        sections = {}
-        lines = result.split("\n")
-        current_section = None
-        current_content = []
-
-        for line in lines:
-            line = line.strip()
-            if ":" in line and any(
-                line.startswith(prefix)
-                for prefix in [
-                    "DISTURBING_CONTENT",
-                    "ARTICLE_TYPE",
-                    "ORIGINAL_LEVEL",
-                    "ORIGINAL_SUMMARY",
-                    "SIMPLIFIED_LEVELS",
-                ]
-            ):
-                # Save previous section
-                if current_section:
-                    sections[current_section] = "\n".join(current_content).strip()
-                # Start new section
-                section_name = line.split(":")[0]
-                current_section = section_name
-                current_content = [line.split(":", 1)[1].strip()]
-            elif "_TITLE:" in line or "_CONTENT:" in line or "_SUMMARY:" in line:
-                # Save previous section
-                if current_section:
-                    sections[current_section] = "\n".join(current_content).strip()
-                # Start new section
-                section_name = line.split(":")[0]
-                current_section = section_name
-                current_content = [line.split(":", 1)[1].strip()]
-            elif current_section:
-                current_content.append(line)
-
-        # Save last section
-        if current_section:
-            sections[current_section] = "\n".join(current_content).strip()
-
-        log(f"  Found {len(sections)} sections in response")
-        log(f"  Section keys: {list(sections.keys())}")
-
-        # Extract basic info
-        is_disturbing = (
-            _clean_text(sections.get("DISTURBING_CONTENT", "NO")).upper() == "YES"
-        )
-        article_type_raw = _clean_text(sections.get("ARTICLE_TYPE", "")).upper()
-        article_type = (
-            article_type_raw if article_type_raw in ["NEWS", "GENERAL"] else None
-        )
-        original_level = _clean_text(sections.get("ORIGINAL_LEVEL", ""))
-        original_summary = _strip_markdown_from_summary(
-            _clean_text(sections.get("ORIGINAL_SUMMARY", ""))
-        )
-        simplified_levels_str = _clean_text(sections.get("SIMPLIFIED_LEVELS", ""))
-
-        # Parse simplified levels
-        if simplified_levels_str:
-            simplified_levels = [
-                level.strip() for level in simplified_levels_str.split(",")
-            ]
-        else:
-            simplified_levels = []
-
-        # Validate CEFR level
-        valid_levels = ["A1", "A2", "B1", "B2", "C1", "C2"]
-        if original_level not in valid_levels:
-            log(
-                f"Warning: Invalid original CEFR level '{original_level}', defaulting to 'B2'"
+        def generate(correction):
+            result, model_name = _call_simplification_llm(
+                prompt + correction, provider, api_key, max_tokens=6000, timeout=180
             )
-            original_level = "B2"
+            _raise_if_paywall_or_advertorial(result)
+            return _parse_adaptive_response(result, provider, model_name)
 
-        log(
-            f"  Extracted: original_level={original_level}, simplified_levels={simplified_levels}"
-        )
-
-        # Extract simplified versions
-        log(f"  Extracting simplified versions for levels: {simplified_levels}")
-        versions = {}
-        for level in simplified_levels:
-            log(f"    Processing level {level}...")
-            title_key = f"{level}_TITLE"
-            content_key = f"{level}_CONTENT"
-            summary_key = f"{level}_SUMMARY"
-
-            if all(key in sections for key in [title_key, content_key, summary_key]):
-                versions[level] = {
-                    "title": _clean_text(sections[title_key]),
-                    "content": _clean_text(sections[content_key]),
-                    "summary": _strip_markdown_from_summary(
-                        _clean_text(sections[summary_key])
-                    ),
-                }
-                log(f"    Successfully extracted {level} version")
-            else:
-                missing_keys = [
-                    key
-                    for key in [title_key, content_key, summary_key]
-                    if key not in sections
-                ]
-                log(f"    Missing keys for {level}: {missing_keys}")
-
-        # Validate we got the expected content
-        if not original_summary:
-            raise Exception("Missing original summary in response")
-
-        # Filter out incomplete levels but keep the ones that are complete
-        valid_levels = []
-        invalid_levels = []
-        for level in simplified_levels:
-            if level in versions and all(versions[level].values()):
-                valid_levels.append(level)
-            else:
-                invalid_levels.append(level)
-                log(
-                    f"  Warning: Missing or incomplete content for {level} level, skipping"
-                )
-
-        # Update simplified_levels to only include valid ones
-        simplified_levels = valid_levels
-
-        # Only fail if we got NO valid levels at all
-        if not simplified_levels:
-            raise Exception(
-                f"No complete simplified versions were created. Incomplete levels: {invalid_levels}"
+        try:
+            simplification = generate_in_language(
+                generate,
+                target_language,
+                _version_fields,
+                f"simplification of '{title[:50]}'",
             )
+        except LanguageMismatchError as e:
+            simplification = _without_wrong_language_levels(e.result, e.mismatches)
 
-        if invalid_levels:
-            log(
-                f"Partially successful: simplified article to {len(simplified_levels)} levels: {simplified_levels} (skipped incomplete: {invalid_levels})"
-            )
-        else:
-            log(
-                f"Successfully simplified article to {len(simplified_levels)} levels: {simplified_levels} (original was {original_level}, disturbing: {is_disturbing})"
-            )
+        versions = simplification["versions"]
+        simplified_levels = simplification["simplified_levels"]
 
         # Grammar correction pass - fix spelling/grammar errors introduced during simplification
         uncorrected_versions = None
@@ -608,17 +765,9 @@ def simplify_article_adaptive_levels(
                 )
                 uncorrected_versions = None  # Don't log if correction failed
 
-        return {
-            "is_disturbing": is_disturbing,
-            "article_type": article_type.lower() if article_type else None,
-            "original_cefr_level": original_level,
-            "original_summary": original_summary,
-            "simplified_levels": simplified_levels,
-            "versions": versions,
-            "uncorrected_versions": uncorrected_versions,  # For logging corrections
-            "provider": provider,
-            "model_name": model_name,
-        }
+        # For logging corrections
+        simplification["uncorrected_versions"] = uncorrected_versions
+        return simplification
 
     except Timeout as e:
         log(f"  ERROR: DeepSeek API call timed out after 3 minutes")
@@ -656,7 +805,7 @@ def create_simplified_article_adaptive(
     """
 
     # Check if simplified version already exists
-    for existing in original_article.simplified_versions:
+    for existing in original_article.usable_simplified_versions:
         if existing.cefr_level == cefr_level:
             log(
                 f"Simplified version for {cefr_level} already exists for article {original_article.id}"
@@ -1139,7 +1288,9 @@ def create_recipient_derivative_from_article(
         f"#translated-from-{source_language_code}-to-{target_language_code}-{target_level}"
     )
     existing = Article.find(translated_url_key)
-    if existing:
+    # Skip a copy marked broken — the audit tool marks wrong-language ones, and
+    # this URL-key cache is the only thing that would otherwise keep serving it.
+    if existing and not existing.broken:
         return existing
 
     content = article.content or ""
@@ -1246,7 +1397,9 @@ def create_recipient_derivative(session, upload, target_language_code, target_le
         f"#translated-from-{source_language_code}-to-{target_language_code}-{target_level}"
     )
     existing = Article.find(translated_url_key)
-    if existing:
+    # Skip a copy marked broken — the audit tool marks wrong-language ones, and
+    # this URL-key cache is the only thing that would otherwise keep serving it.
+    if existing and not existing.broken:
         return existing
 
     content = upload.text_content or upload.raw_html or ""

--- a/zeeguu/core/llm_services/simplification_and_classification.py
+++ b/zeeguu/core/llm_services/simplification_and_classification.py
@@ -13,9 +13,9 @@ import requests
 import time
 from requests.exceptions import Timeout, RequestException
 from zeeguu.logging import log
-from zeeguu.core.language.language_check import (
+from zeeguu.core.language.language_check import describe_mismatches
+from zeeguu.core.language.generate_in_language import (
     LanguageMismatchError,
-    describe_mismatches,
     generate_in_language,
 )
 from zeeguu.core.model.article import Article

--- a/zeeguu/core/llm_services/simplification_and_classification.py
+++ b/zeeguu/core/llm_services/simplification_and_classification.py
@@ -146,8 +146,12 @@ def _level_summary_label(level: str) -> str:
     return f"{level} summary"
 
 
-def _summary_fields(assessment: dict) -> list:
-    """The parts of an assessment that must be in the article's language."""
+def _summaries_to_check(assessment: dict) -> list:
+    """
+    The summaries out of an assessment, labelled — the only part of it that has
+    a language. Each label is also the key we drop that summary by, so they have
+    to match the ones _without_wrong_language_summaries looks for.
+    """
     fields = [(ORIGINAL_SUMMARY_LABEL, assessment.get("original_summary", ""))]
     fields += [
         (_level_summary_label(level), text)
@@ -232,7 +236,7 @@ def assess_and_summarize(
         return generate_in_language(
             generate,
             target_language,
-            _summary_fields,
+            _summaries_to_check,
             f"summary of '{title[:50]}'",
         )
     except LanguageMismatchError as e:
@@ -450,17 +454,22 @@ def get_target_levels_for_original_level(original_level: str) -> list[str]:
     return target_levels
 
 
-def _version_fields(simplification: dict) -> list:
+def _simplification_to_check(simplification: dict) -> list:
     """
-    The parts of a multi-level simplification that must be in the article's
-    language — one field per level, so a level that comes back English can be
-    dropped without taking the others with it.
+    What a simplification run generated, one field per level.
+
+    Split by level for *detection*, not for salvage: an English A2 body sits next
+    to a Danish title and three Danish summaries, and judged as one blob the
+    Danish wins on volume and the English body goes through. Nothing keys off
+    these labels — a run that comes back wrong is lost whole (see the policy in
+    simplify_article_adaptive_levels), because a level has never failed on its
+    own; every failure we have seen was the entire response.
     """
     fields = [(ORIGINAL_SUMMARY_LABEL, simplification.get("original_summary", ""))]
     for level, version in simplification.get("versions", {}).items():
         fields.append(
             (
-                level,
+                f"{level} text",
                 " ".join(
                     [
                         version.get("title", ""),
@@ -471,38 +480,6 @@ def _version_fields(simplification: dict) -> list:
             )
         )
     return fields
-
-
-def _without_wrong_language_levels(simplification: dict, mismatches: list) -> dict:
-    """
-    Policy for a level that came back in the wrong language: drop that level and
-    keep the good ones. A run produces up to six levels and every caller already
-    tolerates a partial set, so one bad generation must not cost the other five.
-
-    Raises when nothing survives — same contract as "no complete versions".
-    """
-    wrong = {m.label for m in mismatches}
-    result = dict(simplification)
-    if ORIGINAL_SUMMARY_LABEL in wrong:
-        result["original_summary"] = ""
-    result["versions"] = {
-        level: version
-        for level, version in result.get("versions", {}).items()
-        if level not in wrong
-    }
-    result["simplified_levels"] = [
-        level for level in result.get("simplified_levels", []) if level not in wrong
-    ]
-    log(
-        f"  Dropping wrong-language output {sorted(wrong)}; "
-        f"keeping levels {result['simplified_levels']}"
-    )
-    if not result["simplified_levels"]:
-        raise Exception(
-            "No simplified versions survived the language check: "
-            f"{describe_mismatches(mismatches)}"
-        )
-    return result
 
 
 def _parse_adaptive_response(result: str, provider: str, model_name: str) -> dict:
@@ -692,13 +669,13 @@ def simplify_article_adaptive_levels(
             'model_name': str  # e.g., 'deepseek-chat' or 'claude-haiku-4-5-20251001'
         }
 
-    Every level must come back in the article's language. If any doesn't, the
-    whole set is re-requested once with the offending levels named; whatever is
-    still wrong after that is dropped, and the levels that are right are kept.
+    The whole set must come back in the article's language. If it doesn't, it is
+    re-requested once with the mistake named, and then the run fails — no level
+    is salvaged from a response that came back in the wrong language twice.
 
     Raises:
-        Exception: If API call fails, returns unexpected response, or no level
-        survives the language check
+        Exception: If API call fails, returns unexpected response, or the output
+        is still in the wrong language after the retry
     """
 
     # Get the adaptive prompt
@@ -719,15 +696,12 @@ def simplify_article_adaptive_levels(
             _raise_if_paywall_or_advertorial(result)
             return _parse_adaptive_response(result, provider, model_name)
 
-        try:
-            simplification = generate_in_language(
-                generate,
-                target_language,
-                _version_fields,
-                f"simplification of '{title[:50]}'",
-            )
-        except LanguageMismatchError as e:
-            simplification = _without_wrong_language_levels(e.result, e.mismatches)
+        simplification = generate_in_language(
+            generate,
+            target_language,
+            _simplification_to_check,
+            f"simplification of '{title[:50]}'",
+        )
 
         versions = simplification["versions"]
         simplified_levels = simplification["simplified_levels"]
@@ -805,7 +779,7 @@ def create_simplified_article_adaptive(
     """
 
     # Check if simplified version already exists
-    for existing in original_article.usable_simplified_versions:
+    for existing in original_article.available_simplified_versions:
         if existing.cefr_level == cefr_level:
             log(
                 f"Simplified version for {cefr_level} already exists for article {original_article.id}"

--- a/zeeguu/core/llm_services/simplification_service.py
+++ b/zeeguu/core/llm_services/simplification_service.py
@@ -6,8 +6,26 @@ import os
 import requests
 from typing import Dict, Optional, Tuple
 from zeeguu.logging import log
+from zeeguu.core.language.language_check import (
+    LanguageMismatchError,
+    generate_in_language,
+)
 from zeeguu.core.llm_services.haiku_client import haiku_completion
 from zeeguu.core.llm_services import models
+
+
+def _text_fields(result: Dict) -> list:
+    """
+    What must be in the requested language, for the output-language check.
+
+    Title and summary are usually under the length threshold and come back as
+    "can't judge"; the content is what actually decides.
+    """
+    return [
+        ("title", result.get("title", "")),
+        ("summary", result.get("summary", "")),
+        ("content", result.get("content", "")),
+    ]
 
 
 class SimplificationService:
@@ -87,43 +105,73 @@ class SimplificationService:
         - Try Anthropic first (fast, real-time, extension use)
         - Fall back to DeepSeek if needed (slower, batch processing)
 
+        Simplifying must not change the language. When the output comes back in
+        another one it is re-requested once naming the mistake, and then given up
+        on — the callers all treat None as "no simplified version".
+
         Returns: Dict with 'title', 'content', 'summary' keys or None if failed
         """
         # Try Anthropic first (faster for real-time use)
         if self.anthropic_api_key:
             log(f"Using Anthropic for real-time simplification to {target_level}")
-            try:
+
+            def generate_anthropic(correction):
                 simplified_title, simplified_content, simplified_summary = self._simplify_anthropic(
-                    title, content, target_level, language_code
+                    title, content, target_level, language_code, correction
                 )
-                if simplified_title and simplified_content:
-                    if not simplified_summary:
-                        # Anthropic didn't produce a summary — strip HTML off the
-                        # content before slicing so we don't leak <p>/<strong> tags.
-                        from bs4 import BeautifulSoup
-                        plain = BeautifulSoup(simplified_content, "html.parser").get_text()
-                        simplified_summary = plain[:200] + ("..." if len(plain) > 200 else "")
-                    return {
-                        "title": simplified_title,
-                        "content": simplified_content,
-                        "summary": simplified_summary,
-                    }
+                if not (simplified_title and simplified_content):
+                    raise Exception("Anthropic returned an incomplete simplification")
+                if not simplified_summary:
+                    # Anthropic didn't produce a summary — strip HTML off the
+                    # content before slicing so we don't leak <p>/<strong> tags.
+                    from bs4 import BeautifulSoup
+                    plain = BeautifulSoup(simplified_content, "html.parser").get_text()
+                    simplified_summary = plain[:200] + ("..." if len(plain) > 200 else "")
+                return {
+                    "title": simplified_title,
+                    "content": simplified_content,
+                    "summary": simplified_summary,
+                }
+
+            try:
+                return generate_in_language(
+                    generate_anthropic,
+                    language_code,
+                    _text_fields,
+                    f"{target_level} simplification of '{title[:50]}'",
+                )
+            except LanguageMismatchError as e:
+                log(f"Anthropic simplified into the wrong language, trying DeepSeek: {e}")
             except Exception as e:
                 log(f"Anthropic simplification failed, falling back to DeepSeek: {e}")
 
         # Fallback to DeepSeek
         if self.deepseek_api_key:
             log(f"Using DeepSeek for batch simplification to {target_level}")
-            try:
-                return self._simplify_deepseek(
-                    title, content, target_level, language_code
+
+            def generate_deepseek(correction):
+                result = self._simplify_deepseek(
+                    title, content, target_level, language_code, correction
                 )
+                if not result:
+                    raise Exception("DeepSeek returned no simplification")
+                return result
+
+            try:
+                return generate_in_language(
+                    generate_deepseek,
+                    language_code,
+                    _text_fields,
+                    f"{target_level} simplification of '{title[:50]}'",
+                )
+            except LanguageMismatchError as e:
+                log(f"DeepSeek simplified into the wrong language, giving up: {e}")
             except Exception as e:
                 log(f"DeepSeek simplification failed: {e}")
 
         log("Neither ANTHROPIC_TEXT_SIMPLIFICATION_KEY nor DEEPSEEK_API_KEY configured")
         return None
-    
+
     def translate_and_adapt(
         self,
         title: str,
@@ -134,7 +182,13 @@ class SimplificationService:
     ) -> Optional[Dict]:
         """
         Translate and adapt text to target language and reading level.
-        
+
+        The riskiest LLM call in the codebase for output language: this is a
+        translation task, so "left it in the source language" is the single most
+        likely way for it to go wrong, and the result is stored as an article in
+        the recipient's language. Checked against target_language, re-requested
+        once, then abandoned (None) rather than stored untranslated.
+
         Returns: Dict with 'title', 'content', 'summary' keys or None if failed
         """
         # Map language codes to names
@@ -158,28 +212,47 @@ class SimplificationService:
         source_lang_name = language_names.get(source_language, source_language)
         target_lang_name = language_names.get(target_language, target_language)
         
+        context = f"{target_lang_name} translation of '{title[:50]}'"
+
+        def translated_by(translate):
+            """Wrap one provider's translate call for the output-language check."""
+
+            def generate(correction):
+                result = translate(correction)
+                if not result:
+                    raise Exception("translation returned nothing")
+                return result
+
+            return generate_in_language(generate, target_language, _text_fields, context)
+
         # Try Anthropic first (faster for real-time use)
         if self.anthropic_api_key:
             log(f"Using Anthropic for translation from {source_language} to {target_language} at {target_level}")
             try:
-                result = self._translate_and_adapt_anthropic(
-                    title, content, source_lang_name, target_lang_name, target_level
+                return translated_by(
+                    lambda correction: self._translate_and_adapt_anthropic(
+                        title, content, source_lang_name, target_lang_name, target_level, correction
+                    )
                 )
-                if result:
-                    return result
+            except LanguageMismatchError as e:
+                log(f"Anthropic did not translate into {target_lang_name}, trying DeepSeek: {e}")
             except Exception as e:
                 log(f"Anthropic translation failed, falling back to DeepSeek: {e}")
-        
+
         # Fallback to DeepSeek
         if self.deepseek_api_key:
             log(f"Using DeepSeek for translation from {source_language} to {target_language} at {target_level}")
             try:
-                return self._translate_and_adapt_deepseek(
-                    title, content, source_lang_name, target_lang_name, target_level
+                return translated_by(
+                    lambda correction: self._translate_and_adapt_deepseek(
+                        title, content, source_lang_name, target_lang_name, target_level, correction
+                    )
                 )
+            except LanguageMismatchError as e:
+                log(f"DeepSeek did not translate into {target_lang_name}, giving up: {e}")
             except Exception as e:
                 log(f"DeepSeek translation failed: {e}")
-        
+
         log("Neither ANTHROPIC_TEXT_SIMPLIFICATION_KEY nor DEEPSEEK_API_KEY configured")
         return None
 
@@ -448,7 +521,8 @@ TOPIC: [topic]"""
             return (None, None)
 
     def _translate_and_adapt_anthropic(
-        self, title: str, content: str, source_language: str, target_language: str, target_level: str
+        self, title: str, content: str, source_language: str, target_language: str,
+        target_level: str, correction: str = ""
     ) -> Optional[Dict]:
         """Translate and adapt text using Anthropic"""
         
@@ -512,6 +586,8 @@ IMPORTANT:
 - Summary should be concise, maximum 25 words, using {target_level} vocabulary
 - Ensure valid JSON format"""
 
+        prompt += correction
+
         log(f"Prompt length: {len(prompt)} chars")
 
         # Route through the shared Haiku client so the model (models.SIMPLIFICATION,
@@ -565,7 +641,8 @@ IMPORTANT:
             return None
 
     def _translate_and_adapt_deepseek(
-        self, title: str, content: str, source_language: str, target_language: str, target_level: str
+        self, title: str, content: str, source_language: str, target_language: str,
+        target_level: str, correction: str = ""
     ) -> Optional[Dict]:
         """Translate and adapt text using DeepSeek"""
         
@@ -602,6 +679,8 @@ Return ONLY valid JSON in this exact format (no markdown, no code blocks):
 }}
 
 IMPORTANT: Summary should be concise, maximum 25 words, using {target_level} vocabulary."""
+
+        prompt += correction
 
         try:
             response = requests.post(
@@ -683,7 +762,8 @@ IMPORTANT: Summary should be concise, maximum 25 words, using {target_level} voc
             return None
 
     def _simplify_anthropic(
-        self, title: str, content: str, target_level: str, language_code: str
+        self, title: str, content: str, target_level: str, language_code: str,
+        correction: str = ""
     ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
         """Simplify text using Anthropic with ultra-strict constraints"""
         language_names = {
@@ -740,6 +820,8 @@ SIMPLIFIED_TITLE: [your simplified title in {language_name}]
 SIMPLIFIED_SUMMARY: [a concise plain-text summary in {language_name}, maximum 25 words, NO Markdown or HTML]
 SIMPLIFIED_CONTENT: [your simplified content in {language_name} using Markdown formatting - preserve paragraph breaks with double newlines, use **bold**, *italics*, ## for headings, - for lists]"""
 
+        prompt += correction
+
         result = haiku_completion(
             prompt, max_tokens=2000, temperature=0.2, timeout=60
         )
@@ -780,7 +862,8 @@ SIMPLIFIED_CONTENT: [your simplified content in {language_name} using Markdown f
         return simplified_title, simplified_html, simplified_summary
 
     def _simplify_deepseek(
-        self, title: str, content: str, target_level: str, language_code: str
+        self, title: str, content: str, target_level: str, language_code: str,
+        correction: str = ""
     ) -> Optional[Dict]:
         """Simplify text using DeepSeek"""
         prompt = f"""You are a language learning content creator. Simplify this {language_code} article from C1 level to {target_level} level.
@@ -806,6 +889,8 @@ SIMPLIFIED_CONTENT: [simplified article content in {language_code} with Markdown
 SIMPLIFIED_SUMMARY: [concise summary in {language_code}, maximum 25 words]
 
 Remember: Keep the same factual information but make it appropriate for {target_level} learners of {language_code}. DO NOT TRANSLATE THE CONTENT."""
+
+        prompt += correction
 
         try:
             response = requests.post(

--- a/zeeguu/core/llm_services/simplification_service.py
+++ b/zeeguu/core/llm_services/simplification_service.py
@@ -6,7 +6,7 @@ import os
 import requests
 from typing import Dict, Optional, Tuple
 from zeeguu.logging import log
-from zeeguu.core.language.language_check import (
+from zeeguu.core.language.generate_in_language import (
     LanguageMismatchError,
     generate_in_language,
 )

--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -185,6 +185,34 @@ class Article(db.Model):
         "AIGenerator", foreign_keys=[simplification_ai_generator_id]
     )
 
+    @property
+    def usable_simplified_versions(self):
+        """
+        The children we're willing to offer as a level of THIS article.
+
+        ``simplified_versions`` is the raw backref on parent_article_id, and it
+        holds two different kinds of child. Same-language ones are level
+        adaptations of this article. Cross-language ones are friend-share
+        derivatives — a recipient learning another language got their own
+        translated copy, hung off the same parent so the reader's "Original:"
+        link works and so it coalesces per (original, language, level). A German
+        copy of a Danish article is not a B1 version of that article, and
+        offering it to a Danish learner is how it leaks: the level lists, the ES
+        available_cefr_levels, and the on-demand "do we already have this level?"
+        check all read this.
+
+        Broken children are excluded too. A version can be marked broken after
+        the fact — most notably by tools/audit_stored_article_languages.py, when
+        the LLM wrote it in the wrong language — and skipping it here is what
+        makes it regenerate: the on-demand path only calls the LLM when it finds
+        no usable version at the reader's level.
+        """
+        return [
+            version
+            for version in self.simplified_versions
+            if not version.broken and version.language_id == self.language_id
+        ]
+
     # 1:1 relationship to CEFR assessment data
     cefr_assessment = relationship(
         "ArticleCefrAssessment",
@@ -909,8 +937,10 @@ class Article(db.Model):
                     user_cefr_level
                 )
 
-        # Look for simplified version matching user's level
-        for simplified in self.simplified_versions:
+        # Look for simplified version matching user's level. usable_ excludes
+        # broken children and cross-language friend-share copies — a German copy
+        # of this Danish article is not the B1 version of it.
+        for simplified in self.usable_simplified_versions:
             if matches_user_level(simplified):
                 return simplified
 

--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -186,7 +186,7 @@ class Article(db.Model):
     )
 
     @property
-    def usable_simplified_versions(self):
+    def available_simplified_versions(self):
         """
         The children we're willing to offer as a level of THIS article.
 
@@ -940,7 +940,7 @@ class Article(db.Model):
         # Look for simplified version matching user's level. usable_ excludes
         # broken children and cross-language friend-share copies — a German copy
         # of this Danish article is not the B1 version of it.
-        for simplified in self.usable_simplified_versions:
+        for simplified in self.available_simplified_versions:
             if matches_user_level(simplified):
                 return simplified
 

--- a/zeeguu/core/model/article_broken_code_map.py
+++ b/zeeguu/core/model/article_broken_code_map.py
@@ -17,6 +17,7 @@ class LowQualityTypes:
     LIVE_BLOG = "LIVE_BLOG"
     ML_PREDICTION = "ML_PREDICTION"
     LANGUAGE_DOES_NOT_MATCH_FEED = "LANGUAGE_DOES_NOT_MATCH_FEED"
+    LLM_WRONG_LANGUAGE = "LLM_WRONG_LANGUAGE"      # LLM wrote a simplification in another language
     ADVERTORIAL_PATTERN = "ADVERTORIAL_PATTERN"    # Detected by URL/keyword patterns
     ADVERTORIAL_LLM = "ADVERTORIAL_LLM"            # Detected by LLM during simplification
     USER_REPORTED = "USER_REPORTED"

--- a/zeeguu/core/test/rules/language_rule.py
+++ b/zeeguu/core/test/rules/language_rule.py
@@ -92,3 +92,11 @@ class LanguageRule(BaseRule):
     def random(self):
         random_id, __ = random.choice(list(self.languages.items()))
         return self.get_or_create_language(random_id)
+
+    def other_than(self, language):
+        """A random language that is NOT `language` — for the many tests whose
+        point is that two things are in different languages."""
+        other = self.random
+        while other.id == language.id:
+            other = self.random
+        return other

--- a/zeeguu/core/test/test_available_simplified_versions.py
+++ b/zeeguu/core/test/test_available_simplified_versions.py
@@ -19,7 +19,7 @@ from zeeguu.core.test.rules.language_rule import LanguageRule
 session = zeeguu.core.model.db.session
 
 
-class UsableSimplifiedVersionsTest(ModelTestMixIn, TestCase):
+class AvailableSimplifiedVersionsTest(ModelTestMixIn, TestCase):
     def setUp(self):
         super().setUp()
         self.original = ArticleRule().article
@@ -33,24 +33,25 @@ class UsableSimplifiedVersionsTest(ModelTestMixIn, TestCase):
         session.commit()
         return child
 
-    def _another_language(self):
-        language = LanguageRule().random
-        while language.id == self.original.language_id:
-            language = LanguageRule().random
-        return language
-
     def test_a_same_language_child_is_a_level_of_the_article(self):
         child = self._child(self.original.language)
-        assert child in self.original.usable_simplified_versions
+        assert child in self.original.available_simplified_versions
+
+    def test_a_child_without_a_level_is_still_listed(self):
+        # Nothing here filters on cefr_level — a level-less child is simply never
+        # matched by get_appropriate_version_for_user_level, which is where the
+        # decision belongs.
+        child = self._child(self.original.language, cefr_level=None)
+        assert child in self.original.available_simplified_versions
 
     def test_a_friend_share_translation_is_not_a_level_of_the_article(self):
-        translated = self._child(self._another_language())
+        translated = self._child(LanguageRule().other_than(self.original.language))
         assert translated in self.original.simplified_versions
-        assert translated not in self.original.usable_simplified_versions
+        assert translated not in self.original.available_simplified_versions
 
     def test_a_child_marked_broken_is_not_offered(self):
         child = self._child(self.original.language)
         child.broken = MARKED_BROKEN_DUE_TO_LOW_QUALITY
         session.add(child)
         session.commit()
-        assert child not in self.original.usable_simplified_versions
+        assert child not in self.original.available_simplified_versions

--- a/zeeguu/core/test/test_generate_in_language.py
+++ b/zeeguu/core/test/test_generate_in_language.py
@@ -1,0 +1,68 @@
+"""
+Re-asking the LLM when it answered in the wrong language.
+
+The detection is tested next door in test_language_check; these are about the
+loop: one call when the answer is good, a second naming the mistake when it is
+not, and a raise carrying enough for the call site to decide what to salvage.
+"""
+
+import pytest
+
+from zeeguu.core.language.generate_in_language import (
+    LanguageMismatchError,
+    generate_in_language,
+)
+
+DANISH = (
+    "Regeringen har i dag fremlagt et nyt forslag om klimaet. Forslaget skal "
+    "gøre det billigere at køre i elbil, og det skal samtidig blive dyrere at "
+    "flyve inden for landets grænser."
+)
+
+ENGLISH = (
+    "The government presented a new proposal about the climate today. The plan "
+    "would make it cheaper to drive an electric car, and at the same time more "
+    "expensive to fly within the country."
+)
+
+
+def test_generate_in_language_returns_a_good_first_attempt_without_retrying():
+    calls = []
+
+    def generate(correction):
+        calls.append(correction)
+        return {"text": DANISH}
+
+    result = generate_in_language(
+        generate, "da", lambda r: [("text", r["text"])], "test"
+    )
+    assert result == {"text": DANISH}
+    assert calls == [""]
+
+
+def test_generate_in_language_retries_with_a_correction_naming_the_problem():
+    calls = []
+    answers = [{"text": ENGLISH}, {"text": DANISH}]
+
+    def generate(correction):
+        calls.append(correction)
+        return answers[len(calls) - 1]
+
+    result = generate_in_language(
+        generate, "da", lambda r: [("text", r["text"])], "test"
+    )
+    assert result == {"text": DANISH}
+    assert calls[0] == ""
+    assert "Danish" in calls[1] and "en" in calls[1]
+
+
+def test_generate_in_language_gives_up_carrying_the_last_result():
+    def generate(correction):
+        return {"assessment": "B1", "text": ENGLISH}
+
+    with pytest.raises(LanguageMismatchError) as caught:
+        generate_in_language(generate, "da", lambda r: [("text", r["text"])], "test")
+
+    # The last result rides along so a caller can keep the parts that are fine.
+    assert caught.value.result["assessment"] == "B1"
+    assert [m.label for m in caught.value.mismatches] == ["text"]

--- a/zeeguu/core/test/test_language_check.py
+++ b/zeeguu/core/test/test_language_check.py
@@ -8,11 +8,9 @@ import pytest
 
 from zeeguu.core.language.language_check import (
     _detectable_text,
-    LanguageMismatchError,
     field_mismatches,
     language_mismatch,
     passage_mismatch,
-    generate_in_language,
 )
 
 DANISH = (
@@ -85,48 +83,6 @@ def test_a_wrong_language_half_is_caught_even_when_the_whole_reads_right():
 def test_a_single_foreign_sentence_does_not_fail_a_good_passage():
     pieces = DANISH.split(". ") * 3 + ["The minister was not available for comment."]
     assert not passage_mismatch(pieces, "da")
-
-
-def test_generate_in_language_returns_a_good_first_attempt_without_retrying():
-    calls = []
-
-    def generate(correction):
-        calls.append(correction)
-        return {"text": DANISH}
-
-    result = generate_in_language(
-        generate, "da", lambda r: [("text", r["text"])], "test"
-    )
-    assert result == {"text": DANISH}
-    assert calls == [""]
-
-
-def test_generate_in_language_retries_with_a_correction_naming_the_problem():
-    calls = []
-    answers = [{"text": ENGLISH}, {"text": DANISH}]
-
-    def generate(correction):
-        calls.append(correction)
-        return answers[len(calls) - 1]
-
-    result = generate_in_language(
-        generate, "da", lambda r: [("text", r["text"])], "test"
-    )
-    assert result == {"text": DANISH}
-    assert calls[0] == ""
-    assert "Danish" in calls[1] and "en" in calls[1]
-
-
-def test_generate_in_language_gives_up_carrying_the_last_result():
-    def generate(correction):
-        return {"assessment": "B1", "text": ENGLISH}
-
-    with pytest.raises(LanguageMismatchError) as caught:
-        generate_in_language(generate, "da", lambda r: [("text", r["text"])], "test")
-
-    # The last result rides along so a caller can keep the parts that are fine.
-    assert caught.value.result["assessment"] == "B1"
-    assert [m.label for m in caught.value.mismatches] == ["text"]
 
 
 def test_prose_with_angle_brackets_is_not_eaten_as_markup():

--- a/zeeguu/core/test/test_language_check.py
+++ b/zeeguu/core/test/test_language_check.py
@@ -7,6 +7,7 @@ No Flask app context or DB — the check works on raw text.
 import pytest
 
 from zeeguu.core.language.language_check import (
+    _detectable_text,
     LanguageMismatchError,
     field_mismatches,
     language_mismatch,
@@ -126,3 +127,24 @@ def test_generate_in_language_gives_up_carrying_the_last_result():
     # The last result rides along so a caller can keep the parts that are fine.
     assert caught.value.result["assessment"] == "B1"
     assert [m.label for m in caught.value.mismatches] == ["text"]
+
+
+def test_prose_with_angle_brackets_is_not_eaten_as_markup():
+    # An unanchored tag pattern turned "Hvis 5 < 10 og 20 > 15" into "Hvis 5 15",
+    # deleting the very text we are about to judge.
+    kept = _detectable_text("Hvis 5 < 10 og 20 > 15, saa er tallene rigtige.")
+    assert "10 og 20" in kept
+    assert _detectable_text("<p>Hej <strong>med</strong> dig</p>") == "Hej med dig"
+
+
+def test_no_language_to_check_against_is_not_a_crash():
+    assert not language_mismatch(DANISH, None)
+    assert not language_mismatch(DANISH, "")
+
+
+def test_a_passage_given_as_one_string_is_refused():
+    # Iterating a string yields characters; the chunks read as Welsh and the
+    # caller gets a confident mismatch on perfectly good text.
+    with pytest.raises(TypeError):
+        passage_mismatch(DANISH, "da")
+    assert not passage_mismatch([DANISH], "da")

--- a/zeeguu/core/test/test_language_check.py
+++ b/zeeguu/core/test/test_language_check.py
@@ -12,7 +12,6 @@ from zeeguu.core.language.language_check import (
     language_mismatch,
     passage_mismatch,
     generate_in_language,
-    language_code_of,
 )
 
 DANISH = (
@@ -37,7 +36,7 @@ GERMAN = (
 
 
 def test_text_in_the_expected_language_passes():
-    assert language_mismatch(DANISH, "da") is None
+    assert not language_mismatch(DANISH, "da")
 
 
 def test_text_in_another_language_is_caught():
@@ -49,23 +48,23 @@ def test_text_in_another_language_is_caught():
 
 def test_confusable_neighbours_are_not_flagged_against_each_other():
     # langdetect regularly reads Danish as Norwegian; that must not fail a text.
-    assert language_mismatch(DANISH, "no") is None
+    assert not language_mismatch(DANISH, "no")
 
 
 def test_too_short_to_judge_is_not_a_mismatch():
     # "Can't judge" is a distinct answer from "wrong" — titles live down here.
-    assert language_mismatch("Hej med dig", "da") is None
+    assert not language_mismatch("Hej med dig", "da")
 
 
 def test_language_langdetect_cannot_check_is_skipped():
     # Kurdish has no langdetect profile; we can't check it, so we don't block on it.
-    assert language_mismatch(ENGLISH, "ku") is None
+    assert not language_mismatch(ENGLISH, "ku")
 
 
 def test_html_markup_does_not_hide_the_language():
     html = f"<p>{ENGLISH}</p><p><strong>More</strong> of the same.</p>"
     assert language_mismatch(html, "da").detected == "en"
-    assert language_mismatch(f"<p>{DANISH}</p>", "da") is None
+    assert not language_mismatch(f"<p>{DANISH}</p>", "da")
 
 
 def test_field_mismatches_reports_one_per_wrong_field():
@@ -79,21 +78,12 @@ def test_a_wrong_language_half_is_caught_even_when_the_whole_reads_right():
     # The audio-lesson failure: an all-English first half followed by correct
     # Danish scores mostly-Danish as one blob and would otherwise pass.
     pieces = ENGLISH.split(". ") + DANISH.split(". ") + DANISH.split(". ")
-    assert passage_mismatch(pieces, "da") is not None
+    assert passage_mismatch(pieces, "da")
 
 
 def test_a_single_foreign_sentence_does_not_fail_a_good_passage():
     pieces = DANISH.split(". ") * 3 + ["The minister was not available for comment."]
-    assert passage_mismatch(pieces, "da") is None
-
-
-def test_language_code_of_accepts_codes_names_and_language_objects():
-    class FakeLanguage:
-        code = "da"
-
-    assert language_code_of("da") == "da"
-    assert language_code_of("Danish") == "da"
-    assert language_code_of(FakeLanguage()) == "da"
+    assert not passage_mismatch(pieces, "da")
 
 
 def test_generate_in_language_returns_a_good_first_attempt_without_retrying():

--- a/zeeguu/core/test/test_language_check.py
+++ b/zeeguu/core/test/test_language_check.py
@@ -1,0 +1,138 @@
+"""
+Unit tests for the shared LLM output-language check.
+
+No Flask app context or DB — the check works on raw text.
+"""
+
+import pytest
+
+from zeeguu.core.language.language_check import (
+    LanguageMismatchError,
+    check_fields,
+    check_language,
+    check_passage,
+    generate_in_language,
+    language_code_of,
+)
+
+DANISH = (
+    "Regeringen har i dag fremlagt et nyt forslag om klimaet. Forslaget skal "
+    "gøre det billigere at køre i elbil, og det skal samtidig blive dyrere at "
+    "flyve inden for landets grænser. Flere partier har allerede sagt, at de "
+    "bakker op om planen."
+)
+
+ENGLISH = (
+    "The government presented a new proposal about the climate today. The plan "
+    "would make it cheaper to drive an electric car, and at the same time more "
+    "expensive to fly within the country. Several parties have already said "
+    "they support the plan."
+)
+
+GERMAN = (
+    "Die Regierung hat heute einen neuen Vorschlag zum Klima vorgelegt. Der "
+    "Plan soll es billiger machen, ein Elektroauto zu fahren, und gleichzeitig "
+    "teurer, innerhalb des Landes zu fliegen."
+)
+
+
+def test_text_in_the_expected_language_passes():
+    assert check_language(DANISH, "da") is None
+
+
+def test_text_in_another_language_is_caught():
+    mismatch = check_language(ENGLISH, "da", label="summary")
+    assert mismatch.label == "summary"
+    assert mismatch.expected == "da"
+    assert mismatch.detected == "en"
+
+
+def test_confusable_neighbours_are_not_flagged_against_each_other():
+    # langdetect regularly reads Danish as Norwegian; that must not fail a text.
+    assert check_language(DANISH, "no") is None
+
+
+def test_too_short_to_judge_is_not_a_mismatch():
+    # "Can't judge" is a distinct answer from "wrong" — titles live down here.
+    assert check_language("Hej med dig", "da") is None
+
+
+def test_language_langdetect_cannot_check_is_skipped():
+    # Kurdish has no langdetect profile; we can't check it, so we don't block on it.
+    assert check_language(ENGLISH, "ku") is None
+
+
+def test_html_markup_does_not_hide_the_language():
+    html = f"<p>{ENGLISH}</p><p><strong>More</strong> of the same.</p>"
+    assert check_language(html, "da").detected == "en"
+    assert check_language(f"<p>{DANISH}</p>", "da") is None
+
+
+def test_check_fields_reports_one_mismatch_per_wrong_field():
+    mismatches = check_fields(
+        [("A1", DANISH), ("A2", ENGLISH), ("B1", GERMAN)], "da"
+    )
+    assert [m.label for m in mismatches] == ["A2", "B1"]
+
+
+def test_a_wrong_language_half_is_caught_even_when_the_whole_reads_right():
+    # The audio-lesson failure: an all-English first half followed by correct
+    # Danish scores mostly-Danish as one blob and would otherwise pass.
+    pieces = ENGLISH.split(". ") + DANISH.split(". ") + DANISH.split(". ")
+    assert check_passage(pieces, "da") is not None
+
+
+def test_a_single_foreign_sentence_does_not_fail_a_good_passage():
+    pieces = DANISH.split(". ") * 3 + ["The minister was not available for comment."]
+    assert check_passage(pieces, "da") is None
+
+
+def test_language_code_of_accepts_codes_names_and_language_objects():
+    class FakeLanguage:
+        code = "da"
+
+    assert language_code_of("da") == "da"
+    assert language_code_of("Danish") == "da"
+    assert language_code_of(FakeLanguage()) == "da"
+
+
+def test_generate_in_language_returns_a_good_first_attempt_without_retrying():
+    calls = []
+
+    def generate(correction):
+        calls.append(correction)
+        return {"text": DANISH}
+
+    result = generate_in_language(
+        generate, "da", lambda r: [("text", r["text"])], "test"
+    )
+    assert result == {"text": DANISH}
+    assert calls == [""]
+
+
+def test_generate_in_language_retries_with_a_correction_naming_the_problem():
+    calls = []
+    answers = [{"text": ENGLISH}, {"text": DANISH}]
+
+    def generate(correction):
+        calls.append(correction)
+        return answers[len(calls) - 1]
+
+    result = generate_in_language(
+        generate, "da", lambda r: [("text", r["text"])], "test"
+    )
+    assert result == {"text": DANISH}
+    assert calls[0] == ""
+    assert "Danish" in calls[1] and "en" in calls[1]
+
+
+def test_generate_in_language_gives_up_carrying_the_last_result():
+    def generate(correction):
+        return {"assessment": "B1", "text": ENGLISH}
+
+    with pytest.raises(LanguageMismatchError) as caught:
+        generate_in_language(generate, "da", lambda r: [("text", r["text"])], "test")
+
+    # The last result rides along so a caller can keep the parts that are fine.
+    assert caught.value.result["assessment"] == "B1"
+    assert [m.label for m in caught.value.mismatches] == ["text"]

--- a/zeeguu/core/test/test_language_check.py
+++ b/zeeguu/core/test/test_language_check.py
@@ -8,9 +8,9 @@ import pytest
 
 from zeeguu.core.language.language_check import (
     LanguageMismatchError,
-    check_fields,
-    check_language,
-    check_passage,
+    field_mismatches,
+    language_mismatch,
+    passage_mismatch,
     generate_in_language,
     language_code_of,
 )
@@ -37,11 +37,11 @@ GERMAN = (
 
 
 def test_text_in_the_expected_language_passes():
-    assert check_language(DANISH, "da") is None
+    assert language_mismatch(DANISH, "da") is None
 
 
 def test_text_in_another_language_is_caught():
-    mismatch = check_language(ENGLISH, "da", label="summary")
+    mismatch = language_mismatch(ENGLISH, "da", label="summary")
     assert mismatch.label == "summary"
     assert mismatch.expected == "da"
     assert mismatch.detected == "en"
@@ -49,27 +49,27 @@ def test_text_in_another_language_is_caught():
 
 def test_confusable_neighbours_are_not_flagged_against_each_other():
     # langdetect regularly reads Danish as Norwegian; that must not fail a text.
-    assert check_language(DANISH, "no") is None
+    assert language_mismatch(DANISH, "no") is None
 
 
 def test_too_short_to_judge_is_not_a_mismatch():
     # "Can't judge" is a distinct answer from "wrong" — titles live down here.
-    assert check_language("Hej med dig", "da") is None
+    assert language_mismatch("Hej med dig", "da") is None
 
 
 def test_language_langdetect_cannot_check_is_skipped():
     # Kurdish has no langdetect profile; we can't check it, so we don't block on it.
-    assert check_language(ENGLISH, "ku") is None
+    assert language_mismatch(ENGLISH, "ku") is None
 
 
 def test_html_markup_does_not_hide_the_language():
     html = f"<p>{ENGLISH}</p><p><strong>More</strong> of the same.</p>"
-    assert check_language(html, "da").detected == "en"
-    assert check_language(f"<p>{DANISH}</p>", "da") is None
+    assert language_mismatch(html, "da").detected == "en"
+    assert language_mismatch(f"<p>{DANISH}</p>", "da") is None
 
 
-def test_check_fields_reports_one_mismatch_per_wrong_field():
-    mismatches = check_fields(
+def test_field_mismatches_reports_one_per_wrong_field():
+    mismatches = field_mismatches(
         [("A1", DANISH), ("A2", ENGLISH), ("B1", GERMAN)], "da"
     )
     assert [m.label for m in mismatches] == ["A2", "B1"]
@@ -79,12 +79,12 @@ def test_a_wrong_language_half_is_caught_even_when_the_whole_reads_right():
     # The audio-lesson failure: an all-English first half followed by correct
     # Danish scores mostly-Danish as one blob and would otherwise pass.
     pieces = ENGLISH.split(". ") + DANISH.split(". ") + DANISH.split(". ")
-    assert check_passage(pieces, "da") is not None
+    assert passage_mismatch(pieces, "da") is not None
 
 
 def test_a_single_foreign_sentence_does_not_fail_a_good_passage():
     pieces = DANISH.split(". ") * 3 + ["The minister was not available for comment."]
-    assert check_passage(pieces, "da") is None
+    assert passage_mismatch(pieces, "da") is None
 
 
 def test_language_code_of_accepts_codes_names_and_language_objects():

--- a/zeeguu/core/test/test_llm_output_language_policy.py
+++ b/zeeguu/core/test/test_llm_output_language_policy.py
@@ -1,14 +1,15 @@
 """
-What the crawl/simplification path does when the LLM answers in the wrong language.
+What the crawl path does when the LLM answers in the wrong language.
 
 The Aug-2026 bug was silent: Haiku wrote ~half of the summaries for non-English
-articles in English, the assessment still succeeded, and the row was stored. These
-tests pin the policy that replaced "hope the prompt is strong enough" — re-ask
-once naming the mistake, then drop only what is still wrong.
+articles in English, the assessment still succeeded, and the row was stored.
+These tests pin the policy that replaced "hope the prompt is strong enough":
+ask again once naming the mistake, then drop what is still wrong.
 
-No DB: the LLM call is mocked, everything else is parsing and policy.
+No DB and no network — the LLM is mocked; everything else is real parsing.
 """
 
+from contextlib import contextmanager
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -18,28 +19,50 @@ DANISH_SUMMARY = (
     "Regeringen har fremlagt et nyt forslag om klimaet, som skal gøre det "
     "billigere at køre i elbil og dyrere at flyve inden for landets grænser."
 )
-
 ENGLISH_SUMMARY = (
     "The government has presented a new climate proposal that would make it "
     "cheaper to drive an electric car and more expensive to fly within the country."
 )
-
 DANISH_BODY = (
     "Regeringen vil gøre det billigere at køre i elbil. Mange partier er enige "
     "i planen. Forslaget skal nu behandles i Folketinget, og det sker efter "
-    "sommerferien. Flere eksperter mener, at planen er et vigtigt skridt for "
-    "klimaet i Danmark."
+    "sommerferien. Flere eksperter mener, at planen er et vigtigt skridt."
 )
-
 ENGLISH_BODY = (
     "The government wants to make it cheaper to drive an electric car. Many "
     "parties agree with the plan. The proposal will now be discussed in "
-    "parliament, and that will happen after the summer holidays. Experts say "
-    "the plan is an important step for the climate in Denmark."
+    "parliament, and that will happen after the summer holidays."
 )
 
 
-def _assessment(summary, level_summary=None):
+@contextmanager
+def _llm_returning(response, prompt_function):
+    """
+    Put the module's whole LLM path under our control: choose a provider without
+    needing an API key, use a trivial prompt template, and answer every call with
+    `response`. Yields the call mock, so a test can assert how many times we asked
+    — which is how "it retried once" is observed.
+    """
+    with patch.object(
+        sac, "_select_provider_and_key", return_value=("anthropic", "fake-key")
+    ), patch.object(
+        sac, prompt_function, return_value="{title}\n{content}"
+    ), patch.object(
+        sac, "_call_simplification_llm", return_value=(response, "fake-model")
+    ) as llm:
+        yield llm
+
+
+def assessing(response):
+    return _llm_returning(response, "get_assessment_and_summary_prompt")
+
+
+def simplifying(response):
+    return _llm_returning(response, "get_adaptive_simplification_prompt")
+
+
+def an_assessment(summary, level_summary=None):
+    """A well-formed assess+summarize response, with the summaries we want to test."""
     response = (
         "ORIGINAL_LEVEL: B1\n"
         "ARTICLE_TYPE: News\n"
@@ -51,41 +74,8 @@ def _assessment(summary, level_summary=None):
     return response
 
 
-class AssessAndSummarizeLanguageTest(TestCase):
-    """Policy: retry once, then drop the summary — the assessment is kept."""
-
-    def _run(self, response):
-        with patch.object(
-            sac, "_select_provider_and_key", return_value=("anthropic", "fake-key")
-        ), patch.object(
-            sac, "get_assessment_and_summary_prompt", return_value="{title}\n{content}"
-        ), patch.object(
-            sac, "_call_simplification_llm", return_value=(response, "fake-model")
-        ) as call:
-            return sac.assess_and_summarize("Titel", "Indhold", "da"), call
-
-    def test_a_danish_summary_is_kept_and_asked_for_only_once(self):
-        result, call = self._run(_assessment(DANISH_SUMMARY, DANISH_SUMMARY))
-        self.assertEqual(result["original_summary"], DANISH_SUMMARY)
-        self.assertIn("A2", result["level_summaries"])
-        self.assertEqual(call.call_count, 1)
-
-    def test_an_english_summary_on_a_danish_article_is_retried_then_dropped(self):
-        result, call = self._run(_assessment(ENGLISH_SUMMARY, ENGLISH_SUMMARY))
-        self.assertEqual(call.call_count, 2, "should re-ask once before giving up")
-        self.assertEqual(result["original_summary"], "")
-        self.assertEqual(result["level_summaries"], {})
-        # The assessment is language-independent and survives.
-        self.assertEqual(result["original_cefr_level"], "B1")
-        self.assertEqual(result["article_type"], "news")
-
-    def test_only_the_wrong_summary_is_dropped(self):
-        result, _ = self._run(_assessment(DANISH_SUMMARY, ENGLISH_SUMMARY))
-        self.assertEqual(result["original_summary"], DANISH_SUMMARY)
-        self.assertEqual(result["level_summaries"], {})
-
-
-def _simplification(a1_body, a2_body):
+def a_simplification(body):
+    """A well-formed two-level simplification response, with `body` at both levels."""
     return (
         "ORIGINAL_LEVEL: B2\n"
         "ARTICLE_TYPE: News\n"
@@ -93,41 +83,57 @@ def _simplification(a1_body, a2_body):
         f"ORIGINAL_SUMMARY: {DANISH_SUMMARY}\n"
         "SIMPLIFIED_LEVELS: A1, A2\n"
         "A1_TITLE: Nyt klimaforslag\n"
-        f"A1_CONTENT: {a1_body}\n"
+        f"A1_CONTENT: {body}\n"
         f"A1_SUMMARY: {DANISH_SUMMARY}\n"
         "A2_TITLE: Nyt klimaforslag fra regeringen\n"
-        f"A2_CONTENT: {a2_body}\n"
+        f"A2_CONTENT: {body}\n"
         f"A2_SUMMARY: {DANISH_SUMMARY}\n"
     )
 
 
+class AssessAndSummarizeLanguageTest(TestCase):
+    """Policy: ask again once, then drop the summary — the assessment is kept."""
+
+    def test_a_danish_summary_is_kept_and_asked_for_only_once(self):
+        with assessing(an_assessment(DANISH_SUMMARY, DANISH_SUMMARY)) as llm:
+            result = sac.assess_and_summarize("Titel", "Indhold", "da")
+
+        self.assertEqual(result["original_summary"], DANISH_SUMMARY)
+        self.assertIn("A2", result["level_summaries"])
+        self.assertEqual(llm.call_count, 1)
+
+    def test_an_english_summary_on_a_danish_article_is_retried_then_dropped(self):
+        with assessing(an_assessment(ENGLISH_SUMMARY, ENGLISH_SUMMARY)) as llm:
+            result = sac.assess_and_summarize("Titel", "Indhold", "da")
+
+        self.assertEqual(llm.call_count, 2, "should ask again before giving up")
+        self.assertEqual(result["original_summary"], "")
+        self.assertEqual(result["level_summaries"], {})
+        # The assessment has no language of its own, so it survives.
+        self.assertEqual(result["original_cefr_level"], "B1")
+        self.assertEqual(result["article_type"], "news")
+
+    def test_only_the_wrong_summary_is_dropped(self):
+        with assessing(an_assessment(DANISH_SUMMARY, ENGLISH_SUMMARY)):
+            result = sac.assess_and_summarize("Titel", "Indhold", "da")
+
+        self.assertEqual(result["original_summary"], DANISH_SUMMARY)
+        self.assertEqual(result["level_summaries"], {})
+
+
 class AdaptiveSimplificationLanguageTest(TestCase):
-    """Policy: retry once, then drop that level — the good levels are kept."""
+    """Policy: ask again once, then fail the run — nothing is salvaged."""
 
-    def _run(self, response):
-        with patch.object(
-            sac, "_select_provider_and_key", return_value=("deepseek", "fake-key")
-        ), patch.object(
-            sac, "get_adaptive_simplification_prompt", return_value="{title}\n{content}"
-        ), patch.object(
-            sac, "_call_simplification_llm", return_value=(response, "fake-model")
-        ) as call:
-            return (
-                sac.simplify_article_adaptive_levels("Titel", "Indhold", "da"),
-                call,
-            )
+    def test_a_danish_simplification_is_kept_and_asked_for_only_once(self):
+        with simplifying(a_simplification(DANISH_BODY)) as llm:
+            result = sac.simplify_article_adaptive_levels("Titel", "Indhold", "da")
 
-    def test_all_danish_levels_are_kept(self):
-        result, call = self._run(_simplification(DANISH_BODY, DANISH_BODY))
         self.assertEqual(result["simplified_levels"], ["A1", "A2"])
-        self.assertEqual(call.call_count, 1)
+        self.assertEqual(llm.call_count, 1)
 
-    def test_an_english_level_is_dropped_and_the_danish_one_survives(self):
-        result, call = self._run(_simplification(DANISH_BODY, ENGLISH_BODY))
-        self.assertEqual(call.call_count, 2, "should re-ask once before giving up")
-        self.assertEqual(result["simplified_levels"], ["A1"])
-        self.assertEqual(list(result["versions"]), ["A1"])
+    def test_an_english_simplification_is_retried_then_fails(self):
+        with simplifying(a_simplification(ENGLISH_BODY)) as llm:
+            with self.assertRaises(Exception):
+                sac.simplify_article_adaptive_levels("Titel", "Indhold", "da")
 
-    def test_a_run_with_no_surviving_level_fails(self):
-        with self.assertRaises(Exception):
-            self._run(_simplification(ENGLISH_BODY, ENGLISH_BODY))
+        self.assertEqual(llm.call_count, 2, "should ask again before giving up")

--- a/zeeguu/core/test/test_llm_output_language_policy.py
+++ b/zeeguu/core/test/test_llm_output_language_policy.py
@@ -1,0 +1,133 @@
+"""
+What the crawl/simplification path does when the LLM answers in the wrong language.
+
+The Aug-2026 bug was silent: Haiku wrote ~half of the summaries for non-English
+articles in English, the assessment still succeeded, and the row was stored. These
+tests pin the policy that replaced "hope the prompt is strong enough" — re-ask
+once naming the mistake, then drop only what is still wrong.
+
+No DB: the LLM call is mocked, everything else is parsing and policy.
+"""
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from zeeguu.core.llm_services import simplification_and_classification as sac
+
+DANISH_SUMMARY = (
+    "Regeringen har fremlagt et nyt forslag om klimaet, som skal gøre det "
+    "billigere at køre i elbil og dyrere at flyve inden for landets grænser."
+)
+
+ENGLISH_SUMMARY = (
+    "The government has presented a new climate proposal that would make it "
+    "cheaper to drive an electric car and more expensive to fly within the country."
+)
+
+DANISH_BODY = (
+    "Regeringen vil gøre det billigere at køre i elbil. Mange partier er enige "
+    "i planen. Forslaget skal nu behandles i Folketinget, og det sker efter "
+    "sommerferien. Flere eksperter mener, at planen er et vigtigt skridt for "
+    "klimaet i Danmark."
+)
+
+ENGLISH_BODY = (
+    "The government wants to make it cheaper to drive an electric car. Many "
+    "parties agree with the plan. The proposal will now be discussed in "
+    "parliament, and that will happen after the summer holidays. Experts say "
+    "the plan is an important step for the climate in Denmark."
+)
+
+
+def _assessment(summary, level_summary=None):
+    response = (
+        "ORIGINAL_LEVEL: B1\n"
+        "ARTICLE_TYPE: News\n"
+        "DISTURBING_CONTENT: NO\n"
+        f"ORIGINAL_SUMMARY: {summary}\n"
+    )
+    if level_summary:
+        response += f"A2_SUMMARY: {level_summary}\n"
+    return response
+
+
+class AssessAndSummarizeLanguageTest(TestCase):
+    """Policy: retry once, then drop the summary — the assessment is kept."""
+
+    def _run(self, response):
+        with patch.object(
+            sac, "_select_provider_and_key", return_value=("anthropic", "fake-key")
+        ), patch.object(
+            sac, "get_assessment_and_summary_prompt", return_value="{title}\n{content}"
+        ), patch.object(
+            sac, "_call_simplification_llm", return_value=(response, "fake-model")
+        ) as call:
+            return sac.assess_and_summarize("Titel", "Indhold", "da"), call
+
+    def test_a_danish_summary_is_kept_and_asked_for_only_once(self):
+        result, call = self._run(_assessment(DANISH_SUMMARY, DANISH_SUMMARY))
+        self.assertEqual(result["original_summary"], DANISH_SUMMARY)
+        self.assertIn("A2", result["level_summaries"])
+        self.assertEqual(call.call_count, 1)
+
+    def test_an_english_summary_on_a_danish_article_is_retried_then_dropped(self):
+        result, call = self._run(_assessment(ENGLISH_SUMMARY, ENGLISH_SUMMARY))
+        self.assertEqual(call.call_count, 2, "should re-ask once before giving up")
+        self.assertEqual(result["original_summary"], "")
+        self.assertEqual(result["level_summaries"], {})
+        # The assessment is language-independent and survives.
+        self.assertEqual(result["original_cefr_level"], "B1")
+        self.assertEqual(result["article_type"], "news")
+
+    def test_only_the_wrong_summary_is_dropped(self):
+        result, _ = self._run(_assessment(DANISH_SUMMARY, ENGLISH_SUMMARY))
+        self.assertEqual(result["original_summary"], DANISH_SUMMARY)
+        self.assertEqual(result["level_summaries"], {})
+
+
+def _simplification(a1_body, a2_body):
+    return (
+        "ORIGINAL_LEVEL: B2\n"
+        "ARTICLE_TYPE: News\n"
+        "DISTURBING_CONTENT: NO\n"
+        f"ORIGINAL_SUMMARY: {DANISH_SUMMARY}\n"
+        "SIMPLIFIED_LEVELS: A1, A2\n"
+        "A1_TITLE: Nyt klimaforslag\n"
+        f"A1_CONTENT: {a1_body}\n"
+        f"A1_SUMMARY: {DANISH_SUMMARY}\n"
+        "A2_TITLE: Nyt klimaforslag fra regeringen\n"
+        f"A2_CONTENT: {a2_body}\n"
+        f"A2_SUMMARY: {DANISH_SUMMARY}\n"
+    )
+
+
+class AdaptiveSimplificationLanguageTest(TestCase):
+    """Policy: retry once, then drop that level — the good levels are kept."""
+
+    def _run(self, response):
+        with patch.object(
+            sac, "_select_provider_and_key", return_value=("deepseek", "fake-key")
+        ), patch.object(
+            sac, "get_adaptive_simplification_prompt", return_value="{title}\n{content}"
+        ), patch.object(
+            sac, "_call_simplification_llm", return_value=(response, "fake-model")
+        ) as call:
+            return (
+                sac.simplify_article_adaptive_levels("Titel", "Indhold", "da"),
+                call,
+            )
+
+    def test_all_danish_levels_are_kept(self):
+        result, call = self._run(_simplification(DANISH_BODY, DANISH_BODY))
+        self.assertEqual(result["simplified_levels"], ["A1", "A2"])
+        self.assertEqual(call.call_count, 1)
+
+    def test_an_english_level_is_dropped_and_the_danish_one_survives(self):
+        result, call = self._run(_simplification(DANISH_BODY, ENGLISH_BODY))
+        self.assertEqual(call.call_count, 2, "should re-ask once before giving up")
+        self.assertEqual(result["simplified_levels"], ["A1"])
+        self.assertEqual(list(result["versions"]), ["A1"])
+
+    def test_a_run_with_no_surviving_level_fails(self):
+        with self.assertRaises(Exception):
+            self._run(_simplification(ENGLISH_BODY, ENGLISH_BODY))

--- a/zeeguu/core/test/test_script_language_validator.py
+++ b/zeeguu/core/test/test_script_language_validator.py
@@ -51,23 +51,73 @@ Teacher: Ask, where shall we meet? [5 seconds]
 Man: Where shall we meet? [3 seconds]
 """
 
-# The inverse: the teacher explains in the language being learned instead of the
-# learner's native language.
-GERMAN_LESSON_TEACHER_NOT_IN_ROMANIAN = """
-Teacher: In der folgenden Unterhaltung hören Sie das Wort: [0.2 seconds]
-TeacherL2: gemütlich [0.5 seconds]
-Teacher: Das bedeutet, dass ein Ort angenehm und warm ist. [1 seconds]
-Man: Hallo Anna, wollen wir heute Abend etwas trinken gehen? [1 seconds]
-Woman: Ja, gerne. Wo möchtest du dich denn treffen? [1 seconds]
-Man: Es gibt ein sehr gemütliches Café unten am Hafen. [1 seconds]
-Woman: Das klingt gut. Ich komme um sieben Uhr dorthin. [1 seconds]
-Man: Wunderbar, ich freue mich sehr auf heute Abend. [1 seconds]
-Woman: Ich mich auch. Bis später dann, mein lieber Freund. [1 seconds]
-Teacher: Lassen Sie uns jetzt einige wichtige Sätze üben. [1 seconds]
-Teacher: Sagen Sie, wo möchtest du dich treffen? [5 seconds]
-Man: Wo möchtest du dich treffen? [3 seconds]
-Teacher: Fragen Sie, wollen wir heute Abend etwas trinken gehen? [5 seconds]
-Man: Wollen wir heute Abend etwas trinken gehen? [3 seconds]
+# Abridged from production dialogue 235 (Danish, A2, generated 2026-08-16). The
+# opening conversation — the part a learner hears first, and for two solid minutes —
+# is entirely English; the practice phrases after it are correctly Danish. The whole
+# script scores 71% Danish, so checking it as one blob passes it.
+DANISH_LESSON_ENGLISH_DIALOGUE_DANISH_PRACTICE = """
+Teacher: Today, we will listen to a conversation about strength training. [0.5 seconds]
+Man: I think we should do strength training at home. It is easy and cheap. [1 seconds]
+Woman: That is a good idea. But what exercises can we do here? [1 seconds]
+Man: We can do push-ups and squats. They are very good for the body. [1 seconds]
+Woman: I like squats. But push-ups are hard for me. [1 seconds]
+Man: That is okay. You can start with a few and do more later. [1 seconds]
+Woman: How many times a week should we train? [1 seconds]
+Man: I think three times a week is good for us. [1 seconds]
+Woman: Should we use weights too? [1 seconds]
+Man: Yes, we can use small weights for our arms. [1 seconds]
+Woman: I do not have weights at home. Can we buy some? [1 seconds]
+Man: Yes, we can buy two small weights at the sports shop. [1 seconds]
+Woman: Great. And what about rest days? [1 seconds]
+Man: Rest days are important. Our muscles need time to grow stronger. [1 seconds]
+Woman: That makes sense. Let us start on Monday then. [1 seconds]
+Man: Perfect. We will train together and help each other. [1 seconds]
+Teacher: Let us practice some key phrases from the conversation. [1 seconds]
+Teacher: Tell your partner that you like squats. [5 seconds]
+Man: Jeg kan godt lide squats. [3 seconds]
+Teacher: Ask your partner how many times a week you should train. [5 seconds]
+Woman: Hvor mange gange om ugen skal vi træne? [3 seconds]
+Teacher: Say that you think three times a week is good for you. [5 seconds]
+Man: Jeg synes, tre gange om ugen er godt for os. [3 seconds]
+Teacher: Tell your partner that push-ups are hard for you. [5 seconds]
+Woman: Armstrækninger er svære for mig. [3 seconds]
+Teacher: Ask your partner if you should use weights. [5 seconds]
+Man: Skal vi bruge vægte? [3 seconds]
+Teacher: Say that rest days are important for your muscles. [5 seconds]
+Woman: Hviledage er vigtige for vores muskler. [3 seconds]
+Teacher: Tell your partner that you can start with a few exercises. [5 seconds]
+Man: Jeg kan starte med et par øvelser. [3 seconds]
+Teacher: Ask your partner if you can buy small weights at the shop. [5 seconds]
+Woman: Kan vi købe små vægte i butikken? [3 seconds]
+Teacher: Tell your friend that you want to get stronger. [5 seconds]
+Man: Jeg vil gerne blive stærkere. [3 seconds]
+Teacher: Ask your friend if they have a training mat. [5 seconds]
+Woman: Har du en træningsmåtte? [3 seconds]
+"""
+
+# Abridged from production lesson 1043 (English course, Ukrainian-speaking teacher).
+# This script is CORRECT. The teacher's lines are bilingual by design — a Ukrainian
+# lead-in plus the exact English sentence the listener must produce — so the teacher
+# reads as English by volume. Checking the teacher would fail a good lesson.
+ENGLISH_LESSON_WITH_UKRAINIAN_TEACHER = """
+Teacher: У наступній розмові ви почуєте слово: [0.2 seconds]
+TeacherL2: says [0.5 seconds]
+Teacher: зі значенням говорить. [1 seconds]
+Man: The news says it will rain tomorrow evening. [1 seconds]
+Woman: Really? My weather app says something completely different. [1 seconds]
+Man: It says the temperature will drop too, quite sharply. [1 seconds]
+Woman: Well, the forecast is never very accurate around here. [1 seconds]
+Man: True. My friend always says the news is more accurate. [1 seconds]
+Woman: Maybe. What does your app say about the weekend? [1 seconds]
+Teacher: Давайте попрактикуємо ключові фрази. [1 seconds]
+Teacher: Скажіть, the news says it will rain tomorrow. [5 seconds]
+Man: The news says it will rain tomorrow. [3 seconds]
+Teacher: Спробуйте, it says the temperature will drop too. [5 seconds]
+Man: It says the temperature will drop too. [3 seconds]
+Teacher: Тепер скажіть, my weather app says something different. [5 seconds]
+Man: My weather app says something different. [3 seconds]
+Teacher: Запитайте, what does your app say? [5 seconds]
+Man: What does your app say? [3 seconds]
 """
 
 GERMAN_LESSON_WITH_ROMANIAN_TEACHER = """
@@ -95,18 +145,28 @@ def test_correct_danish_lesson_passes():
 def test_danish_lesson_written_in_english_is_caught():
     mismatches = find_language_mismatches(DANISH_LESSON_GONE_ENGLISH, "da", "en")
     assert len(mismatches) == 1
-    assert mismatches[0].voices == "Man/Woman/TeacherL2"
+    assert mismatches[0].label == "Man/Woman/TeacherL2"
     assert mismatches[0].expected == "da"
     assert mismatches[0].detected == "en"
 
 
-def test_teacher_speaking_the_learned_language_is_caught():
+def test_english_dialogue_followed_by_danish_practice_is_caught():
+    # Production dialogue 235: the half a learner hears first was English. Checking
+    # the target-language lines as one blob scores 71% Danish and passes, which is
+    # how this reached a real daily lesson.
     mismatches = find_language_mismatches(
-        GERMAN_LESSON_TEACHER_NOT_IN_ROMANIAN, "de", "ro"
+        DANISH_LESSON_ENGLISH_DIALOGUE_DANISH_PRACTICE, "da", "en"
     )
-    assert [m.voices for m in mismatches] == ["Teacher"]
-    assert mismatches[0].expected == "ro"
-    assert mismatches[0].detected == "de"
+    assert len(mismatches) == 1
+    assert mismatches[0].expected == "da"
+    assert mismatches[0].detected == "en"
+
+
+def test_bilingual_teacher_lines_do_not_fail_a_good_lesson():
+    # Production lesson 1043. The teacher's challenges embed the English target
+    # sentence, so the teacher's lines read as English even though the lesson is
+    # correct. Only the target-language voices are judged.
+    assert find_language_mismatches(ENGLISH_LESSON_WITH_UKRAINIAN_TEACHER, "en", "uk") == []
 
 
 def test_correct_german_lesson_with_romanian_teacher_passes():

--- a/zeeguu/core/test/test_script_language_validator.py
+++ b/zeeguu/core/test/test_script_language_validator.py
@@ -1,0 +1,128 @@
+"""
+Unit tests for the audio-lesson script language check.
+
+No Flask app context or DB — the validator works on the raw script text.
+"""
+
+from zeeguu.core.audio_lessons.script_language_validator import (
+    find_language_mismatches,
+)
+
+DANISH_LESSON = """
+Teacher: In the following conversation you will hear the word: [0.2 seconds]
+TeacherL2: hyggelig [0.5 seconds]
+Teacher: with the meaning [0.2 seconds]
+Teacher: cosy. [1 seconds]
+Man: Hej Mette, skal vi mødes i aften? [1 seconds]
+Woman: Ja, det lyder rigtig hyggeligt. Hvor skal vi mødes? [1 seconds]
+Man: Vi kan mødes på den lille café ved havnen. [1 seconds]
+Woman: Perfekt. Jeg synes altid at der er så hyggeligt der. [1 seconds]
+Man: Vi kan sidde udenfor hvis vejret er godt. [1 seconds]
+Woman: Det håber jeg. Jeg tager min søster med, hvis det er i orden. [1 seconds]
+Man: Selvfølgelig, jo flere jo bedre. Vi ses klokken syv. [1 seconds]
+Woman: Vi ses. Jeg glæder mig rigtig meget til i aften. [1 seconds]
+Teacher: Let's practice some key phrases from the conversation. [1 seconds]
+Teacher: Say, that sounds really cosy. [5 seconds]
+Man: Det lyder rigtig hyggeligt. [3 seconds]
+Teacher: Ask, where shall we meet? [5 seconds]
+Man: Hvor skal vi mødes? [3 seconds]
+Teacher: Now say, I am really looking forward to tonight. [5 seconds]
+Man: Jeg glæder mig rigtig meget til i aften. [3 seconds]
+"""
+
+# The failure we're guarding against: a "Danish" lesson written entirely in English.
+DANISH_LESSON_GONE_ENGLISH = """
+Teacher: In the following conversation you will hear the word: [0.2 seconds]
+TeacherL2: cosy [0.5 seconds]
+Teacher: with the meaning [0.2 seconds]
+Teacher: cosy. [1 seconds]
+Man: Hi Mette, shall we meet tonight? [1 seconds]
+Woman: Yes, that sounds really cosy. Where shall we meet? [1 seconds]
+Man: We can meet at the little cafe by the harbour. [1 seconds]
+Woman: Perfect. I always think it is so cosy there. [1 seconds]
+Man: We can sit outside if the weather is good. [1 seconds]
+Woman: I hope so. I will bring my sister if that is all right. [1 seconds]
+Man: Of course, the more the merrier. See you at seven. [1 seconds]
+Woman: See you. I am really looking forward to tonight. [1 seconds]
+Teacher: Let's practice some key phrases from the conversation. [1 seconds]
+Teacher: Say, that sounds really cosy. [5 seconds]
+Man: That sounds really cosy. [3 seconds]
+Teacher: Ask, where shall we meet? [5 seconds]
+Man: Where shall we meet? [3 seconds]
+"""
+
+# The inverse: the teacher explains in the language being learned instead of the
+# learner's native language.
+GERMAN_LESSON_TEACHER_NOT_IN_ROMANIAN = """
+Teacher: In der folgenden Unterhaltung hören Sie das Wort: [0.2 seconds]
+TeacherL2: gemütlich [0.5 seconds]
+Teacher: Das bedeutet, dass ein Ort angenehm und warm ist. [1 seconds]
+Man: Hallo Anna, wollen wir heute Abend etwas trinken gehen? [1 seconds]
+Woman: Ja, gerne. Wo möchtest du dich denn treffen? [1 seconds]
+Man: Es gibt ein sehr gemütliches Café unten am Hafen. [1 seconds]
+Woman: Das klingt gut. Ich komme um sieben Uhr dorthin. [1 seconds]
+Man: Wunderbar, ich freue mich sehr auf heute Abend. [1 seconds]
+Woman: Ich mich auch. Bis später dann, mein lieber Freund. [1 seconds]
+Teacher: Lassen Sie uns jetzt einige wichtige Sätze üben. [1 seconds]
+Teacher: Sagen Sie, wo möchtest du dich treffen? [5 seconds]
+Man: Wo möchtest du dich treffen? [3 seconds]
+Teacher: Fragen Sie, wollen wir heute Abend etwas trinken gehen? [5 seconds]
+Man: Wollen wir heute Abend etwas trinken gehen? [3 seconds]
+"""
+
+GERMAN_LESSON_WITH_ROMANIAN_TEACHER = """
+Teacher: În următoarea conversație veți auzi cuvântul: [0.2 seconds]
+TeacherL2: gemütlich [0.5 seconds]
+Teacher: cu sensul de confortabil și primitor. [1 seconds]
+Man: Hallo Anna, wollen wir heute Abend etwas trinken gehen? [1 seconds]
+Woman: Ja, gerne. Wo möchtest du dich denn treffen? [1 seconds]
+Man: Es gibt ein sehr gemütliches Café unten am Hafen. [1 seconds]
+Woman: Das klingt gut. Ich komme um sieben Uhr dorthin. [1 seconds]
+Man: Wunderbar, ich freue mich sehr auf heute Abend. [1 seconds]
+Woman: Ich mich auch. Bis später dann, mein lieber Freund. [1 seconds]
+Teacher: Acum să exersăm câteva expresii din conversație. [1 seconds]
+Teacher: Spuneți, unde vrei să ne întâlnim diseară? [5 seconds]
+Man: Wo möchtest du dich treffen? [3 seconds]
+Teacher: Întrebați, mergem să bem ceva diseară? [5 seconds]
+Man: Wollen wir heute Abend etwas trinken gehen? [3 seconds]
+"""
+
+
+def test_correct_danish_lesson_passes():
+    assert find_language_mismatches(DANISH_LESSON, "da", "en") == []
+
+
+def test_danish_lesson_written_in_english_is_caught():
+    mismatches = find_language_mismatches(DANISH_LESSON_GONE_ENGLISH, "da", "en")
+    assert len(mismatches) == 1
+    assert mismatches[0].voices == "Man/Woman/TeacherL2"
+    assert mismatches[0].expected == "da"
+    assert mismatches[0].detected == "en"
+
+
+def test_teacher_speaking_the_learned_language_is_caught():
+    mismatches = find_language_mismatches(
+        GERMAN_LESSON_TEACHER_NOT_IN_ROMANIAN, "de", "ro"
+    )
+    assert [m.voices for m in mismatches] == ["Teacher"]
+    assert mismatches[0].expected == "ro"
+    assert mismatches[0].detected == "de"
+
+
+def test_correct_german_lesson_with_romanian_teacher_passes():
+    assert find_language_mismatches(GERMAN_LESSON_WITH_ROMANIAN_TEACHER, "de", "ro") == []
+
+
+def test_scandinavian_neighbours_are_not_flagged_against_each_other():
+    # langdetect regularly reads short Danish sentences as Norwegian or Swedish;
+    # that must not fail a lesson.
+    assert find_language_mismatches(DANISH_LESSON, "no", "en") == []
+
+
+def test_language_langdetect_cannot_check_is_skipped():
+    # Kurdish has no langdetect profile — we can't check it, so we don't block on it.
+    assert find_language_mismatches(DANISH_LESSON_GONE_ENGLISH, "ku", "ku") == []
+
+
+def test_too_short_to_judge_is_not_flagged():
+    assert find_language_mismatches("Man: Hej. [1 seconds]", "da", "en") == []

--- a/zeeguu/core/test/test_usable_simplified_versions.py
+++ b/zeeguu/core/test/test_usable_simplified_versions.py
@@ -1,0 +1,56 @@
+"""
+Which children of an article may be offered as a *level* of it.
+
+Two things hang off parent_article_id: same-language level adaptations, and the
+translated copy a friend-share makes for a recipient learning another language.
+Only the first kind is a level of this article — the second is a legitimately
+foreign-language article that happens to share a parent, and handing it to a
+learner of the parent's language is a silent language failure of exactly the kind
+zeeguu.core.language.language_check exists to prevent.
+"""
+from unittest import TestCase
+
+import zeeguu.core
+from zeeguu.core.model.article import MARKED_BROKEN_DUE_TO_LOW_QUALITY
+from zeeguu.core.test.model_test_mixin import ModelTestMixIn
+from zeeguu.core.test.rules.article_rule import ArticleRule
+from zeeguu.core.test.rules.language_rule import LanguageRule
+
+session = zeeguu.core.model.db.session
+
+
+class UsableSimplifiedVersionsTest(ModelTestMixIn, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.original = ArticleRule().article
+
+    def _child(self, language, cefr_level="A2"):
+        child = ArticleRule().article
+        child.parent_article_id = self.original.id
+        child.language = language
+        child.cefr_level = cefr_level
+        session.add(child)
+        session.commit()
+        return child
+
+    def _another_language(self):
+        language = LanguageRule().random
+        while language.id == self.original.language_id:
+            language = LanguageRule().random
+        return language
+
+    def test_a_same_language_child_is_a_level_of_the_article(self):
+        child = self._child(self.original.language)
+        assert child in self.original.usable_simplified_versions
+
+    def test_a_friend_share_translation_is_not_a_level_of_the_article(self):
+        translated = self._child(self._another_language())
+        assert translated in self.original.simplified_versions
+        assert translated not in self.original.usable_simplified_versions
+
+    def test_a_child_marked_broken_is_not_offered(self):
+        child = self._child(self.original.language)
+        child.broken = MARKED_BROKEN_DUE_TO_LOW_QUALITY
+        session.add(child)
+        session.commit()
+        assert child not in self.original.usable_simplified_versions


### PR DESCRIPTION
Implements `docs/future-work/llm-output-language-verification.md`.

## Why

We keep shipping English where a learner expected their target language, and we keep finding out from the learner rather than from the system. Two instances a day apart:

- **Aug 15** — crawl-time summaries. A weak language directive left ~50% of non-English summaries silently English (fixed in `7cd9d6c` by strengthening the prompt).
- **Aug 16** — a Danish daily audio lesson whose entire script was English (fixed in `5c6d321` by *checking the output*).

Both are silent by construction: the pipeline succeeds, the row is written, and it is usually cached and reused. Prompt-strengthening lowers the rate; only checking the output finds the residue. `5c6d321` established the pattern for lesson scripts — this generalizes it.

## What's here

**`zeeguu/core/language/language_check.py`** — the shared detection, carrying the three calibrations the audio-lesson work paid for:

- a **fixed langdetect seed** (it samples internally, so the same text passed on one call and failed on the next);
- **confusable families** (`{da,no,sv}`, `{cs,sk}`, …) — langdetect reads short Danish as Norwegian, and the failure worth catching is a whole text in the wrong language, not a marginal misread;
- **"can't judge" as an answer distinct from "wrong"** — under ~60 chars, or a language with no profile (Kurdish and Serbian are both offered as native languages). Neither may block.

`check_passage` adds chunking for long multi-part text, so a script that is English for its first half and correct Danish afterwards no longer averages out to a pass. `script_language_validator.py` reduces to the voice-label grouping on top of it.

**Policy stays at the call site**, because it genuinely differs:

| Call site | On mismatch |
|---|---|
| `assess_and_summarize` | retry once, then drop the summaries — the CEFR assessment is language-independent and kept |
| `simplify_article_adaptive_levels` | retry once, then fail the run |
| `simplify_text` | retry, then `None` (callers handle it) |
| `translate_and_adapt` | retry, then `None` — highest risk in the codebase: a translation task where "left it in the source language" is the likely failure |
| example generation | retry, then fail into the existing DeepSeek fallback |
| grammar correction | no retry — discard the correction, keep the uncorrected text, as it already does on error |

`LanguageMismatchError` carries the last result alongside the mismatches, which is what makes the partial-salvage policies expressible.

**`tools/audit_stored_article_languages.py`** — retrofits the check onto what's already stored (`article.summary`, `ArticleLevelSummary.summary`, and child articles), reporting by default with an opt-in `--fix`. Everything is judged against the language of the row itself, never the parent's, so friend-share translations are reported separately and a German child of a Danish article is correctly expected to be German. `tools/backfill_reassess_summaries.py` drops its hand-rolled Danish/English stopword counter for the shared check, so it now works for every language.

## One live bug found along the way

Marking a wrong-language simplified article broken did nothing, because nothing filtered broken children out of the reuse path — hence `Article.available_simplified_versions`. Building it surfaced the real problem: `simplified_versions` is the raw `parent_article_id` backref, so it also holds **friend-share translations**, and a German copy of a Danish article was being offered as its B1 version to Danish learners. The property filters on language too, and the five consumers that decide what a reader is offered now go through it. `test_available_simplified_versions.py` pins it.

This also pays off the load-bearing step of `unify-translated-copies-onto-parent.md` (the language-safety audit), leaving that cleanup mechanical.

## Testing

`zeeguu/core/test` — 244 passed. New: `test_language_check.py`, `test_llm_output_language_policy.py` (regression tests for the Aug-15 drop-the-summary policy, with mocked LLM responses), and `test_available_simplified_versions.py`.

## Note for review

Two changes go slightly beyond the design doc, both needed to make `--fix` actually cause regeneration: the `available_simplified_versions` sweep above, and skipping broken copies in the two friend-share `#translated-from` cache lookups. Happy to split either out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Since first review

Four commits followed the review on this PR:

- **`936d979b`** — `--fix` could not have completed on prod: deleting an
  `ArticleLevelSummary` hits a real FK from `ArticleLevelSummaryContext` (bookmark
  anchors, no cascade), and nulling `article.summary` left the cached tokenized
  copy behind, which is only ever written when empty and so would have outlived
  the repair. Plus a guard for articles with no language.
- **`067b8d78`** — naming: `check_language`/`check_fields`/`check_passage` →
  `language_mismatch`/`field_mismatches`/`passage_mismatch`, since they return a
  mismatch or nothing; `usable_` → `available_simplified_versions`. And the
  per-level salvage is gone — a level has never come back wrong on its own, and
  that path only runs behind `SIMPLIFY_AT_CRAWL` (default false).
- **`8da54178`** — the MWE check removed: word translations average 16
  characters and only 1.9% of the 213,072 stored ones are long enough for
  langdetect to judge, so it answered "can't judge" ~98 times in 100.

The `system=` parameter on the two provider `generate_text` methods has no caller
in this PR: it is the lower half of the audio-lesson commit stacked on this
branch, and lands with it.
