### PR TITLE
One serializer for datetimes on the wire

### DIFF
--- a/zeeguu/core/constants.py
+++ b/zeeguu/core/constants.py
@@ -1,5 +1,4 @@
 JSON_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
-SIMPLE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 SIMPLE_DATE_FORMAT = "%Y-%m-%d"
 
 # Event names for the UserActivityData table

--- a/zeeguu/core/model/starred_article.py
+++ b/zeeguu/core/model/starred_article.py
@@ -12,7 +12,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import relationship
 
-from zeeguu.core.constants import SIMPLE_TIME_FORMAT
+from zeeguu.core.util.encoding import datetime_to_json
 from zeeguu.core.model import Url, User
 from zeeguu.core.model.language import Language
 from zeeguu.core.model.db import db
@@ -62,7 +62,7 @@ class StarredArticle(db.Model):
             url=self.url.as_string(),
             title=self.title,
             language=self.language.code,
-            starred_date=self.starred_date.strftime(SIMPLE_TIME_FORMAT),
+            starred_date=datetime_to_json(self.starred_date),
         )
 
     @classmethod

--- a/zeeguu/core/model/translation_search.py
+++ b/zeeguu/core/model/translation_search.py
@@ -3,7 +3,8 @@ from sqlalchemy import desc
 from zeeguu.core.model.db import db
 from zeeguu.core.model.language import Language
 from zeeguu.core.model.user import User
-from zeeguu.core.util.time import server_now, to_utc_isoformat
+from zeeguu.core.util.encoding import datetime_to_json
+from zeeguu.core.util.time import server_now
 
 
 class TranslationSearch(db.Model):
@@ -70,5 +71,5 @@ class TranslationSearch(db.Model):
             "id": self.id,
             "search_word": self.search_word,
             "language": self.learned_language.code,
-            "search_time": to_utc_isoformat(self.search_time),
+            "search_time": datetime_to_json(self.search_time),
         }

