### PR TITLE
Express the translation-search timestamps against SERVER_TZ

### DIFF
--- a/zeeguu/core/model/translation_search.py
+++ b/zeeguu/core/model/translation_search.py
@@ -1,12 +1,10 @@
-from datetime import datetime, timezone
 from sqlalchemy import desc
 
 from zeeguu.core.model.db import db
 from zeeguu.core.model.language import Language
 from zeeguu.core.model.user import User
+from zeeguu.core.util.time import server_now, to_utc_isoformat
 
-def utc_now_naive():
-    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 class TranslationSearch(db.Model):
     """
@@ -28,13 +26,13 @@ class TranslationSearch(db.Model):
     )
     learned_language = db.relationship(Language)
 
-    search_time = db.Column(db.DateTime, nullable=False, default=utc_now_naive)
+    search_time = db.Column(db.DateTime, nullable=False, default=server_now)
 
     def __init__(self, user: User, search_word: str, learned_language: Language):
         self.user = user
         self.search_word = search_word
         self.learned_language = learned_language
-        self.search_time = utc_now_naive()
+        self.search_time = server_now()
 
     def __repr__(self):
         return f"TranslationSearch({self.search_word}, {self.learned_language.code})"
@@ -72,5 +70,5 @@ class TranslationSearch(db.Model):
             "id": self.id,
             "search_word": self.search_word,
             "language": self.learned_language.code,
-            "search_time": self.search_time.replace(tzinfo=timezone.utc).isoformat(),
+            "search_time": to_utc_isoformat(self.search_time),
         }

--- a/zeeguu/core/util/time.py
+++ b/zeeguu/core/util/time.py
@@ -67,6 +67,34 @@ def to_user_local_date(user, naive_server_dt):
         return None
     return naive_server_dt.replace(tzinfo=SERVER_TZ).astimezone(user_zone(user)).date()
 
+
+def server_now():
+    """
+    'Now' in the format every naive DateTime column in this DB uses: a clock
+    reading in SERVER_TZ, with the tzinfo stripped off.
+
+    Use this instead of `datetime.now()` for anything that gets stored. It is
+    the same value today (the container's libc is UTC and SERVER_TZ is UTC),
+    but it says *which* clock it means, so it stays correct if the constants
+    at the top of this file ever change.
+    """
+    return datetime.now(SERVER_TZ).replace(tzinfo=None)
+
+
+def to_utc_isoformat(naive_server_dt):
+    """
+    Serialize a naive DB datetime for the wire, as an explicit UTC instant.
+
+    Naive isoformat is a trap for JS clients: `new Date("2026-08-25T12:34:56")`
+    is interpreted as the *browser's* local time, so a timestamp written 5
+    seconds ago renders as hours ago (or in the future) for anyone not on UTC.
+    Stamping SERVER_TZ and converting to UTC yields a "+00:00" suffix that
+    `new Date(...)` reads as the instant it actually is.
+    """
+    if naive_server_dt is None:
+        return None
+    return naive_server_dt.replace(tzinfo=SERVER_TZ).astimezone(timezone.utc).isoformat()
+
 """
 datetime (dt) is not by default a timezone aware object. When articles
 are crawled we do get them as time aware objects. This is a problem


### PR DESCRIPTION
Stacked on #710 — merging this into `timezone-translations-fix` folds it into that PR.

## The bug in #710 is real

`new Date(isoString)` in the browser parses a suffix-less ISO string as **browser-local** time, so a search made a second ago rendered as "2 hours ago" in `TranslateHistory.js` for anyone not on UTC. Adding the offset is the right fix.

## What this changes

#710 hardcodes `timezone.utc` in the model module. This codebase doesn't have a "UTC" contract — it has a **`SERVER_TZ`** one, and `zeeguu/core/util/time.py` owns it. The comment at the top of that file states the invariant: every naive datetime in the DB is a clock reading in `SERVER_TZ`. The existing read-side helper, `to_user_local_date()`, stamps `SERVER_TZ` — not `timezone.utc` — before converting.

Today the two agree, because `SERVER_TZ = UTC`. But if anyone ever passes `TZ=Europe/Berlin` to the `zapi` container and moves the constants in lockstep — the scenario that file explicitly warns about, and the one behind the streak bug in #587 — every other model follows and `translation_search` silently wouldn't.

So both operations move next to the invariant they depend on:

```python
def server_now():
    return datetime.now(SERVER_TZ).replace(tzinfo=None)

def to_utc_isoformat(naive_server_dt):
    if naive_server_dt is None:
        return None
    return naive_server_dt.replace(tzinfo=SERVER_TZ).astimezone(timezone.utc).isoformat()
```

`translation_search.py` imports those and drops its local `utc_now_naive`; it no longer imports `datetime` at all.

## Notes

- The **write** half of #710 is a no-op in production — `datetime.now()` in the container already returns naive UTC. `server_now()` earns its place by naming the clock instead of inheriting whatever libc thinks, but `as_dict` was the whole user-visible fix.
- `to_utc_isoformat()` is the reusable half. Roughly fifteen other `as_dict` methods still emit naive isoformat (`user.py:312`, `shared_article.py:232`, `example_sentence.py:162`, `meaning_report.py:53`, the audio-lesson ones) and carry the same latent skew wherever the client does date math rather than just printing. Left for a separate sweep.

## Verified

On a CEST machine: `server_now()` returns 14:33 UTC, not 16:33 local; `to_utc_isoformat()` emits the `+00:00` suffix; `None` passes through; the model imports cleanly under the api venv with `default=server_now` bound on the column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)