### PR TITLE
Tell the classroom what language its texts are in

### DIFF
--- a/zeeguu/api/endpoints/student.py
+++ b/zeeguu/api/endpoints/student.py
@@ -37,12 +37,27 @@ def join_cohort_api():
 @cross_domain
 @requires_session
 def student_info():
+    from zeeguu.core.model import CohortArticleMap
+
     user = User.find_by_id(flask.g.user_id)
-    user_cohorts = [c.cohort.get_cohort_info() for c in user.cohorts]
+
+    # The classroom feed only shows texts in the language the student is
+    # currently learning, so a class in another language looks empty and
+    # unexplained. Ship the per-language counts alongside each class: they are
+    # what lets the empty classroom name the language and offer the switch.
+    user_cohorts = []
+    for c in user.cohorts:
+        info = c.cohort.get_cohort_info()
+        info["texts_by_language"] = CohortArticleMap.text_counts_by_language(c.cohort)
+        user_cohorts.append(info)
+
     return json_result(
         {
             "name": user.name,
             "email": user.email,
+            "learned_language": (
+                user.learned_language.code if user.learned_language else None
+            ),
             "cohorts": user_cohorts,
         }
     )

--- a/zeeguu/api/endpoints/student.py
+++ b/zeeguu/api/endpoints/student.py
@@ -37,8 +37,6 @@ def join_cohort_api():
 @cross_domain
 @requires_session
 def student_info():
-    from zeeguu.core.model import CohortArticleMap
-
     user = User.find_by_id(flask.g.user_id)
 
     # The classroom feed only shows texts in the language the student is
@@ -48,7 +46,7 @@ def student_info():
     user_cohorts = []
     for c in user.cohorts:
         info = c.cohort.get_cohort_info()
