### PR TITLE
cohorts_info reports when each class was last shared with

### DIFF
--- a/zeeguu/api/endpoints/teacher_dashboard/cohorts.py
+++ b/zeeguu/api/endpoints/teacher_dashboard/cohorts.py
@@ -30,6 +30,7 @@ from zeeguu.api.utils.route_wrappers import requires_session
 from zeeguu.api.utils.parse_json_boolean import get_boolean_from_params
 
 from zeeguu.core.model.db import db
+from zeeguu.core.util.encoding import datetime_to_json
 
 
 @api.route("/remove_cohort/<cohort_id>", methods=["POST"])
@@ -224,12 +225,21 @@ def cohorts_info():
     """
     Return list of dictionaries containing cohort info for all cohorts that the logged in user owns.
 
+    Each entry also carries "last_shared_time": when a text was most recently
+    shared with that class, or None if none ever was.
     """
 
     mappings = TeacherCohortMap.query.filter_by(user_id=flask.g.user_id).all()
+    cohort_ids = [m.cohort_id for m in mappings]
+
+    # So the client can put the classes a teacher actually uses on top: some
+    # teachers own ~100 classes, most of them long dormant.
+    last_shared = CohortArticleMap.last_shared_time_per_cohort(cohort_ids)
+
     cohorts = []
-    for m in mappings:
-        info = get_cohort_info(m.cohort_id)
+    for cohort_id in cohort_ids:
+        info = get_cohort_info(cohort_id)
+        info["last_shared_time"] = datetime_to_json(last_shared.get(cohort_id))
         cohorts.append(info)
     return json.dumps(cohorts)
 

--- a/zeeguu/api/test/test_teacher_dashboard.py
+++ b/zeeguu/api/test/test_teacher_dashboard.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+
+from fixtures import create_and_get_article
 from fixtures import logged_in_teacher as client
 
 
@@ -62,6 +65,30 @@ def test_update_cohort(client):
     assert cohorts is not []
 
 
+def test_cohorts_info_reports_last_shared_time(client):
+    from zeeguu.core.model import Article, Cohort, CohortArticleMap
+    from zeeguu.core.model.db import db
+
+    client.post("/create_own_cohort", data=FRENCH_B1_COHORT)
+    client.post("/create_own_cohort", data=SECOND_COHORT)
+
+    article = create_and_get_article(client)
+    db.session.add(
+        CohortArticleMap(
+            Cohort.find_by_code(FRENCH_B1_COHORT["inv_code"]),
+            Article.find_by_id(article["id"]),
+            datetime.now(),
+        )
+    )
+    db.session.commit()
+
+    cohorts_by_name = {c["name"]: c for c in client.get("/cohorts_info")}
+
+    # the client orders a teacher's classes by this; None means "never used"
+    assert cohorts_by_name[FRENCH_B1_COHORT["name"]]["last_shared_time"] is not None
+    assert cohorts_by_name[SECOND_COHORT["name"]]["last_shared_time"] is None
+
+
 def test_student_does_not_have_access_to_cohort(client):
     client.post("/create_own_cohort", data=FRENCH_B1_COHORT)
     cohorts = client.get("/cohorts_info")
@@ -81,6 +108,13 @@ def test_student_does_not_have_access_to_cohort(client):
 FRENCH_B1_COHORT = {
     "inv_code": "123",
     "name": "FrenchB1",
+    "language_id": "fr",
+    "max_students": 33,
+}
+
+SECOND_COHORT = {
+    "inv_code": "456",
+    "name": "FrenchA2",
     "language_id": "fr",
     "max_students": 33,
 }

--- a/zeeguu/core/model/cohort_article_map.py
+++ b/zeeguu/core/model/cohort_article_map.py
@@ -1,4 +1,11 @@
-from sqlalchemy import Column, Integer, ForeignKey, PrimaryKeyConstraint, DateTime
+from sqlalchemy import (
+    Column,
+    Integer,
+    ForeignKey,
+    PrimaryKeyConstraint,
+    DateTime,
+    func,
+)
 from sqlalchemy.orm import relationship
 
 from zeeguu.core.model.db import db
@@ -66,6 +73,26 @@ class CohortArticleMap(db.Model):
             if relation.article is not None  # Defensive check for orphaned mappings
         ]
         return sorted(articles, key=lambda x: x["metrics"]["difficulty"])
+
+    @classmethod
+    def last_shared_time_per_cohort(cls, cohort_ids):
+        """{cohort_id: most recent time a text was shared with it}, in one query.
+
+        Cohorts that have never had a text shared are absent from the map.
+        Callers use this to order a teacher's classes by recency: a teacher
+        with ~100 classes has most of them dormant, and an unordered list of
+        names is unusable.
+        """
+        if not cohort_ids:
+            return {}
+
+        rows = (
+            db.session.query(cls.cohort_id, func.max(cls.published_time))
+            .filter(cls.cohort_id.in_(cohort_ids))
+            .group_by(cls.cohort_id)
+            .all()
+        )
+        return {cohort_id: last for cohort_id, last in rows if last is not None}
 
     @classmethod
     def get_cohort_names_for_article(cls, article):


### PR DESCRIPTION
`/cohorts_info` returns a teacher's classes in creation order, with nothing to distinguish a class in daily use from one abandoned two years ago.

Checked in production on 28 Aug 2026: the heaviest teacher account owns **96 classes**, of which **71 have never had a text shared with them** and **76 have had no member active since February**. The next-worst account owns 17. Sharing a text there means scrolling an unordered wall of names.

This adds `last_shared_time` to each entry of `/cohorts_info` — the most recent `cohort_article_map.published_time` for that class, or `null` if a text was never shared with it — so the client can rank the live classes first.

- `CohortArticleMap.last_shared_time_per_cohort(cohort_ids)` resolves the whole list in one `GROUP BY … MAX(published_time)`. `cohorts_info` already does a query per class for the student count; this deliberately does not add a 97th.
- Serialized through `datetime_to_json`, so it arrives with an explicit `Z` and `Date.parse` in the browser is unambiguous.

The consumer is zeeguu/web#1231 (filter + recency ordering in the share-with-classes dialog), which degrades to alphabetical ordering when the field is absent — so **this deploys first**, and nothing depends on the two landing together.

## Test

`test_cohorts_info_reports_last_shared_time` shares an article with one of two classes and asserts the field is set for that one and `null` for the other. `zeeguu/api/test/test_teacher_dashboard.py` — 9 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)