### PR TITLE
Read boolean request params through one helper

### DIFF
--- a/zeeguu/api/endpoints/article.py
+++ b/zeeguu/api/endpoints/article.py
@@ -6,6 +6,7 @@ from zeeguu.api.utils.json_result import json_result
 from zeeguu.core.model.personal_copy import PersonalCopy
 from sqlalchemy.orm.exc import NoResultFound
 from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
+from zeeguu.api.utils.parse_json_boolean import get_boolean_from_params
 from . import api, db_session
 from zeeguu.core.model.article import HTML_TAG_CLEANR
 
@@ -196,7 +197,7 @@ def find_or_create_article():
     html_content = request.form.get("htmlContent", "")
 
     # Check if extension has pre-extracted all the data
-    pre_extracted = request.form.get("preExtracted", "") == "true"
+    pre_extracted = get_boolean_from_params(request.form, "preExtracted", default=False)
     text_content = request.form.get("textContent", "") if pre_extracted else None
     title = request.form.get("title", "") if pre_extracted else None
     author = request.form.get("author", "") if pre_extracted else None
@@ -368,7 +369,7 @@ def is_article_language_supported():
     """
 
     htmlContent = request.form.get("htmlContent", "")
-    return_detailed = request.form.get("detailed", "false").lower() == "true"
+    return_detailed = get_boolean_from_params(request.form, "detailed", default=False)
 
     text = re.sub(HTML_TAG_CLEANR, "", htmlContent)
     try:

--- a/zeeguu/api/endpoints/bookmarks_and_words.py
+++ b/zeeguu/api/endpoints/bookmarks_and_words.py
@@ -12,7 +12,7 @@ from zeeguu.core.model.example_sentence_context import ExampleSentenceContext
 from . import api, db_session
 from zeeguu.api.utils.json_result import json_result
 from zeeguu.logging import log
-from zeeguu.api.utils.parse_json_boolean import parse_json_boolean
+from zeeguu.api.utils.parse_json_boolean import get_boolean_from_params
 from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
 from zeeguu.core.word_scheduling import BasicSRSchedule
 from zeeguu.core.word_scheduling.basicSR.four_levels_per_word import FourLevelsPerWord
@@ -139,7 +139,7 @@ def bookmarks_by_day():
     also returns the text where the bookmark was found.
     """
 
-    with_context = parse_json_boolean(request.form.get("with_context", "false"))
+    with_context = get_boolean_from_params(request.form, "with_context", default=False)
     user = User.find_by_id(flask.g.user_id)
     return json_result(user.bookmarks_by_day(with_context=with_context))
 
@@ -184,7 +184,7 @@ def bookmarks_for_article(article_id, user_id):
 @requires_session
 def words_to_study_for_article(article_id):
     user = User.find_by_id(flask.g.user_id)
-    with_tokens = parse_json_boolean(request.form.get("with_tokens", "false"))
+    with_tokens = get_boolean_from_params(request.form, "with_tokens", default=False)
 
     # This approach works with UserWords (which have the scheduling logic)
     # instead of Bookmarks (which were the old approach)

--- a/zeeguu/api/endpoints/exercises.py
+++ b/zeeguu/api/endpoints/exercises.py
@@ -8,7 +8,7 @@ from zeeguu.core.model.user import User
 
 from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
 from zeeguu.api.utils.json_result import json_result
-from zeeguu.api.utils.parse_json_boolean import parse_json_boolean
+from zeeguu.api.utils.parse_json_boolean import get_boolean_from_params
 from . import api, db_session
 from flask import request
 
@@ -103,7 +103,7 @@ def get_next_word_due_time():
 def get_user_words_due_today():
 
     user = User.find_by_id(flask.g.user_id)
-    with_tokens = parse_json_boolean(request.form.get("with_context", "false"))
+    with_tokens = get_boolean_from_params(request.form, "with_context", default=False)
     to_study = BasicSRSchedule.scheduled_words_due_today(user)
 
     return _user_words_as_json_result(to_study, True, with_tokens)

