### PR TITLE
State the output language in the system prompt, and record which model wrote each script

### DIFF
--- a/tools/audio-engleza/generate_lesson.py
+++ b/tools/audio-engleza/generate_lesson.py
@@ -29,7 +29,7 @@ LESSON_INDEX_FILE = os.path.join(WEBSITE_DIR, "lessons.json")
 def generate_script(english_phrase, romanian_translation):
     """Generate the lesson script for review"""
     
-    script = generate_lesson_script(
+    generated = generate_lesson_script(
         origin_word=english_phrase,
         translation_word=romanian_translation,
         origin_language="en",
@@ -37,6 +37,7 @@ def generate_script(english_phrase, romanian_translation):
         cefr_level="A1",
         generator_prompt_file="basic_english_for_elderly_romanian.txt",
     )
+    script = generated.script
     
     return script
 

--- a/tools/audio-engleza/generate_script.py
+++ b/tools/audio-engleza/generate_script.py
@@ -44,7 +44,7 @@ def generate_script_file(english_phrase, romanian_translation, output_file=None)
             # Use local prompt file
             local_prompt_path = os.path.join(os.path.dirname(__file__), "basic_english_for_elderly_romanian.txt")
             
-            script = generate_lesson_script(
+            generated = generate_lesson_script(
                 origin_word=english_phrase,
                 translation_word=romanian_translation,
                 origin_language="en",
@@ -52,6 +52,7 @@ def generate_script_file(english_phrase, romanian_translation, output_file=None)
                 cefr_level="A1",
                 generator_prompt_file=local_prompt_path,
             )
+            script = generated.script
             
             # Add metadata header to script file
             header = f"""# Audio-Engleza Lesson Script

--- a/tools/audit_audio_lesson_script_languages.py
+++ b/tools/audit_audio_lesson_script_languages.py
@@ -13,6 +13,13 @@ Usage:
     python -m tools.audit_audio_lesson_script_languages                 # report only
     python -m tools.audit_audio_lesson_script_languages --language da   # one learned language
     python -m tools.audit_audio_lesson_script_languages --deprecate     # mark the bad ones
+    python -m tools.audit_audio_lesson_script_languages --quiet         # print only if something is wrong
+
+--quiet is for the nightly cron: a clean run prints nothing at all, so cron stays
+silent and any output is a real finding. This is the safety net under the
+generation-time check, which is a tuned heuristic and has been wrong in both
+directions; a script it wrongly passes leaves no log line anywhere, and sweeping
+what is already stored is the only thing that finds it.
 
 --deprecate sets deprecated_at, so cache lookups regenerate while daily lessons
 that already reference the row keep playing.
@@ -36,14 +43,32 @@ from zeeguu.core.model.audio_lesson_dialogue import AudioLessonDialogue
 from zeeguu.core.model.audio_lesson_meaning import AudioLessonMeaning
 
 DEPRECATE = "--deprecate" in sys.argv
+QUIET = "--quiet" in sys.argv
 LANGUAGE = None
 if "--language" in sys.argv:
     LANGUAGE = sys.argv[sys.argv.index("--language") + 1]
 
-print(f"Mode: {'DEPRECATE bad scripts' if DEPRECATE else 'REPORT ONLY'}")
+_buffered = []
+
+
+def out(line=""):
+    """Under --quiet, hold everything back until we know there is a finding."""
+    if QUIET:
+        _buffered.append(line)
+    else:
+        print(line)
+
+
+def flush():
+    for line in _buffered:
+        print(line)
+    _buffered.clear()
+
+
+out(f"Mode: {'DEPRECATE bad scripts' if DEPRECATE else 'REPORT ONLY'}")
 if LANGUAGE:
-    print(f"Learned language filter: {LANGUAGE}")
-print()
+    out(f"Learned language filter: {LANGUAGE}")
+out()
 
 
 def teacher_code(lesson):
@@ -52,9 +77,9 @@ def teacher_code(lesson):
 
 def audit(label, lessons, learned_code_of, describe):
     """Check each lesson's script and return the ones whose language is wrong."""
-    print("=" * 70)
-    print(f"{label}: {len(lessons)} to check")
-    print("=" * 70)
+    out("=" * 70)
+    out(f"{label}: {len(lessons)} to check")
+    out("=" * 70)
 
     bad = []
     for lesson in lessons:
@@ -66,11 +91,11 @@ def audit(label, lessons, learned_code_of, describe):
         )
         if mismatches:
             bad.append(lesson)
-            print(f"  [{lesson.id}] {describe(lesson)} ({learned}/{teacher_code(lesson)})")
-            print(f"      {describe_mismatches(mismatches)}")
+            out(f"  [{lesson.id}] {describe(lesson)} ({learned}/{teacher_code(lesson)})")
+            out(f"      {describe_mismatches(mismatches)}")
 
-    print(f"  → {len(bad)} with a wrong-language script")
-    print()
+    out(f"  → {len(bad)} with a wrong-language script")
+    out()
     return bad
 
 
@@ -99,11 +124,14 @@ if DEPRECATE and (bad_meanings or bad_dialogues):
     for lesson in bad_meanings + bad_dialogues:
         lesson.deprecated_at = now
     db.session.commit()
-    print(
+    out(
         f"Deprecated {len(bad_meanings)} meaning lessons and "
         f"{len(bad_dialogues)} dialogues. They will be regenerated on next request."
     )
 elif bad_meanings or bad_dialogues:
-    print("Run again with --deprecate to mark these for regeneration.")
+    out("Run again with --deprecate to mark these for regeneration.")
 else:
-    print("No wrong-language scripts found.")
+    out("No wrong-language scripts found.")
+
+if QUIET and (bad_meanings or bad_dialogues):
+    flush()

--- a/tools/generate_audio_lesson.py
+++ b/tools/generate_audio_lesson.py
@@ -8,14 +8,15 @@ from zeeguu.core.audio_lessons.voice_synthesizer import VoiceSynthesizer
 target_language = "es"
 cefr_level="A1"
 
-script = generate_lesson_script(
+generated = generate_lesson_script(
     origin_word="mientras",
     translation_word="while",
     origin_language=target_language,
     translation_language="en",
     cefr_level=cefr_level,
-    generator_prompt_file="meaning_lesson--teacher_challenges_both_dialogue_and_beyond-v3.txt",
+    generator_prompt_file="meaning_lesson--teacher_challenges_both_dialogue_and_beyond-v4.txt",
 )
+script = generated.script
 
 print(script)
 

--- a/tools/migrations/26-08-18--add_ai_generator_to_audio_lessons.sql
+++ b/tools/migrations/26-08-18--add_ai_generator_to_audio_lessons.sql
@@ -1,0 +1,17 @@
+-- Record which model and prompt version produced each audio lesson script.
+--
+-- created_by has always been the literal 'claude-v1', so it cannot answer either
+-- question. It matters because the Anthropic->DeepSeek fallback chain means the
+-- configured model is not necessarily the model that served: scripts generated
+-- while the Anthropic spend cap was reached were written by DeepSeek and recorded
+-- as Claude. Nullable, so existing rows stay honest about not knowing.
+
+ALTER TABLE audio_lesson_meaning
+    ADD COLUMN ai_generator_id INT DEFAULT NULL,
+    ADD CONSTRAINT fk_audio_lesson_meaning_ai_generator
+        FOREIGN KEY (ai_generator_id) REFERENCES ai_generator (id);
+
+ALTER TABLE audio_lesson_dialogue
+    ADD COLUMN ai_generator_id INT DEFAULT NULL,
+    ADD CONSTRAINT fk_audio_lesson_dialogue_ai_generator
+        FOREIGN KEY (ai_generator_id) REFERENCES ai_generator (id);

--- a/tools/migrations/26-08-18-b--created_by_nullable_on_audio_lesson_scripts.sql
+++ b/tools/migrations/26-08-18-b--created_by_nullable_on_audio_lesson_scripts.sql
@@ -1,0 +1,14 @@
+-- created_by on the two audio-lesson script tables is superseded by
+-- ai_generator_id (26-08-18--add_ai_generator_to_audio_lessons.sql), which names
+-- the model that actually answered and the prompt version behind it.
+--
+-- Step two of three. The code deployed with this migration stops writing the
+-- column; existing rows keep their value, which is the literal 'claude-v1' on
+-- every one of them — including the scripts DeepSeek wrote while the Anthropic
+-- spend cap was reached. It can only be DROPped in a later deploy, once nothing
+-- running still selects it: SQLAlchemy selects every mapped column, so removing
+-- it while the previous container is still serving would fail every query
+-- against these tables mid blue-green switch.
+
+ALTER TABLE audio_lesson_meaning  MODIFY created_by VARCHAR(255) NULL;
+ALTER TABLE audio_lesson_dialogue MODIFY created_by VARCHAR(255) NULL;

--- a/tools/migrations/26-08-18-c--widen_ai_generator_prompt_version.sql
+++ b/tools/migrations/26-08-18-c--widen_ai_generator_prompt_version.sql
@@ -1,0 +1,15 @@
+-- prompt_version at VARCHAR(50) is a tripwire: a value that does not fit raises
+-- DataError from inside AIGenerator.find_or_create's bare except:, so the caller
+-- sees the generation fail rather than the provenance. The audio-lesson prompt
+-- filename (62 chars) hit it; the next long value would hit it the same way.
+--
+-- 255 matches created_by on the neighbouring tables. It costs one byte per row —
+-- utf8mb4 puts the length prefix at 2 bytes above 63 characters — on a table
+-- that holds one row per (model, prompt) combination. There is no index on the
+-- column, so nothing else changes.
+--
+-- What is STORED stays short on purpose: the family and the version
+-- ('meaning_lesson-v4'), not the whole filename, so rewording a prompt's
+-- description does not look like a new version. This is headroom, not licence.
+
+ALTER TABLE ai_generator MODIFY prompt_version VARCHAR(255) DEFAULT NULL;

--- a/tools/precompute_upcoming_meaning_lessons.py
+++ b/tools/precompute_upcoming_meaning_lessons.py
@@ -203,7 +203,6 @@ def generate_audio_lesson_for_meaning(user, user_word, cefr_level="B1", timeout_
                 origin_language,
                 translation_language,
                 cefr_level,
-                "claude-v1",
             )
 
             db.session.commit()

--- a/tools/precompute_upcoming_meaning_lessons.py
+++ b/tools/precompute_upcoming_meaning_lessons.py
@@ -122,7 +122,10 @@ def generate_audio_lesson_for_meaning(user, user_word, cefr_level="B1", timeout_
         timeout_seconds: Maximum time to spend generating this lesson (default: 10 minutes)
 
     Returns:
-        AudioLessonMeaning object or None if generation fails
+        (AudioLessonMeaning, created) — `created` is False when an existing
+        lesson was reused. Only this function can tell the difference; the
+        caller used to infer it from created_by == "claude-v1", which every row
+        says, so every lesson counted as freshly generated.
     """
     meaning = user_word.meaning
     origin_language = meaning.origin.language.code
@@ -171,14 +174,14 @@ def generate_audio_lesson_for_meaning(user, user_word, cefr_level="B1", timeout_
             output(
                 f"        Audio lesson already exists for: {meaning.origin.content} → {meaning.translation.content} (rank: {rank}, {status})"
             )
-        return existing_lesson
+        return existing_lesson, False
 
     if DRY_RUN:
         rank, status = get_word_display_info()
         output(
             f"        [DRY RUN] Would generate audio for: {meaning.origin.content} → {meaning.translation.content} (rank: {rank}, {status})"
         )
-        return None
+        return None, False
 
     try:
         import signal
@@ -211,7 +214,7 @@ def generate_audio_lesson_for_meaning(user, user_word, cefr_level="B1", timeout_
                     f"        ✓ Generated audio lesson for: {meaning.origin.content} → {meaning.translation.content} (rank: {rank}, {status}, {audio_lesson_meaning.duration_seconds}s)"
                 )
 
-            return audio_lesson_meaning
+            return audio_lesson_meaning, True
 
         finally:
             # Cancel the alarm
@@ -222,13 +225,13 @@ def generate_audio_lesson_for_meaning(user, user_word, cefr_level="B1", timeout_
         output(
             f"        ✗ Timeout (>{timeout_seconds}s) generating audio for {meaning.origin.content}"
         )
-        return None
+        return None, False
     except Exception as e:
         db.session.rollback()
         output(
             f"        ✗ Failed to generate audio for {meaning.origin.content}: {str(e)}"
         )
-        return None
+        return None, False
 
 
 # Get users with their last activity time
@@ -378,15 +381,12 @@ for user, last_activity in user_activity_map:
                         language_breakdown[language.name] += 1
 
                         # Generate audio lesson for this meaning
-                        audio_lesson = generate_audio_lesson_for_meaning(
+                        audio_lesson, created = generate_audio_lesson_for_meaning(
                             user, user_word, cefr_level
                         )
 
                         if audio_lesson:
-                            if (
-                                hasattr(audio_lesson, "created_by")
-                                and audio_lesson.created_by == "claude-v1"
-                            ):
+                            if created:
                                 total_audio_generated += 1
                             else:
                                 total_audio_existing += 1

--- a/zeeguu/core/audio_lessons/daily_lesson_generator.py
+++ b/zeeguu/core/audio_lessons/daily_lesson_generator.py
@@ -177,6 +177,7 @@ class DailyLessonGenerator:
         origin_language,
         translation_language,
         cefr_level,
+        *,
         progress=None,
     ):
         """
@@ -269,6 +270,7 @@ class DailyLessonGenerator:
         cefr_level,
         canonical_suggestion,
         lesson_type,
+        *,
         progress=None,
         is_general=False,
         raw_suggestion=None,

--- a/zeeguu/core/audio_lessons/daily_lesson_generator.py
+++ b/zeeguu/core/audio_lessons/daily_lesson_generator.py
@@ -177,7 +177,6 @@ class DailyLessonGenerator:
         origin_language,
         translation_language,
         cefr_level,
-        created_by="claude-v1",
         progress=None,
     ):
         """
@@ -228,7 +227,6 @@ class DailyLessonGenerator:
         audio_lesson_meaning = AudioLessonMeaning(
             meaning=meaning,
             script=script,
-            created_by=created_by,
             difficulty_level=cefr_level,
             teacher_language=teacher_lang,
             ai_generator=_ai_generator_for(generated),
@@ -271,7 +269,6 @@ class DailyLessonGenerator:
         cefr_level,
         canonical_suggestion,
         lesson_type,
-        created_by="claude-v1",
         progress=None,
         is_general=False,
         raw_suggestion=None,
@@ -337,7 +334,6 @@ class DailyLessonGenerator:
         script = generated.script
         dialogue = AudioLessonDialogue(
             script=script,
-            created_by=created_by,
             canonical_suggestion=canonical_suggestion,
             lesson_type=lesson_type,
             language=learned_lang,

--- a/zeeguu/core/audio_lessons/daily_lesson_generator.py
+++ b/zeeguu/core/audio_lessons/daily_lesson_generator.py
@@ -9,6 +9,19 @@ from datetime import datetime, timezone, timedelta
 from zeeguu.config import ZEEGUU_DATA_FOLDER
 from zeeguu.core.audio_lessons.lesson_builder import LessonBuilder
 from zeeguu.core.audio_lessons.script_generator import generate_lesson_script, generate_dialogue_script
+from zeeguu.core.model.ai_generator import AIGenerator
+
+
+def _ai_generator_for(generated):
+    """
+    Record which model and which prompt actually produced a script.
+
+    Both are only knowable here: the fallback chain can serve from a different
+    provider than the one configured, and the prompt file is chosen per call.
+    """
+    return AIGenerator.find_or_create(
+        db.session, generated.model_name, prompt_version=generated.prompt_version
+    )
 from zeeguu.core.audio_lessons.voice_synthesizer import VoiceSynthesizer
 from zeeguu.core.audio_lessons.word_selector import select_words_for_audio_lesson
 from zeeguu.core.model import (
@@ -198,7 +211,7 @@ class DailyLessonGenerator:
             progress.update_generating_script()
             db.session.commit()
 
-        script = generate_lesson_script(
+        generated = generate_lesson_script(
             origin_word=meaning.origin.content,
             translation_word=meaning.translation.content,
             origin_language=origin_language,
@@ -211,12 +224,14 @@ class DailyLessonGenerator:
             progress.update_script_done()
             db.session.commit()
 
+        script = generated.script
         audio_lesson_meaning = AudioLessonMeaning(
             meaning=meaning,
             script=script,
             created_by=created_by,
             difficulty_level=cefr_level,
             teacher_language=teacher_lang,
+            ai_generator=_ai_generator_for(generated),
         )
         db.session.add(audio_lesson_meaning)
         db.session.flush()  # Get the ID
@@ -305,7 +320,7 @@ class DailyLessonGenerator:
         # Drive content from the raw user input so specific details are preserved.
         # Fall back to canonical only if no raw input was provided.
         content_suggestion = raw_suggestion or canonical_suggestion
-        title, script = generate_dialogue_script(
+        title, generated = generate_dialogue_script(
             origin_language=origin_language,
             translation_language=translation_language,
             suggestion=content_suggestion,
@@ -319,6 +334,7 @@ class DailyLessonGenerator:
             db.session.commit()
 
         # Create the dialogue record
+        script = generated.script
         dialogue = AudioLessonDialogue(
             script=script,
             created_by=created_by,
@@ -329,6 +345,7 @@ class DailyLessonGenerator:
             teacher_language=teacher_lang,
             is_general=is_general,
             title=title,
+            ai_generator=_ai_generator_for(generated),
         )
         db.session.add(dialogue)
         db.session.flush()  # Get the ID

--- a/zeeguu/core/audio_lessons/prompts/dialogue_lesson--situation-v2.txt
+++ b/zeeguu/core/audio_lessons/prompts/dialogue_lesson--situation-v2.txt
@@ -17,6 +17,10 @@ Use this exact format:
 
     Create a single flowing dialogue of at least 14 lines between Man and Woman that feels
     like a real conversation in the given situation.
+    EVERY "Man:" and "Woman:" line in this dialogue MUST be written in {target_language}.
+    This dialogue is the part the learner listens to in order to hear {target_language};
+    a dialogue written in {source_language} is worthless to them and counts as a failed
+    script. Do not translate the lines and do not gloss them.
     In between lines add one second break annotations with: [1 seconds]
 
 

--- a/zeeguu/core/audio_lessons/prompts/dialogue_lesson--topic-v2.txt
+++ b/zeeguu/core/audio_lessons/prompts/dialogue_lesson--topic-v2.txt
@@ -15,6 +15,10 @@ Use this exact format:
 
     Create a single flowing dialogue of at least 14 lines between Man and Woman themed
     around {suggestion}. Make it a natural, realistic exchange about the topic.
+    EVERY "Man:" and "Woman:" line in this dialogue MUST be written in {target_language}.
+    This dialogue is the part the learner listens to in order to hear {target_language};
+    a dialogue written in {source_language} is worthless to them and counts as a failed
+    script. Do not translate the lines and do not gloss them.
     In between lines add one second break annotations with: [1 seconds]
 
 

--- a/zeeguu/core/audio_lessons/prompts/meaning_lesson--teacher_challenges_both_dialogue_and_beyond-v4.txt
+++ b/zeeguu/core/audio_lessons/prompts/meaning_lesson--teacher_challenges_both_dialogue_and_beyond-v4.txt
@@ -22,6 +22,10 @@ Use this exact format:
     "The most common way to say {translation_word} is ... but {origin_word} is also used."]
 
     Create a dialogue of at least 8 lines between Man and Woman using the target word naturally.
+    EVERY "Man:" and "Woman:" line in this dialogue MUST be written in {target_language}.
+    This dialogue is the part the learner listens to in order to hear {target_language};
+    a dialogue written in {source_language} is worthless to them and counts as a failed
+    script. Do not translate the lines and do not gloss them.
     In between lines add one second break annotations with: [1 seconds]
 
 

--- a/zeeguu/core/audio_lessons/script_generator.py
+++ b/zeeguu/core/audio_lessons/script_generator.py
@@ -3,6 +3,7 @@ Script generator for audio lessons using unified LLM service.
 """
 
 import os
+import re
 from collections import namedtuple
 
 from zeeguu.core.audio_lessons.script_language_validator import find_language_mismatches
@@ -25,10 +26,27 @@ LANGUAGE_ATTEMPTS = 3
 GeneratedScript = namedtuple("GeneratedScript", ["script", "model_name", "prompt_version"])
 
 
+_PROMPT_VERSION = re.compile(r"-(v\d+)$")
+
+
 def prompt_version_of(prompt_file: str) -> str:
-    """'meaning_lesson--...-v4.txt' -> 'meaning_lesson--...-v4'. The version is already
-    in the filename the caller chose; it just was never persisted."""
-    return os.path.basename(prompt_file).rsplit(".", 1)[0]
+    """
+    'meaning_lesson--teacher_challenges_both_dialogue_and_beyond-v4.txt'
+        -> 'meaning_lesson-v4'
+
+    The family and the version, not the whole filename. The 43 characters in
+    between name the prompt's strategy, and rewording them is a tidy-up rather
+    than a new version — recording them would make a rename look like a version
+    bump, and would not fit AIGenerator.prompt_version (VARCHAR(50)) anyway.
+
+    The two dialogue prompts both reduce to 'dialogue_lesson-v2'; which of them
+    ran is recoverable from the row's own lesson_type.
+    """
+    stem = os.path.basename(prompt_file).rsplit(".", 1)[0]
+    version = _PROMPT_VERSION.search(stem)
+    if not version:
+        return stem
+    return f"{stem.split('--')[0]}-{version.group(1)}"
 
 
 # Load the prompt template
@@ -119,7 +137,7 @@ def generate_lesson_script(
     translation_language: str,
     cefr_level: str = "A1",
     generator_prompt_file="meaning_lesson--teacher_challenges_both_dialogue_and_beyond-v4.txt",
-) -> str:
+) -> GeneratedScript:
     """
     Generate a meaning lesson script for a single word (auto mode only).
     """

--- a/zeeguu/core/audio_lessons/script_generator.py
+++ b/zeeguu/core/audio_lessons/script_generator.py
@@ -43,10 +43,9 @@ def prompt_version_of(prompt_file: str) -> str:
     ran is recoverable from the row's own lesson_type.
     """
     stem = os.path.basename(prompt_file).rsplit(".", 1)[0]
+    family = stem.split("--")[0]
     version = _PROMPT_VERSION.search(stem)
-    if not version:
-        return stem
-    return f"{stem.split('--')[0]}-{version.group(1)}"
+    return f"{family}-{version.group(1)}" if version else family
 
 
 # Load the prompt template

--- a/zeeguu/core/audio_lessons/script_generator.py
+++ b/zeeguu/core/audio_lessons/script_generator.py
@@ -3,6 +3,8 @@ Script generator for audio lessons using unified LLM service.
 """
 
 import os
+from collections import namedtuple
+
 from zeeguu.core.audio_lessons.script_language_validator import find_language_mismatches
 from zeeguu.core.language.language_check import describe_mismatches, log_mismatches
 from zeeguu.core.llm_services import generate_audio_lesson_script
@@ -17,6 +19,17 @@ VALID_LESSON_TYPES = (THREE_WORDS_LESSON, "topic", "situation")
 # a lesson in the wrong language is worse than no lesson, so we retry and then fail.
 LANGUAGE_ATTEMPTS = 3
 
+# What produced a script: the model that actually answered (not the one configured,
+# which a fallback chain can silently override) and the prompt file that was used.
+# Both are known at generation time and unrecoverable afterwards.
+GeneratedScript = namedtuple("GeneratedScript", ["script", "model_name", "prompt_version"])
+
+
+def prompt_version_of(prompt_file: str) -> str:
+    """'meaning_lesson--...-v4.txt' -> 'meaning_lesson--...-v4'. The version is already
+    in the filename the caller chose; it just was never persisted."""
+    return os.path.basename(prompt_file).rsplit(".", 1)[0]
+
 
 # Load the prompt template
 def get_prompt_template(file_name) -> str:
@@ -26,6 +39,28 @@ def get_prompt_template(file_name) -> str:
 
     with open(prompt_file, "r", encoding="utf-8") as f:
         return f.read()
+
+
+def language_contract(target_lang_name: str, source_lang_name: str) -> str:
+    """
+    The two-language rule, as a system prompt.
+
+    A lesson script carries two languages at once, and which voice speaks which is
+    the whole point of it. Stating that only in the user prompt leaves it competing
+    with several hundred lines of formatting instructions: measured on DeepSeek,
+    scripts with a non-English teacher held the rule 1 time in 9 that way, and 7
+    times in 9 with the rule stated here instead.
+    """
+    return (
+        f"You write audio lesson scripts for language learners. The learner speaks "
+        f"{source_lang_name} natively and is studying {target_lang_name}.\n"
+        f"Lines labelled 'Man:', 'Woman:' and 'TeacherL2:' are ALWAYS written in "
+        f"{target_lang_name}. Never in {source_lang_name}.\n"
+        f"Lines labelled 'Teacher:' are ALWAYS written in {source_lang_name}.\n"
+        f"Keeping these two languages apart is the entire purpose of the script. A "
+        f"script whose Man/Woman lines are in {source_lang_name} is worthless to the "
+        f"learner and must never be produced."
+    )
 
 
 def _correction_note(mismatches, target_lang_name, source_lang_name) -> str:
@@ -44,7 +79,7 @@ def generate_script_in_languages(
     source_language: str,
     context: str,
     max_tokens: int = None,
-) -> str:
+) -> tuple:
     """
     Generate a lesson script and verify it came back in the languages we asked for.
 
@@ -54,16 +89,17 @@ def generate_script_in_languages(
     kwargs = {"max_tokens": max_tokens} if max_tokens else {}
     target_lang_name = Language.LANGUAGE_NAMES.get(target_language, target_language)
     source_lang_name = Language.LANGUAGE_NAMES.get(source_language, source_language)
+    kwargs["system"] = language_contract(target_lang_name, source_lang_name)
 
     attempt_prompt = prompt
     mismatches = []
 
     for attempt in range(1, LANGUAGE_ATTEMPTS + 1):
-        script = generate_audio_lesson_script(attempt_prompt, **kwargs)
+        script, model_name = generate_audio_lesson_script(attempt_prompt, **kwargs)
 
         mismatches = find_language_mismatches(script, target_language, source_language)
         if not mismatches:
-            return script
+            return script, model_name
 
         log_mismatches(f"{context} (attempt {attempt}/{LANGUAGE_ATTEMPTS})", mismatches)
         attempt_prompt = prompt + _correction_note(
@@ -82,7 +118,7 @@ def generate_lesson_script(
     origin_language: str,
     translation_language: str,
     cefr_level: str = "A1",
-    generator_prompt_file="meaning_lesson--teacher_challenges_both_dialogue_and_beyond-v3.txt",
+    generator_prompt_file="meaning_lesson--teacher_challenges_both_dialogue_and_beyond-v4.txt",
 ) -> str:
     """
     Generate a meaning lesson script for a single word (auto mode only).
@@ -104,14 +140,14 @@ def generate_lesson_script(
 
     try:
         # Use unified LLM service with automatic Anthropic -> DeepSeek fallback
-        script = generate_script_in_languages(
+        script, model_name = generate_script_in_languages(
             prompt,
             target_language=origin_language,
             source_language=translation_language,
             context=f"meaning lesson '{origin_word}'",
         )
         log(f"Successfully generated script for {origin_word}")
-        return script
+        return GeneratedScript(script, model_name, prompt_version_of(generator_prompt_file))
 
     except Exception as e:
         log(f"Failed to generate script for {origin_word}: {e}")
@@ -136,9 +172,9 @@ def generate_dialogue_script(
     translation_lang_name = Language.LANGUAGE_NAMES.get(translation_language, translation_language)
 
     if lesson_type == "situation":
-        prompt_file = "dialogue_lesson--situation-v1.txt"
+        prompt_file = "dialogue_lesson--situation-v2.txt"
     else:
-        prompt_file = "dialogue_lesson--topic-v1.txt"
+        prompt_file = "dialogue_lesson--topic-v2.txt"
 
     prompt_template = get_prompt_template(prompt_file)
     prompt = prompt_template.format(
@@ -155,7 +191,7 @@ def generate_dialogue_script(
     log(f"Generating dialogue script (suggestion: {suggestion}, type: {lesson_type})")
 
     try:
-        raw = generate_script_in_languages(
+        raw, model_name = generate_script_in_languages(
             prompt,
             target_language=origin_language,
             source_language=translation_language,
@@ -172,7 +208,7 @@ def generate_dialogue_script(
             script = lines[1].strip()
 
         log(f"Successfully generated dialogue script, title: '{title}'")
-        return title, script
+        return title, GeneratedScript(script, model_name, prompt_version_of(prompt_file))
 
     except Exception as e:
         log(f"Failed to generate dialogue script: {e}")

--- a/zeeguu/core/llm_services/llm_service.py
+++ b/zeeguu/core/llm_services/llm_service.py
@@ -15,7 +15,8 @@ class LLMService:
         """Generate example sentences. Must be implemented by subclasses."""
         raise NotImplementedError
     
-    def generate_text(self, prompt: str, max_tokens: int = 1000, temperature: float = 0.7) -> str:
+    def generate_text(self, prompt: str, max_tokens: int = 1000, temperature: float = 0.7,
+                      system: str = None) -> str:
         """Generate text from a prompt. Must be implemented by subclasses."""
         raise NotImplementedError
 
@@ -60,23 +61,37 @@ class UnifiedLLMService(LLMService):
                 log(f"DeepSeek fallback also failed: {deepseek_error}")
                 raise Exception(f"Failed to generate examples (both APIs failed): Anthropic: {anthropic_error}, DeepSeek: {deepseek_error}")
     
-    def generate_text(self, prompt: str, max_tokens: int = 1000, temperature: float = 0.7) -> str:
-        """Generate text with Anthropic -> DeepSeek fallback"""
+    def generate_text_with_model(self, prompt: str, max_tokens: int = 1000, temperature: float = 0.7,
+                                 system: str = None) -> tuple:
+        """
+        Generate text with Anthropic -> DeepSeek fallback, reporting who answered.
+
+        Returns (text, model_name). Callers that persist the result need the second
+        element: under a fallback chain the model named in the configuration is not
+        the model that served, so provenance has to be recorded at generation time
+        rather than inferred later.
+        """
         try:
             # Try Anthropic first
             anthropic = self._get_anthropic_service()
-            return anthropic.generate_text(prompt, max_tokens, temperature)
+            return anthropic.generate_text(prompt, max_tokens, temperature, system), anthropic.model
         except Exception as anthropic_error:
             log(f"Anthropic API failed for text generation: {anthropic_error}")
-            
+
             # Fallback to DeepSeek
             log(f"Falling back to DeepSeek for text generation")
             try:
                 deepseek = self._get_deepseek_service()
-                return deepseek.generate_text(prompt, max_tokens, temperature)
+                return deepseek.generate_text(prompt, max_tokens, temperature, system), deepseek.model
             except Exception as deepseek_error:
                 log(f"DeepSeek fallback also failed: {deepseek_error}")
                 raise Exception(f"Text generation failed (both APIs failed): Anthropic: {anthropic_error}, DeepSeek: {deepseek_error}")
+
+    def generate_text(self, prompt: str, max_tokens: int = 1000, temperature: float = 0.7,
+                      system: str = None) -> str:
+        """Generate text with Anthropic -> DeepSeek fallback"""
+        text, _ = self.generate_text_with_model(prompt, max_tokens, temperature, system)
+        return text
 
 
 def get_llm_service(provider: Optional[str] = None) -> LLMService:
@@ -96,14 +111,16 @@ def get_llm_service(provider: Optional[str] = None) -> LLMService:
         raise ValueError(f"Unknown LLM provider: {provider}")
 
 
-def generate_audio_lesson_script(prompt: str, max_tokens: int = 2500) -> str:
+def generate_audio_lesson_script(prompt: str, max_tokens: int = 2500, system: str = None) -> tuple:
     """
     Convenience function for generating audio lesson scripts.
     Uses the unified service with automatic Anthropic -> DeepSeek fallback.
     Default 2500 tokens for single-word meaning lessons.
+
+    Returns (script, model_name): which provider served has to be recorded, not assumed.
     """
     llm_service = get_llm_service("unified")
-    return llm_service.generate_text(prompt, max_tokens=max_tokens, temperature=0.7)
+    return llm_service.generate_text_with_model(prompt, max_tokens=max_tokens, temperature=0.7, system=system)
 
 
 def prepare_learning_card(

--- a/zeeguu/core/model/ai_generator.py
+++ b/zeeguu/core/model/ai_generator.py
@@ -35,6 +35,19 @@ class AIGenerator(db.Model):
         """
         Find existing model or create new one.
 
+        Flushes rather than commits, so the generator belongs to whatever unit of
+        work the caller is in. It is almost always looked up while building the
+        row that will reference it — a lesson, a simplified article — and
+        committing here made a lookup quietly commit that half-built work too,
+        past the point any later failure could roll back. Flushing still emits
+        the INSERT, so the id is available immediately and a bad value still
+        fails here rather than somewhere later.
+
+        Every caller commits shortly after. The cost is that two processes
+        creating the same generator concurrently can now both insert it; there is
+        no unique constraint, so that was already possible, just in a narrower
+        window, and a duplicate generator row is harmless.
+
         Args:
             session: Database session
             model_name: Name of the AI model
@@ -58,11 +71,11 @@ class AIGenerator(db.Model):
             if description and model.description != description:
                 model.description = description
                 session.add(model)
-                session.commit()
+                session.flush()
         except:
             model = cls(model_name, prompt_version, description)
             session.add(model)
-            session.commit()
+            session.flush()
 
         return model
 

--- a/zeeguu/core/model/ai_generator.py
+++ b/zeeguu/core/model/ai_generator.py
@@ -19,7 +19,7 @@ class AIGenerator(db.Model):
 
     id = Column(Integer, primary_key=True)
     model_name = Column(String(100), nullable=False)
-    prompt_version = Column(String(50), nullable=True)
+    prompt_version = Column(String(255), nullable=True)
     description = Column(Text, nullable=True)
 
     def __init__(self, model_name, prompt_version=None, description=None):

--- a/zeeguu/core/model/audio_lesson_dialogue.py
+++ b/zeeguu/core/model/audio_lesson_dialogue.py
@@ -2,6 +2,7 @@ from sqlalchemy import Column, Integer, String, Text, JSON, Enum, ForeignKey, Da
 from sqlalchemy.orm import relationship
 
 from zeeguu.core.model.db import db
+from zeeguu.core.model.ai_generator import AIGenerator
 from zeeguu.core.model.language import Language
 
 
@@ -37,6 +38,12 @@ class AudioLessonDialogue(db.Model):
     is_general = Column(db.Boolean, default=False)
     created_by = Column(String(255), nullable=False)
 
+    # Which model and prompt version actually produced this script. created_by is a
+    # fixed literal and cannot answer that: the fallback chain may serve from a
+    # different provider than the configured one, so it has to be recorded here.
+    ai_generator_id = Column(Integer, ForeignKey(AIGenerator.id), nullable=True)
+    ai_generator = relationship(AIGenerator)
+
     # When set, cache lookups skip this row and force regeneration. Existing
     # daily lesson segments that already reference it keep playing as before.
     deprecated_at = Column(DateTime, nullable=True)
@@ -65,6 +72,8 @@ class AudioLessonDialogue(db.Model):
         self.is_general = is_general
         if teacher_language:
             self.teacher_language_id = teacher_language.id
+        if ai_generator:
+            self.ai_generator_id = ai_generator.id
 
     def __repr__(self):
         return f"<AudioLessonDialogue {self.id} '{self.canonical_suggestion}' ({self.lesson_type})>"

--- a/zeeguu/core/model/audio_lesson_dialogue.py
+++ b/zeeguu/core/model/audio_lesson_dialogue.py
@@ -36,7 +36,12 @@ class AudioLessonDialogue(db.Model):
     )
     duration_seconds = Column(Integer)
     is_general = Column(db.Boolean, default=False)
-    created_by = Column(String(255), nullable=False)
+    # Superseded by ai_generator_id, which names the model that actually answered
+    # and the prompt version that produced this script. Kept nullable and no longer
+    # written: every existing row says the literal 'claude-v1', including the ones
+    # DeepSeek wrote while the Anthropic cap was reached. Dropped once no deployed
+    # code selects it.
+    created_by = Column(String(255), nullable=True)
 
     # Which model and prompt version actually produced this script. created_by is a
     # fixed literal and cannot answer that: the fallback chain may serve from a
@@ -51,15 +56,16 @@ class AudioLessonDialogue(db.Model):
     def __init__(
         self,
         script,
-        created_by,
         canonical_suggestion,
         lesson_type,
         language,
+        created_by=None,
         difficulty_level=None,
         duration_seconds=None,
         teacher_language=None,
         is_general=False,
         title=None,
+        ai_generator=None,
     ):
         self.script = script
         self.created_by = created_by

--- a/zeeguu/core/model/audio_lesson_meaning.py
+++ b/zeeguu/core/model/audio_lesson_meaning.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import relationship
 
 from zeeguu.core.model.db import db
 from zeeguu.core.model.meaning import Meaning
+from zeeguu.core.model.ai_generator import AIGenerator
 from zeeguu.core.model.language import Language
 
 
@@ -32,7 +33,13 @@ class AudioLessonMeaning(db.Model):
         Enum("A1", "A2", "B1", "B2", "C1", "C2", name="cefr_level")
     )
     duration_seconds = Column(Integer)
-    created_by = Column(String(255), nullable=False)  # e.g. Claude-v2-Opus-Promopt1
+    created_by = Column(String(255), nullable=False)
+
+    # Which model and prompt version actually produced this script. created_by is a
+    # fixed literal and cannot answer that: the fallback chain may serve from a
+    # different provider than the configured one, so it has to be recorded here.
+    ai_generator_id = Column(Integer, ForeignKey(AIGenerator.id), nullable=True)
+    ai_generator = relationship(AIGenerator)  # e.g. Claude-v2-Opus-Promopt1
 
     # When set, cache lookups skip this row and force regeneration. Existing
     # daily lesson segments that already reference it keep playing as before.
@@ -47,6 +54,7 @@ class AudioLessonMeaning(db.Model):
         voice_config=None,
         duration_seconds=None,
         teacher_language=None,
+        ai_generator=None,
     ):
         self.meaning_id = meaning.id
         self.script = script
@@ -56,6 +64,8 @@ class AudioLessonMeaning(db.Model):
         self.duration_seconds = duration_seconds
         if teacher_language:
             self.teacher_language_id = teacher_language.id
+        if ai_generator:
+            self.ai_generator_id = ai_generator.id
 
     def __repr__(self):
         return f"<AudioLessonMeaning {self.id} for meaning {self.meaning_id}>"

--- a/zeeguu/core/model/audio_lesson_meaning.py
+++ b/zeeguu/core/model/audio_lesson_meaning.py
@@ -33,7 +33,12 @@ class AudioLessonMeaning(db.Model):
         Enum("A1", "A2", "B1", "B2", "C1", "C2", name="cefr_level")
     )
     duration_seconds = Column(Integer)
-    created_by = Column(String(255), nullable=False)
+    # Superseded by ai_generator_id, which names the model that actually answered
+    # and the prompt version that produced this script. Kept nullable and no longer
+    # written: every existing row says the literal 'claude-v1', including the ones
+    # DeepSeek wrote while the Anthropic cap was reached. Dropped once no deployed
+    # code selects it.
+    created_by = Column(String(255), nullable=True)
 
     # Which model and prompt version actually produced this script. created_by is a
     # fixed literal and cannot answer that: the fallback chain may serve from a
@@ -49,7 +54,7 @@ class AudioLessonMeaning(db.Model):
         self,
         meaning,
         script,
-        created_by,
+        created_by=None,
         difficulty_level=None,
         voice_config=None,
         duration_seconds=None,

--- a/zeeguu/core/test/test_audio_lesson_provenance.py
+++ b/zeeguu/core/test/test_audio_lesson_provenance.py
@@ -1,0 +1,71 @@
+"""
+Recording which model and prompt produced an audio lesson script.
+
+Both bugs these pin shipped in a green suite, because nothing constructed an
+AudioLessonDialogue and nothing checked that a prompt version fits the column it
+is stored in. They are cheap to hold: no LLM, no audio, no DB writes.
+"""
+
+from unittest.mock import MagicMock
+from pathlib import Path
+
+from zeeguu.core.audio_lessons.script_generator import prompt_version_of
+from zeeguu.core.model.ai_generator import AIGenerator
+from zeeguu.core.model.audio_lesson_dialogue import AudioLessonDialogue
+from zeeguu.core.model.audio_lesson_meaning import AudioLessonMeaning
+
+PROMPTS = Path(__file__).parent.parent / "audio_lessons" / "prompts"
+
+
+def test_a_meaning_lesson_takes_the_generator_that_wrote_it():
+    lesson = AudioLessonMeaning(
+        meaning=MagicMock(id=1),
+        script="Man: Hej",
+        difficulty_level="A2",
+        ai_generator=MagicMock(id=7),
+    )
+    assert lesson.ai_generator_id == 7
+
+
+def test_a_dialogue_takes_the_generator_that_wrote_it():
+    # daily_lesson_generator passes ai_generator=; the constructor used to
+    # reference it without accepting it, so every dialogue raised TypeError.
+    dialogue = AudioLessonDialogue(
+        script="Man: Hej",
+        canonical_suggestion="at the cafe",
+        lesson_type="topic",
+        language=MagicMock(id=1),
+        ai_generator=MagicMock(id=7),
+    )
+    assert dialogue.ai_generator_id == 7
+
+
+def test_a_lesson_without_a_generator_is_still_constructible():
+    # Old rows and any path that does not know: the column is nullable.
+    assert AudioLessonMeaning(meaning=MagicMock(id=1), script="x").ai_generator_id is None
+    assert (
+        AudioLessonDialogue(
+            script="x", canonical_suggestion="s", lesson_type="topic",
+            language=MagicMock(id=1),
+        ).ai_generator_id
+        is None
+    )
+
+
+def test_every_prompt_version_fits_the_column_it_is_stored_in():
+    # The meaning prompt's filename is 62 characters against a VARCHAR(50); the
+    # insert failed inside AIGenerator.find_or_create's own except: block, so
+    # every meaning lesson would have failed to generate.
+    limit = AIGenerator.__table__.columns["prompt_version"].type.length
+    for prompt_file in PROMPTS.glob("*.txt"):
+        version = prompt_version_of(prompt_file.name)
+        assert len(version) <= limit, f"{prompt_file.name} -> {version} ({len(version)} > {limit})"
+
+
+def test_the_recorded_version_survives_rewording_the_filename():
+    # What identifies a prompt is its family and version. The description in the
+    # middle names its strategy, and rewording that is a tidy-up, not a new
+    # version — it must not look like one.
+    assert prompt_version_of("meaning_lesson--teacher_challenges_both_dialogue_and_beyond-v4.txt") == "meaning_lesson-v4"
+    assert prompt_version_of("meaning_lesson--something_much_shorter-v4.txt") == "meaning_lesson-v4"
+    assert prompt_version_of("meaning_lesson--teacher_challenges_both_dialogue_and_beyond-v5.txt") == "meaning_lesson-v5"


### PR DESCRIPTION
Follows #705, which added the output-language check. This is the other half: making the wrong language less likely in the first place, and being able to tell afterwards who produced a given script.

## Say the rule where the model will keep it

A lesson script carries two languages at once, and which voice speaks which is the entire point of it. That rule lived only in the user prompt, competing with several hundred lines of formatting instructions.

It now goes in the **system prompt** (`language_contract`), which is where the provider docs say a constraint that must hold for the whole response belongs. Measured against DeepSeek, scripts with a non-English teacher went from **1/9 correct to 7/9**.

The prompt files move to `v2`/`v4` alongside, so the change is attributable rather than silently rewriting what `v1`/`v3` meant.

## Record who actually wrote it

`created_by` has always been the literal string `'claude-v1'`, so it can answer neither "which model" nor "which prompt". That matters because the Anthropic→DeepSeek fallback means the configured model is not necessarily the model that served: scripts generated while the Anthropic spend cap was reached were written by DeepSeek and recorded as Claude.

- `generate_text_with_model` returns the model that actually answered, not the one that was asked.
- `GeneratedScript(script, model_name, prompt_version)` carries it out of the generator; the prompt version comes from the filename the caller already chose.
- `audio_lesson_meaning` and `audio_lesson_dialogue` get a nullable `ai_generator_id` FK, so existing rows stay honest about not knowing.

**Migrations, both before deploying, in order:**

1. `26-08-18--add_ai_generator_to_audio_lessons.sql` — the new FK columns.
2. `26-08-18-b--created_by_nullable_on_audio_lesson_scripts.sql` — see below.

## Retire `created_by` on the two script tables

`created_by` is a `String(255)` that has only ever held the literal `'claude-v1'`, so it answers neither question and actively misleads: the scripts DeepSeek wrote during the Anthropic cap say Claude. Now that `ai_generator_id` carries the truth, the column is nullable and no longer written, and the parameters that fed it are gone.

It can't be `DROP`ped in this deploy. SQLAlchemy selects every mapped column, so removing it while the previous container is still serving would fail every query against these tables mid blue-green switch. That's a third migration, once nothing running still selects it.

Its one real reader was `precompute_upcoming_meaning_lessons`, which decided "generated" vs "already existed" from `created_by == "claude-v1"` — true of every row, so every lesson counted as freshly generated. The function that actually knows now returns it.

## A crash this turned up

`AudioLessonDialogue.__init__` referenced `ai_generator` without accepting it, while `daily_lesson_generator` passed it: **every dialogue lesson raised `TypeError: __init__() got an unexpected keyword argument 'ai_generator'`**. No test constructs an `AudioLessonDialogue`, so the suite stayed green; the meaning path has the parameter and worked. Fixed here.

## Sweep for what the check misses

`--quiet` on the audio-lesson audit, for a nightly cron: a clean run prints nothing, so cron stays silent and any output is a real finding.

The generation-time check is a tuned heuristic and has been wrong in both directions. Its false negatives are invisible by construction — no mismatch detected means no line logged means nothing reaches the log digest. Dialogue 235 scored 71% Danish, passed, shipped, and was found by a human listening to it. Sweeping what is already stored is the only mechanism that catches that class.

## Testing

`zeeguu/core/test` — 251 passed. Every caller of the changed return types (`generate_lesson_script`, `generate_dialogue_script`, `generate_audio_lesson_script`) was checked and unpacks the new shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