--- a/zeeguu/core/model/user_activitiy_data.py
+++ b/zeeguu/core/model/user_activitiy_data.py
@@ -24,6 +24,7 @@ from zeeguu.core.constants import (
 from zeeguu.core.behavioral_modeling import (
     find_last_reading_percentage,
 )
+from zeeguu.core.util.encoding import datetime_to_json
 from zeeguu.core.util.url import remove_tracking_query_params
 import zeeguu
 
@@ -71,7 +72,7 @@ class UserActivityData(db.Model):
     def data_as_dictionary(self):
         data = dict(
             user_id=self.user_id,
-            time=self.time.strftime("%Y-%m-%dT%H:%M:%S"),
+            time=datetime_to_json(self.time),
             event=self.event,
             value=self.value,
             extra_data=self.extra_data,

--- a/zeeguu/core/util/encoding.py
+++ b/zeeguu/core/util/encoding.py
@@ -1,9 +1,11 @@
 # -*- coding: utf8 -*-
 import json
+from datetime import timezone
 
 from flask import make_response
 
 from zeeguu.core.constants import JSON_TIME_FORMAT
+from zeeguu.core.util.time import SERVER_TZ
 
 
 class JSONSerializable(object):
@@ -25,5 +27,23 @@ def encode_error(code, error):
     return make_response(encode(error), code)
 
 
-def datetime_to_json(datetime):
-    return datetime.strftime(JSON_TIME_FORMAT)
+def datetime_to_json(naive_server_dt):
+    """
+    The one way this API puts a stored datetime on the wire.
+
+    Every naive DateTime column in this DB is a clock reading in SERVER_TZ
+    (see zeeguu/core/util/time.py). This converts one to UTC and emits it
+    with an explicit "Z", which is what makes it safe for JS clients:
+    `new Date("2026-08-25T12:34:56")` — no suffix — is parsed as the
+    *browser's* local time, so a timestamp written seconds ago renders as
+    hours ago for anyone not on UTC. The "Z" removes the ambiguity.
+
+    Returns None for None, so call sites don't each need their own guard.
+    """
+    if naive_server_dt is None:
+        return None
+    return (
+        naive_server_dt.replace(tzinfo=SERVER_TZ)
+        .astimezone(timezone.utc)
+        .strftime(JSON_TIME_FORMAT)
+    )

--- a/zeeguu/core/util/time.py
+++ b/zeeguu/core/util/time.py
@@ -81,20 +81,6 @@ def server_now():
     return datetime.now(SERVER_TZ).replace(tzinfo=None)
 
 
-def to_utc_isoformat(naive_server_dt):
-    """
-    Serialize a naive DB datetime for the wire, as an explicit UTC instant.
-
-    Naive isoformat is a trap for JS clients: `new Date("2026-08-25T12:34:56")`
-    is interpreted as the *browser's* local time, so a timestamp written 5
-    seconds ago renders as hours ago (or in the future) for anyone not on UTC.
-    Stamping SERVER_TZ and converting to UTC yields a "+00:00" suffix that
-    `new Date(...)` reads as the instant it actually is.
-    """
-    if naive_server_dt is None:
-        return None
-    return naive_server_dt.replace(tzinfo=SERVER_TZ).astimezone(timezone.utc).isoformat()
-
 """
 datetime (dt) is not by default a timezone aware object. When articles
 are crawled we do get them as time aware objects. This is a problem


### PR DESCRIPTION
Follow-up to #710 / #712. Consolidates the four different ways this API was putting stored timestamps into JSON.

## The problem

| where | format | sites |
|---|---|---|
| `datetime_to_json()` | `...595226Z` | ~15 |
| `to_utc_isoformat()` (added in #712) | `...595226+00:00` | 1 |
| `strftime("%Y-%m-%dT%H:%M:%S")` | `...:26` — naive | 1 |
| `strftime(SIMPLE_TIME_FORMAT)` | `...:26` — naive | 1 |

That last row is the one worth naming. `SIMPLE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S%z"` **looks** timezone-aware, but `%z` renders as the *empty string* when the datetime has no `tzinfo` — and no datetime in this DB ever has one, since MySQL `DATETIME` cannot store an offset and no column here uses `DateTime(timezone=True)`. A constant that promises a timezone it structurally cannot emit is worse than one that doesn't promise. Deleted.

The suffix isn't cosmetic: `new Date("2026-08-25T12:34:56")` in a browser is parsed as the **user's local time**, so a timestamp written seconds ago renders as hours ago for anyone off UTC. That was the original bug in #710.

## The change

`datetime_to_json()` becomes the single serializer:

- **routed through `SERVER_TZ`** instead of assuming UTC, so it tracks the constant the rest of `core/util/time.py` is written against — the one the comment at the top of that file says must move in lockstep if the `zapi` container ever ships with `TZ` set
- **`None`-safe**, so call sites stop each writing their own `if x else None` guard
- **output is byte-identical for all ~15 existing callers** — `SERVER_TZ` is UTC today, so the conversion is a no-op. Verified below.

`to_utc_isoformat()` is removed rather than kept alongside. It was a near-duplicate of a helper that already existed; I missed it when writing #712 because it serializes with `strftime` and I grepped for `isoformat`. `server_now()` stays — the write side has no duplicate.

## Notes for review

- **Both naive call sites are currently unreachable.** `UserActivityData.data_as_dictionary` and `StarredArticle.as_dict` have zero callers (the live starred path is `UserArticle.all_starred_articles_of_user_info`, which already used `datetime_to_json`). I fixed rather than deleted them, so reviving either doesn't revive the bug — but deleting them is a reasonable separate call if you'd rather.
- Because of that, **no live response payload changes shape** except `translation_search`'s `search_time`, which goes from `+00:00` to `Z`. `new Date()` parses both identically, and that endpoint is days old.
- `starred_article.py:77` emits a pre-existing `SyntaxWarning: invalid escape sequence` from a docstring. Untouched, out of scope.

## Verified

- `datetime_to_json(naive)` output identical to the old `strftime(JSON_TIME_FORMAT)`, and `datetime_to_json(None) is None`
- every touched module imports cleanly under the api venv — `encoding.py` now importing from `util/time.py` introduces no cycle
- `pytest zeeguu/core/test/test_user_article.py zeeguu/api/test/test_bookmark.py` — 12 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)