### PR TITLE
Let a teacher restrict a class to the texts they share

### DIFF
--- a/tools/migrations/26-08-25--add_only_classroom_texts_to_cohort.sql
+++ b/tools/migrations/26-08-25--add_only_classroom_texts_to_cohort.sql
@@ -1,0 +1,14 @@
+-- Let a teacher restrict a class to the texts they share.
+--
+-- This behavior already existed as the `hide_recommendations` feature, but the
+-- set of classes it applied to was a constant in the source
+-- (zeeguu/core/user_feature_toggles.py), so enabling it for a class meant a
+-- deploy. The column moves that decision to the teacher.
+--
+-- Cohort 564 is the class the constant named; the UPDATE below keeps it behaving
+-- exactly as it does today, so the constant can be deleted in the same commit.
+
+ALTER TABLE cohort
+    ADD COLUMN only_classroom_texts BOOLEAN NOT NULL DEFAULT 0;
+
+UPDATE cohort SET only_classroom_texts = 1 WHERE id = 564;

--- a/zeeguu/api/endpoints/teacher_dashboard/cohorts.py
+++ b/zeeguu/api/endpoints/teacher_dashboard/cohorts.py
@@ -27,13 +27,9 @@ from ._permissions import (
 )
 from .. import api
 from zeeguu.api.utils.route_wrappers import requires_session
+from zeeguu.api.utils.parse_json_boolean import parse_json_boolean
 
 from zeeguu.core.model.db import db
-
-
-def _parse_bool(raw_value):
-    """Form values arrive as strings; anything unrecognized is False."""
-    return str(raw_value).strip().lower() in ("true", "1", "yes", "on")
 
 
 @api.route("/remove_cohort/<cohort_id>", methods=["POST"])
@@ -130,7 +126,10 @@ def create_own_cohort():
     if int(max_students) < 1:
         flask.abort(400)
 