--- a/zeeguu/api/endpoints/search.py
+++ b/zeeguu/api/endpoints/search.py
@@ -15,6 +15,7 @@ from zeeguu.core.content_recommender import (
 
 from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
 from zeeguu.api.utils.json_result import json_result
+from zeeguu.api.utils.parse_json_boolean import get_boolean_from_params
 from . import api
 
 import zeeguu
@@ -234,8 +235,8 @@ def search_for_search_terms(search_terms, page: int = 0):
     use_published_priority = False
 
     if request.method == "POST":
-        use_published_priority = (
-            request.form.get("use_publish_priority", "false") == "true"
+        use_published_priority = get_boolean_from_params(
+            request.form, "use_publish_priority", default=False
         )
 
     user = User.find_by_id(flask.g.user_id)

--- a/zeeguu/api/endpoints/translation.py
+++ b/zeeguu/api/endpoints/translation.py
@@ -7,7 +7,7 @@ from flask import request
 from python_translators.translation_query import TranslationQuery
 
 from zeeguu.api.utils.json_result import json_result
-from zeeguu.api.utils.parse_json_boolean import parse_json_boolean
+from zeeguu.api.utils.parse_json_boolean import get_boolean_from_params
 from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
 from zeeguu.core.translation_services.translator import (
     get_next_results,
@@ -211,7 +211,7 @@ def get_multiple_translations(from_lang_code, to_lang_code):
 
     word_str = request.form["word"].strip(punctuation_extended)
     context = request.form.get("context", "").strip()
-    is_separated_mwe = request.form.get("is_separated_mwe", "").lower() == "true"
+    is_separated_mwe = get_boolean_from_params(request.form, "is_separated_mwe", default=False)
     full_sentence_context = request.form.get("full_sentence_context", "")
 
     translations = get_all_translations(word_str, context, from_lang_code, to_lang_code, is_separated_mwe, full_sentence_context)
@@ -295,7 +295,7 @@ def get_translations_stream(from_lang_code, to_lang_code):
 
     word_str = request.form["word"].strip(punctuation_extended)
     context = request.form.get("context", "").strip()
-    is_separated_mwe = request.form.get("is_separated_mwe", "").lower() == "true"
+    is_separated_mwe = get_boolean_from_params(request.form, "is_separated_mwe", default=False)
     full_sentence_context = request.form.get("full_sentence_context", "")
 
     def generate():
@@ -649,9 +649,10 @@ def contribute_translation(from_lang_code, to_lang_code):
     c_sent_i = request_params.get("c_sent_i", None)
     c_token_i = request_params.get("c_token_i", None)
     source_id = request_params.get("source_id", None)
-    in_content = parse_json_boolean(request_params.get("in_content", None))
-    left_ellipsis = parse_json_boolean(request_params.get("left_ellipsis", None))
-    right_ellipsis = parse_json_boolean(request_params.get("right_ellipsis", None))
+    # No default: these three stay tri-state, an absent one means unknown.
+    in_content = get_boolean_from_params(request_params, "in_content")
+    left_ellipsis = get_boolean_from_params(request_params, "left_ellipsis")
+    right_ellipsis = get_boolean_from_params(request_params, "right_ellipsis")
     context_identifier = ContextIdentifier.from_dictionary(
         request_params.get("context_identifier", None)
     )

--- a/zeeguu/api/endpoints/user_articles.py
+++ b/zeeguu/api/endpoints/user_articles.py
@@ -18,6 +18,7 @@ from zeeguu.core.model import (
 
 from zeeguu.api.utils.route_wrappers import cross_domain, requires_session
 from zeeguu.api.utils.json_result import json_result
+from zeeguu.api.utils.parse_json_boolean import get_boolean_from_params
 from sentry_sdk import capture_exception
 from . import api
 
@@ -75,7 +76,7 @@ def user_articles_recommended(count: int = 15, page: int = 0):
             language = user.learned_language
 
     # Get exclusion parameters from request args
-    exclude_saved = request.args.get("exclude_saved", "false").lower() == "true"
+    exclude_saved = get_boolean_from_params(request.args, "exclude_saved", default=False)
 
     # Optional single-topic filter (e.g. a topic pill on the home feed). The
     # value is a topic title, matching the shape returned by /subscribed_topics.

--- a/zeeguu/api/test/test_boolean_params.py
+++ b/zeeguu/api/test/test_boolean_params.py
@@ -1,0 +1,44 @@
+from zeeguu.api.utils.parse_json_boolean import (
+    get_boolean_from_params,
+    parse_json_boolean,
+)
+
+
+def test_parses_the_two_json_spellings():
+    assert parse_json_boolean("true") is True
+    assert parse_json_boolean("false") is False
+
+
+def test_is_case_insensitive():
+    # Some clients send "True"; before, that read as neither true nor false.
+    assert parse_json_boolean("True") is True
+    assert parse_json_boolean("FALSE") is False
+
+
+def test_anything_else_is_none():
+    assert parse_json_boolean(None) is None
+    assert parse_json_boolean("") is None
+    assert parse_json_boolean("yes") is None
+    assert parse_json_boolean("1") is None
+
+
+def test_reads_the_named_param():
+    params = {"detailed": "true", "quiet": "false"}
+
+    assert get_boolean_from_params(params, "detailed") is True
+    assert get_boolean_from_params(params, "quiet") is False
+
+
+def test_default_stands_in_for_a_param_that_was_not_sent():
+    assert get_boolean_from_params({}, "detailed", default=False) is False
+    assert get_boolean_from_params({}, "detailed", default=True) is True
+
+
+def test_default_is_none_so_absent_stays_distinguishable_from_false():
+    # What a partial update needs: "not told" must not read as "set it false".
+    assert get_boolean_from_params({}, "detailed") is None
+    assert get_boolean_from_params({"detailed": "false"}, "detailed") is False
+
+
+def test_an_unparseable_value_falls_back_to_the_default():
+    assert get_boolean_from_params({"detailed": "maybe"}, "detailed", default=False) is False

--- a/zeeguu/api/utils/parse_json_boolean.py
+++ b/zeeguu/api/utils/parse_json_boolean.py
@@ -2,9 +2,12 @@ def parse_json_boolean(value):
     """
     Converts a string to a boolean value.
     Used when parsing from the frontend.
+
+    Case-insensitive: some clients send "True". Anything else -- including
+    None -- is None, so a caller can tell "not sent" from "sent false".
     """
-    if value is None:
-        return None
+    if isinstance(value, str):
+        value = value.lower()
     if value == "true":
         return True
     if value == "false":


### PR DESCRIPTION
Follow-up to #709, which added `get_boolean_from_params` and used it in two new call sites. This adopts it everywhere else.

**Stacked on #709** — the base is `classroom-only-cohort-flag`, so the diff shown here is only this change. GitHub retargets it to `master` when #709 merges.

## Why

Nine call sites asked the same question four different ways:

```python
request.args.get("exclude_saved", "false").lower() == "true"     # lenient
request.form.get("use_publish_priority", "false") == "true"      # strict
request.form.get("preExtracted", "") == "true"                   # strict, different default
parse_json_boolean(request.form.get("with_context", "false"))    # two steps for one question
```

Now they all read as one intent, and the `default` says what an absent parameter means at that site.

## Behavior changes

`parse_json_boolean` becomes case-insensitive. That's what lets the `.lower() == "true"` sites convert without quietly narrowing what they accept — but it also widens two sites that were strict:

- `search.py` — `use_publish_priority`
- `article.py` — `preExtracted`

Both compared against `"true"` case-sensitively, so a client sending `"True"` was read as **false**. That's a behavior change, in the direction of the obvious intent, but flagging it since it's the one thing here that isn't a pure refactor.

The three tri-state params in `translation.py` (`in_content`, `left_ellipsis`, `right_ellipsis`) keep the `None` default — for them, absent still has to stay distinguishable from false.

## Tests

`zeeguu/api/test/test_boolean_params.py` — 7 tests covering both spellings, case-insensitivity, the unparseable-and-absent cases, and the two default modes.

## Note on the existing suite

`python -m pytest zeeguu/api/test/` is not currently a usable signal: two identical runs produce different failure sets, and `test_bookmark_positions.py` fails 13/13 on plain `master`. I verified this change by running the affected suites in isolation (`test_bookmark`, `test_article`, `test_user_article` all pass) rather than against the full-suite count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)