-        info["texts_by_language"] = CohortArticleMap.text_counts_by_language(c.cohort)
+        info["texts_by_language"] = c.cohort.text_counts_by_language()
         user_cohorts.append(info)
 
     return json_result(

--- a/zeeguu/api/endpoints/teacher_dashboard/article_management.py
+++ b/zeeguu/api/endpoints/teacher_dashboard/article_management.py
@@ -138,7 +138,7 @@ def get_cohorts_for_article(article_id):
 
     article = Article.find_by_id(article_id)
 
-    return json.dumps(CohortArticleMap.get_cohorts_for_article(article))
+    return json.dumps(CohortArticleMap.get_cohort_names_for_article(article))
 
 
 @api.route("/delete_article_from_cohort", methods=["POST"])
@@ -187,20 +187,6 @@ def remove_article_from_cohort(cohort_id, article_id):
     except sqlalchemy.orm.exc.NoResultFound:
         flask.abort(400)
         return "NoResultFound"
-
-
-@api.route("/cohort_files/<cohort_id>", methods=["GET"])
-@requires_session
-@only_teachers
-def cohort_files(cohort_id):
-    """
-    Gets the files associated with a cohort
-    """
-    check_permission_for_cohort(cohort_id)
-
-    cohort = Cohort.find(cohort_id)
-    articles = CohortArticleMap.get_articles_info_for_cohort(cohort)
-    return json.dumps(articles)
 
 
 @api.route("/cohort_text_overview/<cohort_id>", methods=["GET"])

--- a/zeeguu/api/endpoints/teacher_dashboard/article_management.py
+++ b/zeeguu/api/endpoints/teacher_dashboard/article_management.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 import zeeguu.core
 from zeeguu.api.utils.abort_handling import make_error
+from zeeguu.api.utils import json_result
 from zeeguu.core.model import Cohort, Language, Article, Url, User
 from zeeguu.core.model.cohort_article_map import CohortArticleMap
 from ._only_teachers_decorator import only_teachers
@@ -200,6 +201,34 @@ def cohort_files(cohort_id):
     cohort = Cohort.find(cohort_id)
     articles = CohortArticleMap.get_articles_info_for_cohort(cohort)
     return json.dumps(articles)
+
+
+@api.route("/cohort_text_overview/<cohort_id>", methods=["GET"])
+@requires_session
+@only_teachers
+def cohort_text_overview(cohort_id):
+    """The texts a class holds, as its students see them.
+
+    Students whose learned language differs from the class's see none of these;
+    that is handled on the student's own empty classroom, which names the
+    language and offers the switch, so it is not reported back to the teacher.
+    """
+    check_permission_for_cohort(cohort_id)
+
+    cohort = Cohort.find(cohort_id)
+
+    return json_result(
+        {
+            "cohort": {
+                "id": cohort.id,
+                "name": cohort.name,
+                "language": cohort.language.code if cohort.language else None,
+                "only_classroom_texts": bool(cohort.only_classroom_texts),
+            },
+            "texts": CohortArticleMap.get_articles_info_for_cohort(cohort),
+            "student_count": len(cohort.get_students()),
+        }
+    )
 
 
 @api.route("/teacher_texts", methods=["GET"])

--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -833,8 +833,8 @@ class Article(db.Model):
         # `cohorts` is names only, and is what apps built before Aug 2026 read.
         # `shared_with` carries the ids the texts list needs to filter by class
         # and to unshare; drop `cohorts` once no deployed client reads it.
-        info["cohorts"] = CohortArticleMap.get_cohorts_for_article(self)
-        info["shared_with"] = CohortArticleMap.get_cohorts_with_ids_for_article(self)
+        info["cohorts"] = CohortArticleMap.get_cohort_names_for_article(self)
+        info["shared_with"] = CohortArticleMap.get_cohorts_for_article(self)
 
         # Include CEFR assessment details for teacher view
         if self.cefr_assessment:

--- a/zeeguu/core/model/article.py
+++ b/zeeguu/core/model/article.py
@@ -830,7 +830,11 @@ class Article(db.Model):
         # (UserArticle reader path) re-fetches content itself via
         # article_info(with_content=True) and merges it.
         info = self.article_info(with_content=False)
+        # `cohorts` is names only, and is what apps built before Aug 2026 read.
+        # `shared_with` carries the ids the texts list needs to filter by class
+        # and to unshare; drop `cohorts` once no deployed client reads it.
         info["cohorts"] = CohortArticleMap.get_cohorts_for_article(self)
+        info["shared_with"] = CohortArticleMap.get_cohorts_with_ids_for_article(self)
 
         # Include CEFR assessment details for teacher view
         if self.cefr_assessment:

--- a/zeeguu/core/model/cohort.py
+++ b/zeeguu/core/model/cohort.py
@@ -93,6 +93,34 @@ class Cohort(db.Model):
             "language_id": self.language_id,
         }
 
+    def text_counts_by_language(self):
+        """How many of this class's texts are in which language.
+
+        Grouped by the *article's* language rather than the class's declared
+        one, because that is what cohort_articles_for_user() filters on: a
+        student sees a class text only when the article's language matches
+        their learned language. The empty classroom uses these counts to say
+        which language to switch to, so it has to count the same thing the
+        filter counts.
+        """
+        from zeeguu.core.model.article import Article
+        from zeeguu.core.model.cohort_article_map import CohortArticleMap
+
+        rows = (
+            db.session.query(Language, func.count(Article.id))
+            .select_from(CohortArticleMap)
+            .join(Article, Article.id == CohortArticleMap.article_id)
+            .join(Language, Language.id == Article.language_id)
+            .filter(CohortArticleMap.cohort_id == self.id)
+            .group_by(Language.id)
+            .all()
+        )
+
+        return [
+            {"code": language.code, "name": language.name, "count": count}
+            for language, count in sorted(rows, key=lambda each: -each[1])
+        ]
+
     @classmethod
     def find(cls, id):
         return cls.query.filter_by(id=id).one()

--- a/zeeguu/core/model/cohort_article_map.py
+++ b/zeeguu/core/model/cohort_article_map.py
@@ -1,10 +1,9 @@
-from sqlalchemy import Column, Integer, ForeignKey, PrimaryKeyConstraint, DateTime, func
+from sqlalchemy import Column, Integer, ForeignKey, PrimaryKeyConstraint, DateTime
 from sqlalchemy.orm import relationship
 
 from zeeguu.core.model.db import db
 from zeeguu.core.model.article import Article
 from zeeguu.core.model.cohort import Cohort