-    only_classroom_texts = _parse_bool(params.get("only_classroom_texts"))
+    # None (absent or unparseable) means the teacher did not ask for it.
+    only_classroom_texts = bool(
+        parse_json_boolean(params.get("only_classroom_texts"))
+    )
 
     try:
         c = Cohort(
@@ -180,9 +179,11 @@ def update_cohort(cohort_id):
         # Only touched when the client actually sends it. A teacher on an older
         # web build posts a form without this field, and defaulting it to False
         # there would silently switch the class back to the full app.
-        only_classroom_texts = params.get("only_classroom_texts")
+        only_classroom_texts = parse_json_boolean(
+            params.get("only_classroom_texts")
+        )
         if only_classroom_texts is not None:
-            cohort_to_change.only_classroom_texts = _parse_bool(only_classroom_texts)
+            cohort_to_change.only_classroom_texts = only_classroom_texts
 
         db.session.commit()
         return "OK"

--- a/zeeguu/api/endpoints/teacher_dashboard/cohorts.py
+++ b/zeeguu/api/endpoints/teacher_dashboard/cohorts.py
@@ -27,7 +27,7 @@ from ._permissions import (
 )
 from .. import api
 from zeeguu.api.utils.route_wrappers import requires_session
-from zeeguu.api.utils.parse_json_boolean import parse_json_boolean
+from zeeguu.api.utils.parse_json_boolean import get_boolean_from_params
 
 from zeeguu.core.model.db import db
 
@@ -126,9 +126,8 @@ def create_own_cohort():
     if int(max_students) < 1:
         flask.abort(400)
 
-    # None (absent or unparseable) means the teacher did not ask for it.
-    only_classroom_texts = bool(
-        parse_json_boolean(params.get("only_classroom_texts"))
+    only_classroom_texts = get_boolean_from_params(
+        params, "only_classroom_texts", default=False
     )
 
     try:
@@ -179,8 +178,8 @@ def update_cohort(cohort_id):
         # Only touched when the client actually sends it. A teacher on an older
         # web build posts a form without this field, and defaulting it to False
         # there would silently switch the class back to the full app.
-        only_classroom_texts = parse_json_boolean(
-            params.get("only_classroom_texts")
+        only_classroom_texts = get_boolean_from_params(
+            params, "only_classroom_texts"
         )
         if only_classroom_texts is not None:
             cohort_to_change.only_classroom_texts = only_classroom_texts

--- a/zeeguu/api/endpoints/teacher_dashboard/cohorts.py
+++ b/zeeguu/api/endpoints/teacher_dashboard/cohorts.py
@@ -31,6 +31,11 @@ from zeeguu.api.utils.route_wrappers import requires_session
 from zeeguu.core.model.db import db
 
 
+def _parse_bool(raw_value):
+    """Form values arrive as strings; anything unrecognized is False."""
+    return str(raw_value).strip().lower() in ("true", "1", "yes", "on")
+
+
 @api.route("/remove_cohort/<cohort_id>", methods=["POST"])
 @requires_session
 def remove_cohort(cohort_id):
@@ -125,8 +130,16 @@ def create_own_cohort():
     if int(max_students) < 1:
         flask.abort(400)
 
+    only_classroom_texts = _parse_bool(params.get("only_classroom_texts"))
+
     try:
-        c = Cohort(inv_code, name, language, max_students)
+        c = Cohort(
+            inv_code,
+            name,
+            language,
+            max_students,
+            only_classroom_texts=only_classroom_texts,
+        )
         db.session.add(c)
         db.session.commit()
         _link_teacher_cohort(teacher_id, c.id)
@@ -163,6 +176,13 @@ def update_cohort(cohort_id):
 
         cohort_to_change.declared_level_min = params.get("declared_level_min")
         cohort_to_change.declared_level_max = params.get("declared_level_max")
+
+        # Only touched when the client actually sends it. A teacher on an older
+        # web build posts a form without this field, and defaulting it to False
+        # there would silently switch the class back to the full app.
+        only_classroom_texts = params.get("only_classroom_texts")
+        if only_classroom_texts is not None:
+            cohort_to_change.only_classroom_texts = _parse_bool(only_classroom_texts)
 
         db.session.commit()
         return "OK"

--- a/zeeguu/api/endpoints/teacher_dashboard/helpers.py
+++ b/zeeguu/api/endpoints/teacher_dashboard/helpers.py
@@ -74,6 +74,7 @@ def get_cohort_info(id):
             "language_name": language_name,
             "declared_level_min": c.declared_level_min,
             "declared_level_max": c.declared_level_max,
+            "only_classroom_texts": bool(c.only_classroom_texts),
             "teachers_for_cohort": teachers_for_cohort(id),
         }
         return dictionary

--- a/zeeguu/api/utils/__init__.py
+++ b/zeeguu/api/utils/__init__.py
@@ -1,3 +1,3 @@
 from .route_wrappers import cross_domain, requires_session
 from .json_result import json_result
-from .parse_json_boolean import parse_json_boolean
+from .parse_json_boolean import parse_json_boolean, get_boolean_from_params

--- a/zeeguu/api/utils/parse_json_boolean.py
+++ b/zeeguu/api/utils/parse_json_boolean.py
@@ -10,3 +10,17 @@ def parse_json_boolean(value):
     if value == "false":
         return False
     return None
+
+
+def get_boolean_from_params(params, name, default=None):
+    """
+    The boolean form/query parameter `name`, or `default` when the client did
+    not send it -- or sent something that is not "true"/"false".
+
+    The default is where the two cases part ways: pass False when an absent
+    parameter simply means off, and leave it None when absent has to stay
+    distinguishable from false (e.g. a partial update that must not clobber
+    a stored value it was never told about).
+    """
+    value = parse_json_boolean(params.get(name))
+    return default if value is None else value

--- a/zeeguu/core/model/cohort.py
+++ b/zeeguu/core/model/cohort.py
@@ -19,10 +19,21 @@ class Cohort(db.Model):
     declared_level_max = Column(Integer)
     is_cohort_of_teachers = Column(Boolean)
 
+    # When set, students of this cohort see only the texts their teacher shares
+    # with the class: no recommendation feed, no search, no shared inbox.
+    only_classroom_texts = Column(Boolean, nullable=False, default=False)
+
     users = relationship("UserCohortMap", back_populates="cohort")
 
     def __init__(
-        self, inv_code, name, language, max_students, level_min=0, level_max=10
+        self,
+        inv_code,
+        name,
+        language,
+        max_students,
+        level_min=0,
+        level_max=10,
+        only_classroom_texts=False,
     ):
         self.inv_code = inv_code
         self.name = name
@@ -31,6 +42,7 @@ class Cohort(db.Model):
         self.declared_level_min = level_min
         self.declared_level_max = level_max
         self.is_cohort_of_teachers = False  # by default a cohort is a student cohort!
+        self.only_classroom_texts = only_classroom_texts
 
     def get_current_student_count(self):
         from zeeguu.core.model.user import User

--- a/zeeguu/core/test/test_classroom_only_feature.py
+++ b/zeeguu/core/test/test_classroom_only_feature.py
@@ -32,6 +32,15 @@ class ClassroomOnlyFeatureTest(ModelTestMixIn, TestCase):
 
         self.assertTrue(self._classroom_only_for(self.student))
 
+    def test_legacy_feature_name_still_emitted(self):
+        # Apps installed before 25 Aug 2026 gate on hide_recommendations.
+        self.cohort.only_classroom_texts = True
+        db_session.commit()
+
+        self.assertTrue(
+            is_feature_enabled_for_user("hide_recommendations", self.student)
+        )
+
     def test_strictest_cohort_wins(self):
         self.cohort.only_classroom_texts = True
         unrestricted_cohort = CohortRule().cohort

--- a/zeeguu/core/test/test_classroom_only_feature.py
+++ b/zeeguu/core/test/test_classroom_only_feature.py
@@ -1,0 +1,62 @@
+from unittest import TestCase
+
+import zeeguu.core
+from zeeguu.core.test.model_test_mixin import ModelTestMixIn
+from zeeguu.core.test.rules.cohort_rule import CohortRule
+from zeeguu.core.model.teacher import Teacher
+from zeeguu.core.user_feature_toggles import is_feature_enabled_for_user
+
+db_session = zeeguu.core.model.db.session
+
+
+class ClassroomOnlyFeatureTest(ModelTestMixIn, TestCase):
+    """Cohort.only_classroom_texts drives the classroom_only feature."""
+
+    def setUp(self):
+        super().setUp()
+        self.cohort_rule = CohortRule()
+        self.cohort = self.cohort_rule.cohort
+        self.teacher = self.cohort_rule.teacher
+        self.student = self.cohort_rule.student1
+        self.student.add_user_to_cohort(self.cohort, db_session)
+
+    def _classroom_only_for(self, user):
+        return is_feature_enabled_for_user("classroom_only", user)
+
+    def test_off_by_default(self):
+        self.assertFalse(self._classroom_only_for(self.student))
+
+    def test_on_when_the_cohort_asks_for_it(self):
+        self.cohort.only_classroom_texts = True
+        db_session.commit()
+
+        self.assertTrue(self._classroom_only_for(self.student))
+
+    def test_legacy_feature_name_still_emitted(self):
+        # Deployed app versions gate on hide_recommendations, not classroom_only.
+        self.cohort.only_classroom_texts = True
+        db_session.commit()
+
+        self.assertTrue(
+            is_feature_enabled_for_user("hide_recommendations", self.student)
+        )
+
+    def test_strictest_cohort_wins(self):
+        self.cohort.only_classroom_texts = True
+        unrestricted_cohort = CohortRule().cohort
+        self.student.add_user_to_cohort(unrestricted_cohort, db_session)
+        db_session.commit()
+
+        self.assertTrue(self._classroom_only_for(self.student))
+
+    def test_teachers_are_never_restricted(self):
+        # A teacher needs the feed and the search to find texts to share.
+        # CohortRule only links the teacher to the cohort; the Teacher row is
+        # what User.isTeacher() actually looks at, and account creation is what
+        # writes it in production.
+        db_session.add(Teacher(self.teacher))
+        self.cohort.only_classroom_texts = True
+        self.teacher.add_user_to_cohort(self.cohort, db_session)
+        db_session.commit()
+
+        self.assertFalse(self._classroom_only_for(self.teacher))

--- a/zeeguu/core/test/test_classroom_only_feature.py
+++ b/zeeguu/core/test/test_classroom_only_feature.py
@@ -32,15 +32,6 @@ class ClassroomOnlyFeatureTest(ModelTestMixIn, TestCase):
 
         self.assertTrue(self._classroom_only_for(self.student))
 
-    def test_legacy_feature_name_still_emitted(self):
-        # Deployed app versions gate on hide_recommendations, not classroom_only.
-        self.cohort.only_classroom_texts = True
-        db_session.commit()
-
-        self.assertTrue(
-            is_feature_enabled_for_user("hide_recommendations", self.student)
-        )
-
     def test_strictest_cohort_wins(self):
         self.cohort.only_classroom_texts = True
         unrestricted_cohort = CohortRule().cohort

--- a/zeeguu/core/user_feature_toggles.py
+++ b/zeeguu/core/user_feature_toggles.py
@@ -30,7 +30,10 @@ def _feature_map():
         "tiago_exercises": _tiago_exercises,
         "new_topics": _new_topics,
         "daily_feedback": _daily_feedback,
-        "hide_recommendations": _hide_recommendations,
+        "classroom_only": _classroom_only,
+        # Legacy name for classroom_only. Deployed app versions gate on this
+        # string, and they will keep doing so until every student updates.
+        "hide_recommendations": _classroom_only,
         "verbal_flashcards": _verbal_flashcards,
         "show_non_simplified_articles": _show_non_simplified_articles,
         "always_open_externally": _always_open_externally,
@@ -113,21 +116,29 @@ def _always_open_externally(user):
     return True
 
 
-def _hide_recommendations(user):
-    """Hide recommended articles for students in specific cohorts.
+def _classroom_only(user):
+    """The student sees only the texts their teacher shares with the class.
 
-    When enabled, students only see the Classroom tab with teacher-uploaded texts.
-    Teachers are excluded from this feature even if they are in the cohort.
+    Set per class by the teacher (Cohort.only_classroom_texts). A student in
+    several classes is restricted if any one of them asks for it: the strictest
+    class wins, and the way out is to leave that class.
+
+    Teachers are excluded even when they are members of such a cohort -- they
+    need the feed and search to find the texts they are going to share.
     """
     if user.isTeacher():
         return False
 
-    COHORTS_WITH_HIDDEN_RECOMMENDATIONS = {564}
+    cohort_ids = [user_cohort.cohort_id for user_cohort in user.cohorts]
+    if not cohort_ids:
+        return False
 
-    for user_cohort in user.cohorts:
-        if user_cohort.cohort_id in COHORTS_WITH_HIDDEN_RECOMMENDATIONS:
-            return True
-    return False
+    return (
+        Cohort.query.filter(Cohort.id.in_(cohort_ids))
+        .filter(Cohort.only_classroom_texts.is_(True))
+        .count()
+        > 0
+    )
 
 
 def _verbal_flashcards(user):

--- a/zeeguu/core/user_feature_toggles.py
+++ b/zeeguu/core/user_feature_toggles.py
@@ -31,6 +31,12 @@ def _feature_map():
         "new_topics": _new_topics,
         "daily_feedback": _daily_feedback,
         "classroom_only": _classroom_only,
+        # Legacy name for classroom_only, kept as of 25 Aug 2026. The native
+        # apps ship a bundled web build, so a student whose app predates the
+        # release that adopts the new name reads this string and nothing else.
+        # Safe to delete once no app build from before 25 Aug 2026 is still in
+        # use -- check the oldest active version first.
+        "hide_recommendations": _classroom_only,
         "verbal_flashcards": _verbal_flashcards,
         "show_non_simplified_articles": _show_non_simplified_articles,
         "always_open_externally": _always_open_externally,

--- a/zeeguu/core/user_feature_toggles.py
+++ b/zeeguu/core/user_feature_toggles.py
@@ -31,9 +31,6 @@ def _feature_map():
         "new_topics": _new_topics,
         "daily_feedback": _daily_feedback,
         "classroom_only": _classroom_only,
-        # Legacy name for classroom_only. Deployed app versions gate on this
-        # string, and they will keep doing so until every student updates.
-        "hide_recommendations": _classroom_only,
         "verbal_flashcards": _verbal_flashcards,
         "show_non_simplified_articles": _show_non_simplified_articles,
         "always_open_externally": _always_open_externally,


### PR DESCRIPTION
Teachers want a class where students see exclusively the texts the teacher shares — no recommendation feed, no search, no shared inbox.

That behavior already existed as the `hide_recommendations` feature, but the set of classes it applied to was a constant in the source, so turning it on for a class meant a deploy. This PR moves the decision to the teacher.

**API only.** The teacher-facing toggle and the student-side hiding are a separate web PR — this can merge and deploy on its own without changing what anyone sees.

## What changes

- `cohort.only_classroom_texts`, backfilled to `1` for cohort 564 so the class the constant named keeps behaving exactly as it does today, and the constant is deleted in the same commit
- `create_own_cohort` / `update_cohort` read the param. Update only writes it when the field is actually present, so a teacher on an older web build posting a form without it can't silently switch a class back to the full app
- `get_cohort_info` returns it — that dict is what pre-fills the Edit Class dialog
- `features_for_user` emits both `classroom_only` and the legacy `hide_recommendations`. Deployed iOS/Android builds gate on the old string and will keep doing so until every student updates

The split is deliberate: **the server owns the flag, the client owns the surfaces it hides.** Nothing in any existing request path changes behavior for a user who isn't in a flagged cohort.

A student in several classes is restricted if any one of them asks for it — strictest class wins, and the way out is to leave that class. Teachers are excluded even when they're members, since they need the feed and search to find texts to share.

## Deploy order

**The migration must run before this code.** The feature computation reads the new column on every `/user_details`.

Once it's in, cohort 564 behaving unchanged is the regression check — before any UI exists.

## Tests

`zeeguu/core/test/test_classroom_only_feature.py`: default off, on when the cohort asks for it, legacy feature name still emitted, strictest-cohort-wins, teachers never restricted.

## One thing worth checking before the toggle reaches real teachers

There are two definitions of "is a teacher" in the codebase: `User.isTeacher()` queries the `teacher` table, while `Teacher.from_user()` derives it from having any `TeacherCohortMap` rows. This feature uses the former (unchanged from the previous implementation). If any production teacher has cohort links but no `teacher` row, they'd get restricted alongside their students — and the symptom would look like the feature is broken rather than like a data gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)