### PR TITLE
A cheap poll target for the shared-articles inbox

### DIFF
--- a/zeeguu/api/endpoints/friends.py
+++ b/zeeguu/api/endpoints/friends.py
@@ -552,6 +552,20 @@ def articles_shared_with_me():
 
 
 # ---------------------------------------------------------------------------
+@api.route("/shared_articles_inbox_signature", methods=["GET"])
+# ---------------------------------------------------------------------------
+@cross_domain
+@requires_session
+def shared_articles_inbox_signature():
+    """Poll target for "did my inbox change?" — see SharedArticle.inbox_signature_for.
+
+    Exists so the client can notice a share within a second without paying for
+    the full inbox serialization on every tick.
+    """
+    return json_result({"signature": SharedArticle.inbox_signature_for(flask.g.user_id)})
+
+
+# ---------------------------------------------------------------------------
 @api.route("/mark_shared_article_read", methods=["POST"])
 # ---------------------------------------------------------------------------
 @cross_domain

--- a/zeeguu/core/model/shared_article.py
+++ b/zeeguu/core/model/shared_article.py
@@ -198,6 +198,37 @@ class SharedArticle(db.Model):
         )
 
     @classmethod
+    def inbox_signature_for(cls, user_id: int) -> str:
+        """A token that changes whenever this user's inbox changes.
+
+        One aggregate query, no per-article serialization — cheap enough for the
+        client to poll every second, which ``articles_shared_with_me`` (an
+        ``article_info`` per row) is not. The client refetches the real inbox
+        only when this moves.
+
+        Deliberately language-agnostic, unlike the inbox the client renders: it
+        only has to detect *that* something changed. A share arriving in a
+        language the reader isn't currently studying costs one wasted refetch,
+        which is cheaper than teaching this query about delivery languages.
+
+        The three counts cover the three things that change a rendered inbox
+        besides a new share: a dismissal (drops out of the count), a read, and
+        a delivery derivative finishing in the background.
+        """
+        total, newest_id, read, delivered = (
+            db.session.query(
+                func.count(cls.id),
+                func.max(cls.id),
+                func.count(cls.read_at),
+                func.count(cls.delivery_article_id),
+            )
+            .filter(cls.to_user_id == user_id)
+            .filter(cls.dismissed_at.is_(None))
+            .one()
+        )
+        return f"{total}-{newest_id or 0}-{read}-{delivered}"
+
+    @classmethod
     def unread_count_for(cls, user_id: int) -> int:
         return (
             cls.query.filter(cls.to_user_id == user_id)

--- a/zeeguu/core/test/test_shared_article_inbox_signature.py
+++ b/zeeguu/core/test/test_shared_article_inbox_signature.py
@@ -1,0 +1,67 @@
+"""The inbox signature is what the client polls once a second instead of the
+full inbox, so it has to move for every change the recipient would see rendered.
+See SharedArticle.inbox_signature_for.
+"""
+from unittest import TestCase
+
+from zeeguu.core.test.model_test_mixin import ModelTestMixIn
+from zeeguu.core.test.rules.user_rule import UserRule
+from zeeguu.core.test.rules.article_rule import ArticleRule
+
+import zeeguu.core
+from zeeguu.core.model.shared_article import SharedArticle
+
+session = zeeguu.core.model.db.session
+
+
+class SharedArticleInboxSignatureTest(ModelTestMixIn, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.sender = UserRule().user
+        self.recipient = UserRule().user
+        self.article = ArticleRule().article
+
+    def _signature(self):
+        return SharedArticle.inbox_signature_for(self.recipient.id)
+
+    def _share(self):
+        return SharedArticle.create(
+            session, self.sender.id, self.recipient.id, self.article.id
+        )
+
+    def test_stable_while_nothing_changes(self):
+        self._share()
+        assert self._signature() == self._signature()
+
+    def test_moves_on_a_new_share(self):
+        before = self._signature()
+        self._share()
+        assert self._signature() != before
+
+    def test_moves_when_a_share_is_read(self):
+        shared = self._share()
+        before = self._signature()
+        shared.mark_read(session)
+        assert self._signature() != before
+
+    def test_moves_when_a_share_is_dismissed(self):
+        shared = self._share()
+        before = self._signature()
+        shared.dismiss(session)
+        assert self._signature() != before
+
+    def test_moves_when_the_delivery_derivative_lands(self):
+        # The background-generated copy arriving is what flips a row from
+        # "preparing" to openable — invisible to a plain count of the inbox.
+        shared = self._share()
+        before = self._signature()
+        shared.delivery_article_id = ArticleRule().article.id
+        session.add(shared)
+        session.commit()
+        assert self._signature() != before
+
+    def test_ignores_shares_to_other_users(self):
+        other = UserRule().user
+        before = self._signature()
+        SharedArticle.create(session, self.sender.id, other.id, self.article.id)
+        assert self._signature() == before


### PR DESCRIPTION
Paired with zeeguu/web#1228, which polls this. **Deploy this first** — that PR calls this endpoint.

## Why

The web client only learns about a share when it navigates. A share landing while the recipient sits on the feed stays invisible until they happen to change route — which is the one moment it matters, and the one thing a live demo shows.

Polling fixes that, but `articles_shared_with_me` runs an `article_info` per row. A once-a-second poll would pay full serialization sixty times a minute to be told nothing changed.

## What

- `SharedArticle.inbox_signature_for(user_id)` — one aggregate query, returns `count-maxid-read-delivered`.
- `GET /shared_articles_inbox_signature` — returns `{"signature": ...}`.

The client polls this and refetches the real inbox only when the token moves.

The three sub-counts (rather than a plain inbox count) cover everything a recipient can see change: a new share, a read, a dismissal, and the background-generated delivery derivative landing — the last being what flips a row from "preparing" to openable, and invisible to a count.

Deliberately language-agnostic, unlike the inbox the client renders: it only has to detect *that* something moved. A share arriving in a language the reader isn't currently studying costs one wasted refetch — cheaper than teaching this query about delivery languages.

## Load

At the client's fastest cadence (1/s, only while the inbox badge is on screen) this is one indexed aggregate over `shared_article` and ~30 bytes back. The expensive endpoint is hit only on an actual change.

## Tests

`zeeguu/core/test/test_shared_article_inbox_signature.py` — 6 tests: stable when nothing changes, moves on new share / read / dismiss / derivative landing, ignores other users' shares. Passing locally, along with the 10 existing shared-article tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)