-from zeeguu.core.model.language import Language
 from zeeguu.core.util.encoding import datetime_to_json
 
 
@@ -41,47 +40,20 @@ class CohortArticleMap(db.Model):
         ]
 
     @classmethod
-    def get_cohorts_with_ids_for_article(cls, article):
-        """Classes this article is shared with, as {id, name}.
-
-        get_cohorts_for_article returns bare names, which is enough to print a
-        list but not to act on one: two classes can share a name, and unsharing
-        or filtering by class needs the id.
-        """
+    def get_cohorts_for_article(cls, article):
+        """Classes this article is shared with, as {id, name}."""
         return [
             {"id": entry.cohort.id, "name": entry.cohort.name}
             for entry in cls.query.filter_by(article=article).all()
         ]
 
     @classmethod
-    def text_counts_by_language(cls, cohort):
-        """How many of this cohort's texts are in which language.
-
-        Grouped by the *article's* language rather than the cohort's declared
-        one, because that is what cohort_articles_for_user() filters on: a
-        student sees a cohort text only when the article's language matches
-        their learned language. The empty classroom uses this to say which
-        language to switch to, so it has to count the same thing the filter
-        counts.
-        """
-        rows = (
-            db.session.query(Language, func.count(Article.id))
-            .select_from(cls)
-            .join(Article, Article.id == cls.article_id)
-            .join(Language, Language.id == Article.language_id)
-            .filter(cls.cohort_id == cohort.id)
-            .group_by(Language.id)
-            .all()
-        )
-
-        return [
-            {"code": language.code, "name": language.name, "count": count}
-            for language, count in sorted(rows, key=lambda r: -r[1])
-        ]
-
-    @classmethod
     def get_articles_info_for_cohort(cls, cohort):
-        """Legacy method - returns basic article info without user context."""
+        """A cohort's articles, without any one user's reading state.
+
+        Used by the teacher-facing class Texts tab: it shows the class's texts
+        as the class holds them, not as the teacher personally has read them.
+        """
         def _adapted_article_info(relation):
             article_info = relation.article.article_info()
             if relation.published_time:
@@ -96,7 +68,14 @@ class CohortArticleMap(db.Model):
         return sorted(articles, key=lambda x: x["metrics"]["difficulty"])
 
     @classmethod
-    def get_cohorts_for_article(cls, article):
+    def get_cohort_names_for_article(cls, article):
+        """Just the names -- enough to print a list, not to act on one.
+
+        Two classes can share a name, and unsharing or filtering by class needs
+        the id, so prefer get_cohorts_for_article for anything but display.
+        Kept for the /get_cohorts_for_article endpoint, whose response shape
+        deployed clients still depend on.
+        """
         cohorts = [
             cohort_article_entry.cohort.name
             for cohort_article_entry in cls.query.filter_by(article=article).all()

--- a/zeeguu/core/model/cohort_article_map.py
+++ b/zeeguu/core/model/cohort_article_map.py
@@ -1,9 +1,10 @@
-from sqlalchemy import Column, Integer, ForeignKey, PrimaryKeyConstraint, DateTime
+from sqlalchemy import Column, Integer, ForeignKey, PrimaryKeyConstraint, DateTime, func
 from sqlalchemy.orm import relationship
 
 from zeeguu.core.model.db import db
 from zeeguu.core.model.article import Article
 from zeeguu.core.model.cohort import Cohort
+from zeeguu.core.model.language import Language
 from zeeguu.core.util.encoding import datetime_to_json
 
 
@@ -37,6 +38,45 @@ class CohortArticleMap(db.Model):
             relation.article
             for relation in cls.query.filter_by(cohort=cohort).all()
             if relation.article is not None
+        ]
+
+    @classmethod
+    def get_cohorts_with_ids_for_article(cls, article):
+        """Classes this article is shared with, as {id, name}.
+
+        get_cohorts_for_article returns bare names, which is enough to print a
+        list but not to act on one: two classes can share a name, and unsharing
+        or filtering by class needs the id.
+        """
+        return [
+            {"id": entry.cohort.id, "name": entry.cohort.name}
+            for entry in cls.query.filter_by(article=article).all()
+        ]
+
+    @classmethod
+    def text_counts_by_language(cls, cohort):
+        """How many of this cohort's texts are in which language.
+
+        Grouped by the *article's* language rather than the cohort's declared
+        one, because that is what cohort_articles_for_user() filters on: a
+        student sees a cohort text only when the article's language matches
+        their learned language. The empty classroom uses this to say which
+        language to switch to, so it has to count the same thing the filter
+        counts.
+        """
+        rows = (
+            db.session.query(Language, func.count(Article.id))
+            .select_from(cls)
+            .join(Article, Article.id == cls.article_id)
+            .join(Language, Language.id == Article.language_id)
+            .filter(cls.cohort_id == cohort.id)
+            .group_by(Language.id)
+            .all()
+        )
+
+        return [
+            {"code": language.code, "name": language.name, "count": count}
+            for language, count in sorted(rows, key=lambda r: -r[1])
         ]
 
     @classmethod

--- a/zeeguu/core/test/test_cohort_text_languages.py
+++ b/zeeguu/core/test/test_cohort_text_languages.py
@@ -11,7 +11,7 @@ db_session = zeeguu.core.model.db.session
 
 
 class CohortTextLanguagesTest(ModelTestMixIn, TestCase):
-    """CohortArticleMap.text_counts_by_language feeds the empty classroom.
+    """Cohort.text_counts_by_language feeds the empty classroom.
 
     The classroom feed keeps only the texts whose language matches the
     student's learned language, so when it comes up empty the student needs to
@@ -37,14 +37,14 @@ class CohortTextLanguagesTest(ModelTestMixIn, TestCase):
         return article
 
     def test_empty_cohort_reports_nothing(self):
-        self.assertEqual([], CohortArticleMap.text_counts_by_language(self.cohort))
+        self.assertEqual([], self.cohort.text_counts_by_language())
 
     def test_counts_texts_per_language(self):
         self._share(self._article_in(self.danish))
         self._share(self._article_in(self.danish))
         self._share(self._article_in(self.german))
 
-        counts = CohortArticleMap.text_counts_by_language(self.cohort)
+        counts = self.cohort.text_counts_by_language()
 
         self.assertEqual(
             {"da": 2, "de": 1}, {each["code"]: each["count"] for each in counts}
@@ -57,7 +57,7 @@ class CohortTextLanguagesTest(ModelTestMixIn, TestCase):
         self._share(self._article_in(self.danish))
         self._share(self._article_in(self.danish))
 
-        counts = CohortArticleMap.text_counts_by_language(self.cohort)
+        counts = self.cohort.text_counts_by_language()
 
         self.assertEqual(["da", "de"], [each["code"] for each in counts])
 
@@ -68,6 +68,6 @@ class CohortTextLanguagesTest(ModelTestMixIn, TestCase):
 
         self._share(self._article_in(self.danish))
 
-        counts = CohortArticleMap.text_counts_by_language(self.cohort)
+        counts = self.cohort.text_counts_by_language()
 
         self.assertEqual([{"code": "da", "name": "Danish", "count": 1}], counts)

--- a/zeeguu/core/test/test_cohort_text_languages.py
+++ b/zeeguu/core/test/test_cohort_text_languages.py
@@ -1,0 +1,73 @@
+from unittest import TestCase
+
+import zeeguu.core
+from zeeguu.core.model.cohort_article_map import CohortArticleMap
+from zeeguu.core.test.model_test_mixin import ModelTestMixIn
+from zeeguu.core.test.rules.article_rule import ArticleRule
+from zeeguu.core.test.rules.cohort_rule import CohortRule
+from zeeguu.core.test.rules.language_rule import LanguageRule
+
+db_session = zeeguu.core.model.db.session
+
+
+class CohortTextLanguagesTest(ModelTestMixIn, TestCase):
+    """CohortArticleMap.text_counts_by_language feeds the empty classroom.
+
+    The classroom feed keeps only the texts whose language matches the
+    student's learned language, so when it comes up empty the student needs to
+    be told which language the class's texts are actually in. These counts are
+    what that message is built from.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.cohort = CohortRule().cohort
+        self.danish = LanguageRule().da
+        self.german = LanguageRule().de
+
+    def _share(self, article):
+        db_session.add(CohortArticleMap(self.cohort, article, None))
+        db_session.commit()
+
+    def _article_in(self, language):
+        article = ArticleRule().article
+        article.language = language
+        db_session.add(article)
+        db_session.commit()
+        return article
+
+    def test_empty_cohort_reports_nothing(self):
+        self.assertEqual([], CohortArticleMap.text_counts_by_language(self.cohort))
+
+    def test_counts_texts_per_language(self):
+        self._share(self._article_in(self.danish))
+        self._share(self._article_in(self.danish))
+        self._share(self._article_in(self.german))
+
+        counts = CohortArticleMap.text_counts_by_language(self.cohort)
+
+        self.assertEqual(
+            {"da": 2, "de": 1}, {each["code"]: each["count"] for each in counts}
+        )
+
+    def test_biggest_language_comes_first(self):
+        # The empty classroom offers one switch per language; the one with the
+        # most texts behind it is the one worth offering first.
+        self._share(self._article_in(self.german))
+        self._share(self._article_in(self.danish))
+        self._share(self._article_in(self.danish))
+
+        counts = CohortArticleMap.text_counts_by_language(self.cohort)
+
+        self.assertEqual(["da", "de"], [each["code"] for each in counts])
+
+    def test_ignores_texts_shared_with_other_cohorts(self):
+        other_cohort = CohortRule().cohort
+        db_session.add(CohortArticleMap(other_cohort, self._article_in(self.german), None))
+        db_session.commit()
+
+        self._share(self._article_in(self.danish))
+
+        counts = CohortArticleMap.text_counts_by_language(self.cohort)
+
+        self.assertEqual([{"code": "da", "name": "Danish", "count": 1}], counts)


### PR DESCRIPTION
## Why

`User.cohort_articles_for_user` keeps only the cohort texts whose `language_id` matches **the student's** `learned_language`, and `join_cohort_api` never sets that language. So a student learning Greek in an English class sees an empty classroom, with no explanation. Under classroom-only mode that is the entire app.

This is live. Checked against production:

| Class | Language | Texts | Students | Set to another language |
|---|---|---|---|---|
| CUT Language Centre | English | 5 | 19 | **11** (10 Greek, 1 Italian) |
| LCE 104 | English | 9 | 18 | 0 |

Across all classes, **532 of 2,484** student memberships are mismatched — mostly dormant accounts (14 active since June), but it is the mechanism that matters now that a class can be the whole app.

Our pilot teacher hit this himself, from a student account set to Greek, and reported it as "there are no articles in your classroom".

## What this does

**Keeps the language filter.** `learned_language` is a whole-app mode switch — `basicSR.py:169` filters the exercise queue on `Phrase.language_id == user.learned_language_id` — so showing off-language texts would let a student read and translate words that are then never scheduled. A quieter failure than an empty tab, not a better one.

- `CohortArticleMap.text_counts_by_language` — a class's texts grouped by the **article's** language, deliberately the same thing the feed filters on.
- `/student_info` also returns `learned_language` and per-class `texts_by_language`, so the empty classroom can name the language and offer the switch. Additive; `ClassroomArticles` already called this endpoint, so it costs no extra round trip.

Also, for the teacher texts work (zeeguu/web#TEACHER):

- `shared_with` carries cohort ids alongside names. `cohorts` returns bare names, which cannot drive a filter or an unshare and which collide when two classes share a name. **The old field stays** — the API deploys before the web, and the currently deployed client reads `cohorts`; drop it once nothing does.
- `/cohort_text_overview/<cohort_id>` returns one class's texts and student count, for the class Texts tab.

## Deploy

**This deploys before the web changes.** The web side degrades safely without it — `otherLanguageOptions` returns `[]` and the old message shows, which is covered by a test.

## Tests

4 new (`test_cohort_text_languages.py`), 12 green with the existing classroom-only suite.